### PR TITLE
feat: Show locations and training for characters in own tabs

### DIFF
--- a/internal/app/ui/assetsearch.go
+++ b/internal/app/ui/assetsearch.go
@@ -398,7 +398,6 @@ func (a *assetSearchArea) characterCount() int {
 
 func (a *assetSearchArea) makeTopText(c int) (string, widget.Importance) {
 	it := humanize.Comma(int64(len(a.assets)))
-	ch := humanize.Comma(int64(c))
-	text := fmt.Sprintf("%s total items - %s characters", it, ch)
+	text := fmt.Sprintf("%d characters • %s items", c, it)
 	return text, widget.MediumImportance
 }

--- a/internal/app/ui/locations.go
+++ b/internal/app/ui/locations.go
@@ -1,0 +1,196 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/ErikKalkoken/evebuddy/internal/set"
+)
+
+type locationCharacter struct {
+	id                 int32
+	location           *app.EntityShort[int64]
+	name               string
+	region             *app.EntityShort[int32]
+	ship               *app.EntityShort[int32]
+	solarSystem        *app.EntityShort[int32]
+	systemSecurity     optional.Optional[float32]
+	securityImportance widget.Importance
+}
+
+// locationsArea is the UI area that shows an overview of all the user's characters.
+type locationsArea struct {
+	characters []locationCharacter
+	content    *fyne.Container
+	table      *widget.Table
+	top        *widget.Label
+	u          *UI
+}
+
+func (u *UI) newLocationsArea() *locationsArea {
+	a := locationsArea{
+		characters: make([]locationCharacter, 0),
+		top:        widget.NewLabel(""),
+		u:          u,
+	}
+	a.top.TextStyle.Bold = true
+
+	top := container.NewVBox(a.top, widget.NewSeparator())
+	a.table = a.makeTable()
+	a.content = container.NewBorder(top, nil, nil, nil, a.table)
+	return &a
+}
+
+func (a *locationsArea) makeTable() *widget.Table {
+	var headers = []struct {
+		text     string
+		maxChars int
+	}{
+		{"Name", 20},
+		{"Location", 30},
+		{"System", 15},
+		{"Sec.", 5},
+		{"Region", 15},
+		{"Ship", 15},
+	}
+
+	t := widget.NewTable(
+		func() (rows int, cols int) {
+			return len(a.characters), len(headers)
+		},
+		func() fyne.CanvasObject {
+			return widget.NewLabel("Template")
+		},
+		func(tci widget.TableCellID, co fyne.CanvasObject) {
+			l := co.(*widget.Label)
+			if tci.Row >= len(a.characters) || tci.Row < 0 {
+				return
+			}
+			c := a.characters[tci.Row]
+			l.Alignment = fyne.TextAlignLeading
+			l.Importance = widget.MediumImportance
+			l.Truncation = fyne.TextTruncateClip
+			switch tci.Col {
+			case 0:
+				l.Text = c.name
+			case 1:
+				l.Text = entityNameOrFallback(c.location, "?")
+			case 2:
+				if c.solarSystem == nil || c.systemSecurity.IsEmpty() {
+					l.Text = "?"
+				} else {
+					l.Text = c.solarSystem.Name
+				}
+			case 3:
+				if c.systemSecurity.IsEmpty() {
+					l.Text = "?"
+					l.Importance = widget.LowImportance
+				} else {
+					l.Text = fmt.Sprintf("%.1f", c.systemSecurity.MustValue())
+					l.Importance = c.securityImportance
+				}
+				l.Alignment = fyne.TextAlignTrailing
+			case 4:
+				l.Text = entityNameOrFallback(c.region, "?")
+			case 5:
+				l.Text = entityNameOrFallback(c.ship, "?")
+			}
+			l.Refresh()
+		},
+	)
+	t.ShowHeaderRow = true
+	t.StickyColumnCount = 1
+	t.CreateHeader = func() fyne.CanvasObject {
+		return widget.NewLabel("Template")
+	}
+	t.UpdateHeader = func(tci widget.TableCellID, co fyne.CanvasObject) {
+		s := headers[tci.Col]
+		label := co.(*widget.Label)
+		label.SetText(s.text)
+	}
+	t.OnSelected = func(tci widget.TableCellID) {
+		defer t.UnselectAll()
+	}
+
+	for i, h := range headers {
+		x := widget.NewLabel(strings.Repeat("w", h.maxChars))
+		w := x.MinSize().Width
+		t.SetColumnWidth(i, w)
+	}
+	return t
+}
+
+func (a *locationsArea) refresh() {
+	t, i, err := func() (string, widget.Importance, error) {
+		locations, err := a.updateCharacters()
+		if err != nil {
+			return "", 0, err
+		}
+		if len(a.characters) == 0 {
+			return "No characters", widget.LowImportance, nil
+		}
+		s := fmt.Sprintf("%d characters • %d locations", len(a.characters), locations)
+		return s, widget.MediumImportance, nil
+	}()
+	if err != nil {
+		slog.Error("Failed to refresh overview UI", "err", err)
+		t = "ERROR"
+		i = widget.DangerImportance
+	}
+	a.top.Text = t
+	a.top.Importance = i
+	a.table.Refresh()
+}
+
+func (a *locationsArea) updateCharacters() (int, error) {
+	var err error
+	ctx := context.TODO()
+	mycc, err := a.u.CharacterService.ListCharacters(ctx)
+	if err != nil {
+		return 0, err
+	}
+	locationIDs := set.New[int64]()
+	cc := make([]locationCharacter, len(mycc))
+	for i, m := range mycc {
+		c := locationCharacter{
+			id:   m.ID,
+			name: m.EveCharacter.Name,
+		}
+		if m.Location != nil {
+			locationIDs.Add(m.Location.ID)
+			c.location = &app.EntityShort[int64]{
+				ID:   m.Location.ID,
+				Name: m.Location.DisplayName(),
+			}
+			if m.Location.SolarSystem != nil {
+				c.solarSystem = &app.EntityShort[int32]{
+					ID:   m.Location.SolarSystem.ID,
+					Name: m.Location.SolarSystem.Name,
+				}
+				c.systemSecurity = optional.New(m.Location.SolarSystem.SecurityStatus)
+				c.securityImportance = m.Location.SolarSystem.SecurityType().ToImportance()
+				c.region = &app.EntityShort[int32]{
+					ID:   m.Location.SolarSystem.Constellation.Region.ID,
+					Name: m.Location.SolarSystem.Constellation.Region.Name,
+				}
+			}
+		}
+		if m.Ship != nil {
+			c.ship = &app.EntityShort[int32]{
+				ID:   m.Ship.ID,
+				Name: m.Ship.Name,
+			}
+		}
+		cc[i] = c
+	}
+	a.characters = cc
+	return locationIDs.Size(), nil
+}

