### PR TITLE
Improve obsolete asset deletion

### DIFF
--- a/internal/app/character/characterasset.go
+++ b/internal/app/character/characterasset.go
@@ -143,11 +143,10 @@ func (s *CharacterService) updateCharacterAssetsESI(ctx context.Context, arg Upd
 						return err
 					}
 				}
-				obsoleteIDs := currentIDs.Difference(incomingIDs)
-				if obsoleteIDs.Size() > 0 {
-					if err := s.st.DeleteCharacterAssets(ctx, characterID, obsoleteIDs.ToSlice()); err != nil {
-						return err
-					}
+			}
+			if ids := currentIDs.Difference(incomingIDs); ids.Size() > 0 {
+				if err := s.st.DeleteCharacterAssets(ctx, characterID, ids.ToSlice()); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/internal/app/character/characterjumpclone.go
+++ b/internal/app/character/characterjumpclone.go
@@ -52,9 +52,10 @@ func (s *CharacterService) updateCharacterJumpClonesESI(ctx context.Context, arg
 				}
 				args[i] = storage.CreateCharacterJumpCloneParams{
 					CharacterID: characterID,
-					LocationID:  jc.LocationId,
-					JumpCloneID: int64(jc.JumpCloneId),
 					Implants:    jc.Implants,
+					JumpCloneID: int64(jc.JumpCloneId),
+					LocationID:  jc.LocationId,
+					Name:        jc.Name,
 				}
 			}
 			if err := s.st.ReplaceCharacterJumpClones(ctx, characterID, args); err != nil {

--- a/internal/app/character/characterjumpclone_internal_test.go
+++ b/internal/app/character/characterjumpclone_internal_test.go
@@ -20,6 +20,21 @@ func TestUpdateCharacterJumpClonesESI(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	s := newCharacterService(st)
 	ctx := context.Background()
+	data := map[string]any{
+		"home_location": map[string]any{
+			"location_id":   1021348135816,
+			"location_type": "structure",
+		},
+		"jump_clones": []map[string]any{
+			{
+				"implants":      []int{22118},
+				"jump_clone_id": 12345,
+				"location_id":   60003463,
+				"location_type": "station",
+				"name":          "Alpha",
+			},
+		},
+	}
 	t.Run("should create new clones from scratch", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
@@ -29,20 +44,6 @@ func TestUpdateCharacterJumpClonesESI(t *testing.T) {
 		factory.CreateEveType(storage.CreateEveTypeParams{ID: 22118})
 		factory.CreateLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60003463})
 		factory.CreateLocationStructure(storage.UpdateOrCreateLocationParams{ID: 1021348135816})
-		data := map[string]any{
-			"home_location": map[string]any{
-				"location_id":   1021348135816,
-				"location_type": "structure",
-			},
-			"jump_clones": []map[string]any{
-				{
-					"implants":      []int{22118},
-					"jump_clone_id": 12345,
-					"location_id":   60003463,
-					"location_type": "station",
-				},
-			},
-		}
 		httpmock.RegisterResponder(
 			"GET",
 			fmt.Sprintf("https://esi.evetech.net/v3/characters/%d/clones/", c.ID),
@@ -56,16 +57,56 @@ func TestUpdateCharacterJumpClonesESI(t *testing.T) {
 		// then
 		if assert.NoError(t, err) {
 			assert.True(t, changed)
-			oo, err := st.ListCharacterJumpClones(ctx, c.ID)
+			o, err := st.GetCharacterJumpClone(ctx, c.ID, 12345)
 			if assert.NoError(t, err) {
-				if assert.Len(t, oo, 1) {
-					o := oo[0]
-					assert.Equal(t, int32(12345), o.JumpCloneID)
-					assert.Equal(t, int64(60003463), o.Location.ID)
-					if assert.Len(t, o.Implants, 1) {
-						x := o.Implants[0]
-						assert.Equal(t, int32(22118), x.EveType.ID)
-					}
+				assert.Equal(t, int32(12345), o.JumpCloneID)
+				assert.Equal(t, "Alpha", o.Name)
+				assert.Equal(t, int64(60003463), o.Location.ID)
+				if assert.Len(t, o.Implants, 1) {
+					x := o.Implants[0]
+					assert.Equal(t, int32(22118), x.EveType.ID)
+				}
+			}
+		}
+	})
+	t.Run("should update existing clone", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID})
+		implant1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 22118})
+		implant2 := factory.CreateEveType()
+		station := factory.CreateLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60003463})
+		factory.CreateLocationStructure(storage.UpdateOrCreateLocationParams{ID: 1021348135816})
+		factory.CreateCharacterJumpClone(storage.CreateCharacterJumpCloneParams{
+			CharacterID: c.ID,
+			JumpCloneID: 12345,
+			Implants:    []int32{implant2.ID},
+			LocationID:  station.ID,
+			Name:        "Bravo",
+		})
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/v3/characters/%d/clones/", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, data))
+
+		// when
+		changed, err := s.updateCharacterJumpClonesESI(ctx, UpdateSectionParams{
+			CharacterID: c.ID,
+			Section:     app.SectionJumpClones,
+		})
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			o, err := st.GetCharacterJumpClone(ctx, c.ID, 12345)
+			if assert.NoError(t, err) {
+				assert.Equal(t, int32(12345), o.JumpCloneID)
+				assert.Equal(t, "Alpha", o.Name)
+				assert.Equal(t, station.ID, o.Location.ID)
+				if assert.Len(t, o.Implants, 1) {
+					x := o.Implants[0]
+					assert.Equal(t, int32(implant1.ID), x.EveType.ID)
 				}
 			}
 		}

