### PR TITLE
fix: Allow small time difference when validating tokens

### DIFF
--- a/internal/httptransport/http.go
+++ b/internal/httptransport/http.go
@@ -20,8 +20,8 @@ import (
 // Authorization headers in requests are redacted.
 // Can redact response bodies for URLs (e.g. which would contain tokens)
 type LoggedTransport struct {
-	// Pattern for blocked URLs. Body of blocked URLs will not be logged.
-	BlockedResponseURLs []string
+	// Body of blacklisted response URLs will not be logged.
+	BlacklistedResponseURLs []string
 }
 
 func (t LoggedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -30,7 +30,7 @@ func (t LoggedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return resp, err
 	}
-	logResponse(t.BlockedResponseURLs, isDebug, resp, req)
+	logResponse(t.BlacklistedResponseURLs, isDebug, resp, req)
 	return resp, err
 }
 

--- a/internal/httptransport/http_test.go
+++ b/internal/httptransport/http_test.go
@@ -111,7 +111,7 @@ func TestLoggedTransport(t *testing.T) {
 		// given
 		myClient := &http.Client{
 			Transport: httptransport.LoggedTransport{
-				BlockedResponseURLs: []string{"https://www.example.com/"},
+				BlacklistedResponseURLs: []string{"https://www.example.com/"},
 			},
 		}
 		slog.SetLogLoggerLevel(slog.LevelDebug)

--- a/internal/sso/jose.go
+++ b/internal/sso/jose.go
@@ -3,6 +3,8 @@ package sso
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -23,12 +25,13 @@ var (
 )
 
 // validateJWT validates a JWT payload and when valid returns it as parsed object.
-func validateJWT(ctx context.Context, accessToken string) (jwt.Token, error) {
+func validateJWT(ctx context.Context, client *http.Client, accessToken string) (jwt.Token, error) {
 	// fetch the JWK set
-	set, err := jwkFetch(ctx, jwksURL)
+	set, err := jwkFetch(ctx, jwksURL, jwk.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("fetching JWK set: %w", err)
 	}
+	slog.Debug("jwk fetched", "set", set) // TODO: Remove me when no longer needed
 	// validate token
 	token, err := jwkParseString(
 		accessToken,

--- a/internal/sso/sso.go
+++ b/internal/sso/sso.go
@@ -128,7 +128,7 @@ func (s *SSOService) Authenticate(ctx context.Context, scopes []string) (*Token,
 		if err != nil {
 			return http.StatusUnauthorized, fmt.Errorf("fetch new token: %w", err)
 		}
-		jwtToken, err := validateJWT(ctx, rawToken.AccessToken)
+		jwtToken, err := validateJWT(ctx, s.httpClient, rawToken.AccessToken)
 		if err != nil {
 			return http.StatusUnauthorized, fmt.Errorf("token validation: %w", err)
 		}
@@ -269,7 +269,7 @@ func (s *SSOService) RefreshToken(ctx context.Context, refreshToken string) (*To
 	if err != nil {
 		return nil, err
 	}
-	_, err = validateJWT(ctx, rawToken.AccessToken)
+	_, err = validateJWT(ctx, s.httpClient, rawToken.AccessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -178,7 +178,8 @@ func main() {
 	// init HTTP client, ESI client and cache
 	httpClient := &http.Client{
 		Transport: httptransport.LoggedTransport{
-			BlockedResponseURLs: []string{"login.eveonline.com/v2/oauth/token"},
+			// tokens must not be logged
+			BlacklistedResponseURLs: []string{"login.eveonline.com/v2/oauth/token"},
 		},
 	}
 	esiHttpClient := &http.Client{

--- a/main.go
+++ b/main.go
@@ -136,9 +136,7 @@ func main() {
 		Timeout: mutexTimeout,
 	})
 	if errors.Is(err, mutex.ErrTimeout) {
-		slog.Warn("Attempted to run an additional instance. Shutting down that process.")
-		fmt.Println("There is already an instance running")
-		os.Exit(1)
+		log.Fatal("There is already an instance running")
 	} else if err != nil {
 		log.Fatal(err)
 	}
@@ -148,6 +146,8 @@ func main() {
 	// start fyne app
 	fyneApp := app.NewWithID(appID)
 	ad.SetSettings(fyneApp.Storage().RootURI().Path())
+
+	fmt.Println(fyneApp.Preferences().Float("window-height"))
 
 	// start uninstall app if requested
 	if *deleteAppFlag {


### PR DESCRIPTION
Allow a small time difference between local and server time when validating JWTs.

Fixes #46 