--- a/internal/app/ui/overview.go
+++ b/internal/app/ui/overview.go
@@ -27,9 +27,6 @@ type overviewCharacter struct {
 	lastLoginAt   optional.Optional[time.Time]
 	name          string
 	security      float64
-	totalSP       optional.Optional[int]
-	training      optional.Optional[time.Duration]
-	unallocatedSP optional.Optional[int]
 	unreadCount   optional.Optional[int]
 	walletBalance optional.Optional[float64]
 }
@@ -67,9 +64,6 @@ func (a *overviewArea) makeTable() *widget.Table {
 		{"Alliance", 20},
 		{"Security", 5},
 		{"Unread", 5},
-		{"Total SP", 5},
-		{"Unall. SP", 5},
-		{"Training", 5},
 		{"Wallet", 5},
 		{"Assets", 5},
 		{"Last Login", 10},
@@ -112,29 +106,16 @@ func (a *overviewArea) makeTable() *widget.Table {
 				text = ihumanize.Optional(c.unreadCount, "?")
 				l.Alignment = fyne.TextAlignTrailing
 			case 5:
-				text = ihumanize.Optional(c.totalSP, "?")
-				l.Alignment = fyne.TextAlignTrailing
-			case 6:
-				text = ihumanize.Optional(c.unallocatedSP, "?")
-				l.Alignment = fyne.TextAlignTrailing
-			case 7:
-				if c.training.IsEmpty() {
-					text = "Inactive"
-					l.Importance = widget.WarningImportance
-				} else {
-					text = ihumanize.Duration(c.training.MustValue())
-				}
-			case 8:
 				text = ihumanize.OptionalFloat(c.walletBalance, 1, "?")
 				l.Alignment = fyne.TextAlignTrailing
-			case 9:
+			case 6:
 				text = ihumanize.OptionalFloat(c.assetValue, 1, "?")
 				l.Alignment = fyne.TextAlignTrailing
-			case 10:
+			case 7:
 				text = ihumanize.Optional(c.lastLoginAt, "?")
-			case 11:
+			case 8:
 				text = entityNameOrFallback(c.home, "?")
-			case 12:
+			case 9:
 				text = humanize.RelTime(c.birthday, time.Now(), "", "")
 				l.Alignment = fyne.TextAlignTrailing
 			}
@@ -176,14 +157,12 @@ func (a *overviewArea) refresh() {
 		}
 		walletText := ihumanize.OptionalFloat(totals.wallet, 1, "?")
 		assetsText := ihumanize.OptionalFloat(totals.assets, 1, "?")
-		spText := ihumanize.Optional(totals.sp, "?")
 		unreadText := ihumanize.Optional(totals.unread, "?")
 		s := fmt.Sprintf(
-			"%d characters • %s ISK wallet • %s ISK assets • %s SP  • %s unread",
+			"%d characters • %s ISK wallet • %s ISK assets • %s unread",
 			len(a.characters),
 			walletText,
 			assetsText,
-			spText,
 			unreadText,
 		)
 		return s, widget.MediumImportance, nil
@@ -199,7 +178,6 @@ func (a *overviewArea) refresh() {
 }
 
 type overviewTotals struct {
-	sp     optional.Optional[int]
 	unread optional.Optional[int]
 	wallet optional.Optional[float64]
 	assets optional.Optional[float64]
@@ -223,8 +201,6 @@ func (a *overviewArea) updateCharacters() (overviewTotals, error) {
 			id:            m.ID,
 			name:          m.EveCharacter.Name,
 			security:      m.EveCharacter.SecurityStatus,
-			totalSP:       m.TotalSP,
-			unallocatedSP: m.UnallocatedSP,
 			walletBalance: m.WalletBalance,
 		}
 		if m.Home != nil {
@@ -234,13 +210,6 @@ func (a *overviewArea) updateCharacters() (overviewTotals, error) {
 			}
 		}
 		cc[i] = c
-	}
-	for i, c := range cc {
-		v, err := a.u.CharacterService.GetCharacterTotalTrainingTime(ctx, c.id)
-		if err != nil {
-			return totals, err
-		}
-		cc[i].training = v
 	}
 	for i, c := range cc {
 		total, unread, err := a.u.CharacterService.GetCharacterMailCounts(ctx, c.id)
@@ -259,9 +228,6 @@ func (a *overviewArea) updateCharacters() (overviewTotals, error) {
 		cc[i].assetValue = v
 	}
 	for _, c := range cc {
-		if !c.totalSP.IsEmpty() {
-			totals.sp.Set(totals.sp.ValueOrZero() + c.totalSP.MustValue())
-		}
 		if !c.unreadCount.IsEmpty() {
 			totals.unread.Set(totals.unread.ValueOrZero() + c.unreadCount.MustValue())
 		}

--- a/internal/app/ui/overview.go
+++ b/internal/app/ui/overview.go
@@ -18,25 +18,20 @@ import (
 )
 
 type overviewCharacter struct {
-	alliance       string
-	assetValue     optional.Optional[float64]
-	birthday       time.Time
-	corporation    string
-	home           *app.EntityShort[int64]
-	id             int32
-	lastLoginAt    optional.Optional[time.Time]
-	location       *app.EntityShort[int64]
-	name           string
-	region         *app.EntityShort[int32]
-	security       float64
-	ship           *app.EntityShort[int32]
-	solarSystem    *app.EntityShort[int32]
-	systemSecurity optional.Optional[float32]
-	totalSP        optional.Optional[int]
-	training       optional.Optional[time.Duration]
-	unallocatedSP  optional.Optional[int]
-	unreadCount    optional.Optional[int]
-	walletBalance  optional.Optional[float64]
+	alliance      string
+	assetValue    optional.Optional[float64]
+	birthday      time.Time
+	corporation   string
+	home          *app.EntityShort[int64]
+	id            int32
+	lastLoginAt   optional.Optional[time.Time]
+	name          string
+	security      float64
+	totalSP       optional.Optional[int]
+	training      optional.Optional[time.Duration]
+	unallocatedSP optional.Optional[int]
+	unreadCount   optional.Optional[int]
+	walletBalance optional.Optional[float64]
 }
 
 // overviewArea is the UI area that shows an overview of all the user's characters.
@@ -77,10 +72,6 @@ func (a *overviewArea) makeTable() *widget.Table {
 		{"Training", 5},
 		{"Wallet", 5},
 		{"Assets", 5},
-		{"Location", 20},
-		{"System", 15},
-		{"Region", 15},
-		{"Ship", 15},
 		{"Last Login", 10},
 		{"Home", 20},
 		{"Age", 10},
@@ -140,22 +131,10 @@ func (a *overviewArea) makeTable() *widget.Table {
 				text = ihumanize.OptionalFloat(c.assetValue, 1, "?")
 				l.Alignment = fyne.TextAlignTrailing
 			case 10:
-				text = entityNameOrFallback(c.location, "?")
-			case 11:
-				if c.solarSystem == nil || c.systemSecurity.IsEmpty() {
-					text = "?"
-				} else {
-					text = fmt.Sprintf("%s %.1f", c.solarSystem.Name, c.systemSecurity.MustValue())
-				}
-			case 12:
-				text = entityNameOrFallback(c.region, "?")
-			case 13:
-				text = entityNameOrFallback(c.ship, "?")
-			case 14:
 				text = ihumanize.Optional(c.lastLoginAt, "?")
-			case 15:
+			case 11:
 				text = entityNameOrFallback(c.home, "?")
-			case 16:
+			case 12:
 				text = humanize.RelTime(c.birthday, time.Now(), "", "")
 				l.Alignment = fyne.TextAlignTrailing
 			}
@@ -200,7 +179,7 @@ func (a *overviewArea) refresh() {
 		spText := ihumanize.Optional(totals.sp, "?")
 		unreadText := ihumanize.Optional(totals.unread, "?")
 		s := fmt.Sprintf(
-			"Total: %d characters • %s ISK wallet • %s ISK assets • %s SP  • %s unread",
+			"%d characters • %s ISK wallet • %s ISK assets • %s SP  • %s unread",
 			len(a.characters),
 			walletText,
 			assetsText,
@@ -252,29 +231,6 @@ func (a *overviewArea) updateCharacters() (overviewTotals, error) {
 			c.home = &app.EntityShort[int64]{
 				ID:   m.Home.ID,
 				Name: m.Home.DisplayName(),
-			}
-		}
-		if m.Location != nil {
-			c.location = &app.EntityShort[int64]{
-				ID:   m.Location.ID,
-				Name: m.Location.DisplayName(),
-			}
-			if m.Location.SolarSystem != nil {
-				c.solarSystem = &app.EntityShort[int32]{
-					ID:   m.Location.SolarSystem.ID,
-					Name: m.Location.SolarSystem.Name,
-				}
-				c.systemSecurity = optional.New(m.Location.SolarSystem.SecurityStatus)
-				c.region = &app.EntityShort[int32]{
-					ID:   m.Location.SolarSystem.Constellation.Region.ID,
-					Name: m.Location.SolarSystem.Constellation.Region.Name,
-				}
-			}
-		}
-		if m.Ship != nil {
-			c.ship = &app.EntityShort[int32]{
-				ID:   m.Ship.ID,
-				Name: m.Ship.Name,
 			}
 		}
 		cc[i] = c

--- a/internal/app/ui/training.go
+++ b/internal/app/ui/training.go
@@ -1,0 +1,175 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+
+	ihumanize "github.com/ErikKalkoken/evebuddy/internal/app/humanize"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+)
+
+type trainingCharacter struct {
+	id            int32
+	name          string
+	totalSP       optional.Optional[int]
+	training      optional.Optional[time.Duration]
+	unallocatedSP optional.Optional[int]
+}
+
+// trainingArea is the UI area that shows an overview of all the user's characters.
+type trainingArea struct {
+	characters []trainingCharacter
+	content    *fyne.Container
+	table      *widget.Table
+	top        *widget.Label
+	u          *UI
+}
+
+func (u *UI) newTrainingArea() *trainingArea {
+	a := trainingArea{
+		characters: make([]trainingCharacter, 0),
+		top:        widget.NewLabel(""),
+		u:          u,
+	}
+	a.top.TextStyle.Bold = true
+
+	top := container.NewVBox(a.top, widget.NewSeparator())
+	a.table = a.makeTable()
+	a.content = container.NewBorder(top, nil, nil, nil, a.table)
+	return &a
+}
+
+func (a *trainingArea) makeTable() *widget.Table {
+	var headers = []struct {
+		text     string
+		maxChars int
+	}{
+		{"Name", 20},
+		{"SP", 5},
+		{"Unall. SP", 5},
+		{"Training", 5},
+	}
+
+	t := widget.NewTable(
+		func() (rows int, cols int) {
+			return len(a.characters), len(headers)
+		},
+		func() fyne.CanvasObject {
+			return widget.NewLabel("Template")
+		},
+		func(tci widget.TableCellID, co fyne.CanvasObject) {
+			l := co.(*widget.Label)
+			if tci.Row >= len(a.characters) || tci.Row < 0 {
+				return
+			}
+			c := a.characters[tci.Row]
+			l.Alignment = fyne.TextAlignLeading
+			l.Importance = widget.MediumImportance
+			var text string
+			switch tci.Col {
+			case 0:
+				text = c.name
+			case 1:
+				text = ihumanize.Optional(c.totalSP, "?")
+				l.Alignment = fyne.TextAlignTrailing
+			case 2:
+				text = ihumanize.Optional(c.unallocatedSP, "?")
+				l.Alignment = fyne.TextAlignTrailing
+			case 3:
+				if c.training.IsEmpty() {
+					text = "Inactive"
+					l.Importance = widget.WarningImportance
+				} else {
+					text = ihumanize.Duration(c.training.MustValue())
+				}
+			}
+			l.Text = text
+			l.Truncation = fyne.TextTruncateClip
+			l.Refresh()
+		},
+	)
+	t.ShowHeaderRow = true
+	t.StickyColumnCount = 1
+	t.CreateHeader = func() fyne.CanvasObject {
+		return widget.NewLabel("Template")
+	}
+	t.UpdateHeader = func(tci widget.TableCellID, co fyne.CanvasObject) {
+		s := headers[tci.Col]
+		label := co.(*widget.Label)
+		label.SetText(s.text)
+	}
+	t.OnSelected = func(tci widget.TableCellID) {
+		defer t.UnselectAll()
+	}
+
+	for i, h := range headers {
+		x := widget.NewLabel(strings.Repeat("w", h.maxChars))
+		w := x.MinSize().Width
+		t.SetColumnWidth(i, w)
+	}
+	return t
+}
+
+func (a *trainingArea) refresh() {
+	t, i, err := func() (string, widget.Importance, error) {
+		totalSP, err := a.updateCharacters()
+		if err != nil {
+			return "", 0, err
+		}
+		if len(a.characters) == 0 {
+			return "No characters", widget.LowImportance, nil
+		}
+		spText := ihumanize.Optional(totalSP, "?")
+		s := fmt.Sprintf("%d characters • %s Total SP", len(a.characters), spText)
+		return s, widget.MediumImportance, nil
+	}()
+	if err != nil {
+		slog.Error("Failed to refresh overview UI", "err", err)
+		t = "ERROR"
+		i = widget.DangerImportance
+	}
+	a.top.Text = t
+	a.top.Importance = i
+	a.table.Refresh()
+}
+
+func (a *trainingArea) updateCharacters() (optional.Optional[int], error) {
+	var totalSP optional.Optional[int]
+	var err error
+	ctx := context.TODO()
+	mycc, err := a.u.CharacterService.ListCharacters(ctx)
+	if err != nil {
+		return totalSP, err
+	}
+	cc := make([]trainingCharacter, len(mycc))
+	for i, m := range mycc {
+		c := trainingCharacter{
+			id:            m.ID,
+			name:          m.EveCharacter.Name,
+			totalSP:       m.TotalSP,
+			unallocatedSP: m.UnallocatedSP,
+		}
+		cc[i] = c
+	}
+	for i, c := range cc {
+		v, err := a.u.CharacterService.GetCharacterTotalTrainingTime(ctx, c.id)
+		if err != nil {
+			return totalSP, err
+		}
+		cc[i].training = v
+	}
+	for _, c := range cc {
+		if !c.totalSP.IsEmpty() {
+			totalSP.Set(totalSP.ValueOrZero() + c.totalSP.ValueOrZero())
+		}
+	}
+	a.characters = cc
+	return totalSP, nil
+}

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -77,6 +77,7 @@ type UI struct {
 	statusBarArea         *statusBarArea
 	statusWindow          fyne.Window
 	tabs                  *container.AppTabs
+	trainingArea          *trainingArea
 	toolbarArea           *toolbarArea
 	walletJournalArea     *walletJournalArea
 	walletTab             *container.TabItem
@@ -133,6 +134,7 @@ func NewUI(fyneApp fyne.App, ad appdirs.AppDirs) *UI {
 
 	u.overviewArea = u.newOverviewArea()
 	u.locationsArea = u.newLocationsArea()
+	u.trainingArea = u.newTrainingArea()
 	u.assetSearchArea = u.newAssetSearchArea()
 	u.coloniesArea = u.newColoniesArea()
 	u.wealthArea = u.newWealthArea()
@@ -140,6 +142,7 @@ func NewUI(fyneApp fyne.App, ad appdirs.AppDirs) *UI {
 		theme.NewThemedResource(resourceGroupSvg), container.NewAppTabs(
 			container.NewTabItem("Overview", u.overviewArea.content),
 			container.NewTabItem("Locations", u.locationsArea.content),
+			container.NewTabItem("Training", u.trainingArea.content),
 			container.NewTabItem("Assets", u.assetSearchArea.content),
 			container.NewTabItem("Colonies", u.coloniesArea.content),
 			container.NewTabItem("Wealth", u.wealthArea.content),
@@ -427,12 +430,13 @@ func (u *UI) setAnyCharacter() error {
 func (u *UI) refreshCrossPages() {
 	ff := map[string]func(){
 		"assetSearch": u.assetSearchArea.refresh,
-		"overview":    u.overviewArea.refresh,
-		"locations":   u.locationsArea.refresh,
-		"toolbar":     u.toolbarArea.refresh,
 		"colony":      u.coloniesArea.refresh,
-		"wealth":      u.wealthArea.refresh,
+		"locations":   u.locationsArea.refresh,
+		"overview":    u.overviewArea.refresh,
 		"statusBar":   u.statusBarArea.refreshCharacterCount,
+		"toolbar":     u.toolbarArea.refresh,
+		"training":    u.trainingArea.refresh,
+		"wealth":      u.wealthArea.refresh,
 	}
 	runFunctionsWithProgressModal("Updating characters", ff, u.window)
 }

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -59,6 +59,7 @@ type UI struct {
 	deskApp               desktop.App
 	fyneApp               fyne.App
 	implantsArea          *implantsArea
+	locationsArea         *locationsArea
 	jumpClonesArea        *jumpClonesArea
 	mailArea              *mailArea
 	mailTab               *container.TabItem
@@ -131,12 +132,14 @@ func NewUI(fyneApp fyne.App, ad appdirs.AppDirs) *UI {
 		))
 
 	u.overviewArea = u.newOverviewArea()
+	u.locationsArea = u.newLocationsArea()
 	u.assetSearchArea = u.newAssetSearchArea()
 	u.coloniesArea = u.newColoniesArea()
 	u.wealthArea = u.newWealthArea()
 	u.overviewTab = container.NewTabItemWithIcon("Characters",
 		theme.NewThemedResource(resourceGroupSvg), container.NewAppTabs(
 			container.NewTabItem("Overview", u.overviewArea.content),
+			container.NewTabItem("Locations", u.locationsArea.content),
 			container.NewTabItem("Assets", u.assetSearchArea.content),
 			container.NewTabItem("Colonies", u.coloniesArea.content),
 			container.NewTabItem("Wealth", u.wealthArea.content),
@@ -425,6 +428,7 @@ func (u *UI) refreshCrossPages() {
 	ff := map[string]func(){
 		"assetSearch": u.assetSearchArea.refresh,
 		"overview":    u.overviewArea.refresh,
+		"locations":   u.locationsArea.refresh,
 		"toolbar":     u.toolbarArea.refresh,
 		"colony":      u.coloniesArea.refresh,
 		"wealth":      u.wealthArea.refresh,

--- a/internal/app/ui/updateticker.go
+++ b/internal/app/ui/updateticker.go
@@ -143,11 +143,9 @@ func (u *UI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, chara
 		}
 	case app.SectionLocation,
 		app.SectionOnline,
-		app.SectionShip,
-		app.SectionWalletBalance:
-		if hasChanged {
-			u.overviewArea.refresh()
-			u.wealthArea.refresh()
+		app.SectionShip:
+		if isShown && hasChanged {
+			u.locationsArea.refresh()
 		}
 	case app.SectionPlanets:
 		if isShown && hasChanged {
@@ -195,6 +193,11 @@ func (u *UI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, chara
 		}
 		if isShown {
 			u.skillqueueArea.refresh()
+		}
+	case app.SectionWalletBalance:
+		if isShown && hasChanged {
+			u.overviewArea.refresh()
+			u.wealthArea.refresh()
 		}
 	case app.SectionWalletJournal:
 		if isShown && hasChanged {

--- a/internal/app/ui/updateticker.go
+++ b/internal/app/ui/updateticker.go
@@ -144,12 +144,14 @@ func (u *UI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, chara
 	case app.SectionLocation,
 		app.SectionOnline,
 		app.SectionShip:
-		if isShown && hasChanged {
+		if hasChanged {
 			u.locationsArea.refresh()
 		}
 	case app.SectionPlanets:
 		if isShown && hasChanged {
 			u.planetArea.refresh()
+		}
+		if hasChanged {
 			u.coloniesArea.refresh()
 		}
 	case app.SectionMailLabels,
@@ -181,8 +183,10 @@ func (u *UI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, chara
 		if isShown && hasChanged {
 			u.skillCatalogueArea.refresh()
 			u.shipsArea.refresh()
-			u.overviewArea.refresh()
 			u.planetArea.refresh()
+		}
+		if hasChanged {
+			u.trainingArea.refresh()
 		}
 	case app.SectionSkillqueue:
 		if u.fyneApp.Preferences().BoolWithFallback(settingNotifyTrainingEnabled, settingNotifyTrainingEnabledDefault) {
@@ -194,8 +198,11 @@ func (u *UI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, chara
 		if isShown {
 			u.skillqueueArea.refresh()
 		}
+		if hasChanged {
+			u.trainingArea.refresh()
+		}
 	case app.SectionWalletBalance:
-		if isShown && hasChanged {
+		if hasChanged {
 			u.overviewArea.refresh()
 			u.wealthArea.refresh()
 		}


### PR DESCRIPTION
- Move location information from overview tab into new "Locations" tab
- Move training information from overview tab into new "Training" tab
- Improve update logic for tabs under "Characters"

In part addresses the feature request in #8 