--- a/internal/app/character/characterskills.go
+++ b/internal/app/character/characterskills.go
@@ -63,9 +63,8 @@ func (s *CharacterService) updateCharacterSkillsESI(ctx context.Context, arg Upd
 					return err
 				}
 			}
-			obsoleteSkillIDs := currentSkillIDs.Difference(incomingSkillIDs)
-			if obsoleteSkillIDs.Size() > 0 {
-				if err := s.st.DeleteCharacterSkills(ctx, characterID, obsoleteSkillIDs.ToSlice()); err != nil {
+			if ids := currentSkillIDs.Difference(incomingSkillIDs); ids.Size() > 0 {
+				if err := s.st.DeleteCharacterSkills(ctx, characterID, ids.ToSlice()); err != nil {
 					return err
 				}
 			}

--- a/internal/app/storage/characterjumpclone_test.go
+++ b/internal/app/storage/characterjumpclone_test.go
@@ -90,6 +90,7 @@ func TestCharacterJumpClone(t *testing.T) {
 			x, err := r.GetCharacterJumpClone(ctx, c.ID, 5)
 			if assert.NoError(t, err) {
 				assert.Equal(t, location.ID, x.Location.ID)
+				assert.Equal(t, "dummy", x.Name)
 				if assert.NotEmpty(t, x.Implants) {
 					y := x.Implants[0]
 					assert.Equal(t, eveType, y.EveType)

--- a/internal/app/storage/characterwalletjournal.go
+++ b/internal/app/storage/characterwalletjournal.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/queries"
 )
 
+// FIXME: Wrong unique clause and missing index for ref_id
+
 type CreateCharacterWalletJournalEntryParams struct {
 	Amount        float64
 	Balance       float64

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -224,6 +224,9 @@ func (f Factory) CreateCharacterJumpClone(args ...storage.CreateCharacterJumpClo
 		x := f.CreateEveType()
 		arg.Implants = append(arg.Implants, x.ID)
 	}
+	if arg.Name == "" {
+		arg.Name = fmt.Sprintf("JC-%d", arg.JumpCloneID)
+	}
 	err := f.st.CreateCharacterJumpClone(ctx, arg)
 	if err != nil {
 		panic(err)

--- a/internal/app/ui/jumpclones.go
+++ b/internal/app/ui/jumpclones.go
@@ -24,6 +24,7 @@ type jumpCloneNode struct {
 	ImplantTypeDescription string
 	IsUnknown              bool
 	JumpCloneID            int32
+	JumpCloneName          string
 	LocationID             int64
 	LocationName           string
 }
@@ -169,9 +170,10 @@ func (a *jumpClonesArea) newTreeData() (*fynetree.FyneTree[jumpCloneNode], error
 	}
 	for _, c := range clones {
 		n := jumpCloneNode{
-			JumpCloneID:  c.JumpCloneID,
-			ImplantCount: len(c.Implants),
-			LocationID:   c.Location.ID,
+			ImplantCount:  len(c.Implants),
+			JumpCloneID:   c.JumpCloneID,
+			JumpCloneName: c.Name,
+			LocationID:    c.Location.ID,
 		}
 		// TODO: Refactor to use same location method for all unknown location cases
 		if c.Location.Name != "" {
@@ -183,10 +185,10 @@ func (a *jumpClonesArea) newTreeData() (*fynetree.FyneTree[jumpCloneNode], error
 		uid := tree.MustAdd("", n.UID(), n)
 		for _, i := range c.Implants {
 			n := jumpCloneNode{
-				JumpCloneID:            c.JumpCloneID,
-				ImplantTypeName:        i.EveType.Name,
-				ImplantTypeID:          i.EveType.ID,
 				ImplantTypeDescription: i.EveType.DescriptionPlain(),
+				ImplantTypeID:          i.EveType.ID,
+				ImplantTypeName:        i.EveType.Name,
+				JumpCloneID:            c.JumpCloneID,
 			}
 			tree.MustAdd(uid, n.UID(), n)
 		}


### PR DESCRIPTION
The current asset update loop deletes obsolete assets with every asset. That is slow and unnecessary. With this PR obsolete assets are removed only once per update.