### PR TITLE
chore: improve sso stability

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.10.0"
+  Version = "0.10.1"
   Build = 1
 
 [Release]

--- a/internal/app/character/character.go
+++ b/internal/app/character/character.go
@@ -20,6 +20,7 @@ func (s *CharacterService) DeleteCharacter(ctx context.Context, id int32) error 
 	if err := s.st.DeleteCharacter(ctx, id); err != nil {
 		return err
 	}
+	slog.Info("Character deleted", "characterID", id)
 	return s.StatusCacheService.UpdateCharacters(ctx, s.st)
 }
 

--- a/internal/app/character/charactertoken.go
+++ b/internal/app/character/charactertoken.go
@@ -39,9 +39,9 @@ func (s *CharacterService) CharacterHasTokenWithScopes(ctx context.Context, char
 	} else if err != nil {
 		return false, err
 	}
-	got := set.NewFromSlice(t.Scopes)
-	want := set.NewFromSlice(esiScopes)
-	return got.Equal(want), nil
+	incoming := set.NewFromSlice(t.Scopes)
+	required := set.NewFromSlice(esiScopes)
+	return required.IsSubset(incoming), nil
 }
 
 // getValidCharacterToken returns a valid token for a character. Convenience function.

--- a/internal/app/character/charactertoken_internal_test.go
+++ b/internal/app/character/charactertoken_internal_test.go
@@ -2,6 +2,7 @@ package character
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
@@ -14,7 +15,7 @@ func TestHasTokenWithScopes(t *testing.T) {
 	defer db.Close()
 	s := newCharacterService(st)
 	ctx := context.Background()
-	t.Run("should return true when token has all scopes", func(t *testing.T) {
+	t.Run("should return true when token has same scopes", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		c := factory.CreateCharacter()
@@ -25,7 +26,6 @@ func TestHasTokenWithScopes(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.True(t, x)
 		}
-
 	})
 	t.Run("should return false when token is missing scopes", func(t *testing.T) {
 		// given
@@ -38,6 +38,18 @@ func TestHasTokenWithScopes(t *testing.T) {
 		// then
 		if assert.NoError(t, err) {
 			assert.False(t, x)
+		}
+	})
+	t.Run("should return true when token has at least requested scopes", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID, Scopes: slices.Concat(esiScopes, []string{"extra"})})
+		// when
+		x, err := s.CharacterHasTokenWithScopes(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, x)
 		}
 	})
 }

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -48,12 +48,17 @@ func (s *Set[T]) Clear() {
 func (s *Set[T]) Difference(other *Set[T]) *Set[T] {
 	n := NewFromSlice([]T{})
 	for v := range s.values {
-		if other.Contains(v) {
-			continue
+		if !other.Contains(v) {
+			n.Add(v)
 		}
-		n.Add(v)
 	}
 	return n
+}
+
+// IsSubset reports whether a set is the subset of another set.
+func (s *Set[T]) IsSubset(other *Set[T]) bool {
+	x := s.Difference(other)
+	return x.Size() == 0
 }
 
 // Equal reports wether two sets are equal.

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -155,3 +155,22 @@ func TestSetEqual(t *testing.T) {
 		assert.False(t, s1.Equal(s2))
 	})
 }
+
+func TestIsSubset(t *testing.T) {
+	t.Parallel()
+	t.Run("report true when a is subset of b", func(t *testing.T) {
+		a := set.NewFromSlice([]int{1, 2})
+		b := set.NewFromSlice([]int{1, 2, 3})
+		assert.True(t, a.IsSubset(b))
+	})
+	t.Run("report true when a is same as b", func(t *testing.T) {
+		a := set.NewFromSlice([]int{1, 2})
+		b := set.NewFromSlice([]int{1, 2})
+		assert.True(t, a.IsSubset(b))
+	})
+	t.Run("report false when a is not a subset of b", func(t *testing.T) {
+		a := set.NewFromSlice([]int{1, 3})
+		b := set.NewFromSlice([]int{1, 2, 4})
+		assert.False(t, a.IsSubset(b))
+	})
+}

--- a/internal/sso/sso.go
+++ b/internal/sso/sso.go
@@ -148,9 +148,10 @@ func (s *SSOService) Authenticate(ctx context.Context, scopes []string) (*Token,
 		)
 		return http.StatusOK, nil
 	}))
-	router.HandleFunc("/", makeHandler(func(w http.ResponseWriter, r *http.Request) (int, error) {
-		return http.StatusNotFound, fmt.Errorf("unexpected route requested: %s", r.RequestURI)
-	}))
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("request", "status", http.StatusNotFound, "path", r.URL.Path)
+		http.Error(w, "not found", http.StatusNotFound)
+	})
 	// we want to be sure the server is running before starting the browser
 	// and we want to be able to exit early in case the port is blocked
 	server := &http.Server{


### PR DESCRIPTION
The web server may shut down during the SSO process when receiving an unexpected request (e.g. /favicon). With this patch the web server will continue to log unexpected requests, but no longer abort the SSO process.