### PR TITLE
Improve DB performance

### DIFF
--- a/internal/app/storage/cache.go
+++ b/internal/app/storage/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (st *Storage) CacheClear(ctx context.Context) error {
-	err := st.q.CacheClear(ctx)
+	err := st.qRW.CacheClear(ctx)
 	if err != nil {
 		return fmt.Errorf("cache clear: %w", err)
 	}
@@ -19,7 +19,7 @@ func (st *Storage) CacheClear(ctx context.Context) error {
 }
 
 func (st *Storage) CacheCleanUp(ctx context.Context) (int, error) {
-	n, err := st.q.CacheCleanUp(ctx, NewNullTimeFromTime(time.Now().UTC()))
+	n, err := st.qRW.CacheCleanUp(ctx, NewNullTimeFromTime(time.Now().UTC()))
 	if err != nil {
 		return 0, fmt.Errorf("cache cleanup: %w", err)
 	}
@@ -42,7 +42,7 @@ func (st *Storage) CacheGet(ctx context.Context, key string) ([]byte, error) {
 		Key: key,
 		Now: NewNullTimeFromTime(time.Now().UTC()),
 	}
-	x, err := st.q.CacheGet(ctx, arg)
+	x, err := st.qRO.CacheGet(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -53,7 +53,7 @@ func (st *Storage) CacheGet(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (st *Storage) CacheDelete(ctx context.Context, key string) error {
-	err := st.q.CacheDelete(ctx, key)
+	err := st.qRW.CacheDelete(ctx, key)
 	if err != nil {
 		return fmt.Errorf("cache delete %s: %w", key, err)
 	}
@@ -76,7 +76,7 @@ func (st *Storage) CacheSet(ctx context.Context, arg CacheSetParams) error {
 		Key:       arg.Key,
 		Value:     arg.Value,
 	}
-	err := st.q.CacheSet(ctx, arg2)
+	err := st.qRW.CacheSet(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("cache set %s: %w", arg.Key, err)
 	}

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (st *Storage) DeleteCharacter(ctx context.Context, characterID int32) error {
-	err := st.q.DeleteCharacter(ctx, int64(characterID))
+	err := st.qRW.DeleteCharacter(ctx, int64(characterID))
 	if err != nil {
 		return fmt.Errorf("delete character %d: %w", characterID, err)
 	}
@@ -23,14 +23,14 @@ func (st *Storage) DeleteCharacter(ctx context.Context, characterID int32) error
 }
 
 func (st *Storage) DisableAllTrainingWatchers(ctx context.Context) error {
-	if err := st.q.DisableAllTrainingWatchers(ctx); err != nil {
+	if err := st.qRW.DisableAllTrainingWatchers(ctx); err != nil {
 		return fmt.Errorf("disable all training watchers: %w", err)
 	}
 	return nil
 }
 
 func (st *Storage) GetCharacter(ctx context.Context, characterID int32) (*app.Character, error) {
-	r, err := st.q.GetCharacter(ctx, int64(characterID))
+	r, err := st.qRO.GetCharacter(ctx, int64(characterID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -79,7 +79,7 @@ func (st *Storage) GetAnyCharacter(ctx context.Context) (*app.Character, error) 
 }
 
 func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error) {
-	rows, err := st.q.ListCharacters(ctx)
+	rows, err := st.qRO.ListCharacters(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list characters: %w", err)
 	}
@@ -116,7 +116,7 @@ func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error)
 }
 
 func (st *Storage) ListCharactersShort(ctx context.Context) ([]*app.CharacterShort, error) {
-	rows, err := st.q.ListCharactersShort(ctx)
+	rows, err := st.qRO.ListCharactersShort(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list short characters: %w", err)
 
@@ -129,7 +129,7 @@ func (st *Storage) ListCharactersShort(ctx context.Context) ([]*app.CharacterSho
 }
 
 func (st *Storage) ListCharacterIDs(ctx context.Context) (set.Set[int32], error) {
-	ids, err := st.q.ListCharacterIDs(ctx)
+	ids, err := st.qRO.ListCharacterIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list character IDs: %w", err)
 	}
@@ -142,7 +142,7 @@ func (st *Storage) UpdateCharacterHome(ctx context.Context, characterID int32, h
 		ID:     int64(characterID),
 		HomeID: optional.ToNullInt64(homeID),
 	}
-	if err := st.q.UpdateCharacterHomeId(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterHomeId(ctx, arg); err != nil {
 		return fmt.Errorf("update home for character %d: %w", characterID, err)
 	}
 	return nil
@@ -153,7 +153,7 @@ func (st *Storage) UpdateCharacterIsTrainingWatched(ctx context.Context, charact
 		ID:                int64(characterID),
 		IsTrainingWatched: isWatched,
 	}
-	if err := st.q.UpdateCharacterIsTrainingWatched(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterIsTrainingWatched(ctx, arg); err != nil {
 		return fmt.Errorf("update is training watched for character %d: %w", characterID, err)
 	}
 	return nil
@@ -164,7 +164,7 @@ func (st *Storage) UpdateCharacterLastCloneJump(ctx context.Context, characterID
 		ID:              int64(characterID),
 		LastCloneJumpAt: optional.ToNullTime(v),
 	}
-	if err := st.q.UpdateCharacterLastCloneJump(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterLastCloneJump(ctx, arg); err != nil {
 		return fmt.Errorf("update last clone jump for character %d: %w", characterID, err)
 	}
 	return nil
@@ -175,7 +175,7 @@ func (st *Storage) UpdateCharacterLastLoginAt(ctx context.Context, characterID i
 		ID:          int64(characterID),
 		LastLoginAt: optional.ToNullTime(v),
 	}
-	if err := st.q.UpdateCharacterLastLoginAt(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterLastLoginAt(ctx, arg); err != nil {
 		return fmt.Errorf("update last login for character %d: %w", characterID, err)
 	}
 	return nil
@@ -186,7 +186,7 @@ func (st *Storage) UpdateCharacterLocation(ctx context.Context, characterID int3
 		ID:         int64(characterID),
 		LocationID: optional.ToNullInt64(locationID),
 	}
-	if err := st.q.UpdateCharacterLocationID(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterLocationID(ctx, arg); err != nil {
 		return fmt.Errorf("update location for character %d: %w", characterID, err)
 	}
 	return nil
@@ -197,7 +197,7 @@ func (st *Storage) UpdateCharacterShip(ctx context.Context, characterID int32, s
 		ID:     int64(characterID),
 		ShipID: optional.ToNullInt64(shipID),
 	}
-	if err := st.q.UpdateCharacterShipID(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterShipID(ctx, arg); err != nil {
 		return fmt.Errorf("update ship for character %d: %w", characterID, err)
 	}
 	return nil
@@ -209,7 +209,7 @@ func (st *Storage) UpdateCharacterSkillPoints(ctx context.Context, characterID i
 		TotalSp:       optional.ToNullInt64(totalSP),
 		UnallocatedSp: optional.ToNullInt64(unallocatedSP),
 	}
-	if err := st.q.UpdateCharacterSP(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterSP(ctx, arg); err != nil {
 		return fmt.Errorf("update sp for character %d: %w", characterID, err)
 	}
 	return nil
@@ -220,7 +220,7 @@ func (st *Storage) UpdateCharacterWalletBalance(ctx context.Context, characterID
 		ID:            int64(characterID),
 		WalletBalance: optional.ToNullFloat64(v),
 	}
-	if err := st.q.UpdateCharacterWalletBalance(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterWalletBalance(ctx, arg); err != nil {
 		return fmt.Errorf("update wallet balance for character %d: %w", characterID, err)
 	}
 	return nil
@@ -231,7 +231,7 @@ func (st *Storage) UpdateCharacterAssetValue(ctx context.Context, characterID in
 		ID:         int64(characterID),
 		AssetValue: optional.ToNullFloat64(v),
 	}
-	if err := st.q.UpdateCharacterAssetValue(ctx, arg); err != nil {
+	if err := st.qRW.UpdateCharacterAssetValue(ctx, arg); err != nil {
 		return fmt.Errorf("update asset value for character %d: %w", characterID, err)
 	}
 	return nil
@@ -265,7 +265,7 @@ func (st *Storage) UpdateOrCreateCharacter(ctx context.Context, arg UpdateOrCrea
 		UnallocatedSp:     optional.ToNullInt64(arg.UnallocatedSP),
 		WalletBalance:     optional.ToNullFloat64(arg.WalletBalance),
 	}
-	if err := st.q.UpdateOrCreateCharacter(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateOrCreateCharacter(ctx, arg2); err != nil {
 		return fmt.Errorf("update or create character %d: %w", arg.ID, err)
 	}
 	return nil
@@ -319,7 +319,7 @@ func (st *Storage) characterFromDBModel(
 }
 
 func (st *Storage) GetCharacterAssetValue(ctx context.Context, id int32) (optional.Optional[float64], error) {
-	v, err := st.q.GetCharacterAssetValue(ctx, int64(id))
+	v, err := st.qRO.GetCharacterAssetValue(ctx, int64(id))
 	if err != nil {
 		return optional.Optional[float64]{}, fmt.Errorf("get asset value for character %d: %w", id, err)
 	}

--- a/internal/app/storage/characterasset.go
+++ b/internal/app/storage/characterasset.go
@@ -41,7 +41,7 @@ func (st *Storage) CreateCharacterAsset(ctx context.Context, arg CreateCharacter
 		Name:            arg.Name,
 		Quantity:        int64(arg.Quantity),
 	}
-	if err := st.q.CreateCharacterAsset(ctx, arg2); err != nil {
+	if err := st.qRW.CreateCharacterAsset(ctx, arg2); err != nil {
 		return fmt.Errorf("create character asset %v, %w", arg, err)
 	}
 	return nil
@@ -52,7 +52,7 @@ func (st *Storage) DeleteCharacterAssets(ctx context.Context, characterID int32,
 		CharacterID: int64(characterID),
 		ItemIds:     itemIDs,
 	}
-	return st.q.DeleteCharacterAssets(ctx, arg)
+	return st.qRW.DeleteCharacterAssets(ctx, arg)
 }
 
 func (st *Storage) GetCharacterAsset(ctx context.Context, characterID int32, itemID int64) (*app.CharacterAsset, error) {
@@ -60,7 +60,7 @@ func (st *Storage) GetCharacterAsset(ctx context.Context, characterID int32, ite
 		CharacterID: int64(characterID),
 		ItemID:      itemID,
 	}
-	r, err := st.q.GetCharacterAsset(ctx, arg)
+	r, err := st.qRO.GetCharacterAsset(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -72,7 +72,7 @@ func (st *Storage) GetCharacterAsset(ctx context.Context, characterID int32, ite
 }
 
 func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, characterID int32) (float64, error) {
-	v, err := st.q.CalculateCharacterAssetTotalValue(ctx, int64(characterID))
+	v, err := st.qRO.CalculateCharacterAssetTotalValue(ctx, int64(characterID))
 	if err != nil {
 		return 0, fmt.Errorf("calculate character asset for character %d: %w", characterID, err)
 	}
@@ -80,7 +80,7 @@ func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, charac
 }
 
 func (st *Storage) ListCharacterAssetIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
-	ids, err := st.q.ListCharacterAssetIDs(ctx, int64(characterID))
+	ids, err := st.qRO.ListCharacterAssetIDs(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list character asset IDs: %w", err)
 	}
@@ -94,7 +94,7 @@ func (st *Storage) ListCharacterAssetsInShipHangar(ctx context.Context, characte
 		LocationFlag:  "Hangar",
 		EveCategoryID: app.EveCategoryShip,
 	}
-	rows, err := st.q.ListCharacterAssetsInShipHangar(ctx, arg)
+	rows, err := st.qRO.ListCharacterAssetsInShipHangar(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list assets in ship hangar for character ID %d: %w", characterID, err)
 	}
@@ -112,7 +112,7 @@ func (st *Storage) ListCharacterAssetsInItemHangar(ctx context.Context, characte
 		LocationFlag:  "Hangar",
 		EveCategoryID: app.EveCategoryShip,
 	}
-	rows, err := st.q.ListCharacterAssetsInItemHangar(ctx, arg)
+	rows, err := st.qRO.ListCharacterAssetsInItemHangar(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list assets in item hangar for character ID %d: %w", characterID, err)
 	}
@@ -128,7 +128,7 @@ func (st *Storage) ListCharacterAssetsInLocation(ctx context.Context, characterI
 		CharacterID: int64(characterID),
 		LocationID:  locationID,
 	}
-	rows, err := st.q.ListCharacterAssetsInLocation(ctx, arg)
+	rows, err := st.qRO.ListCharacterAssetsInLocation(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list assets in location for character ID %d: %w", characterID, err)
 	}
@@ -162,14 +162,14 @@ func (st *Storage) UpdateCharacterAsset(ctx context.Context, arg UpdateCharacter
 		Name:         arg.Name,
 		Quantity:     int64(arg.Quantity),
 	}
-	if err := st.q.UpdateCharacterAsset(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateCharacterAsset(ctx, arg2); err != nil {
 		return fmt.Errorf("update character asset %v, %w", arg, err)
 	}
 	return nil
 }
 
 func (st *Storage) ListAllCharacterAssets(ctx context.Context) ([]*app.CharacterAsset, error) {
-	rows, err := st.q.ListAllCharacterAssets(ctx)
+	rows, err := st.qRO.ListAllCharacterAssets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list all character assets: %w", err)
 	}
@@ -181,7 +181,7 @@ func (st *Storage) ListAllCharacterAssets(ctx context.Context) ([]*app.Character
 }
 
 func (st *Storage) ListCharacterAssets(ctx context.Context, characterID int32) ([]*app.CharacterAsset, error) {
-	rows, err := st.q.ListCharacterAssets(ctx, int64(characterID))
+	rows, err := st.qRO.ListCharacterAssets(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list assets for character ID %d: %w", characterID, err)
 	}

--- a/internal/app/storage/characterattributes.go
+++ b/internal/app/storage/characterattributes.go
@@ -24,7 +24,7 @@ type UpdateOrCreateCharacterAttributesParams struct {
 }
 
 func (st *Storage) GetCharacterAttributes(ctx context.Context, characterID int32) (*app.CharacterAttributes, error) {
-	o, err := st.q.GetCharacterAttributes(ctx, int64(characterID))
+	o, err := st.qRO.GetCharacterAttributes(ctx, int64(characterID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -48,7 +48,7 @@ func (st *Storage) UpdateOrCreateCharacterAttributes(ctx context.Context, arg Up
 		arg2.LastRemapDate.Time = arg.LastRemapDate
 		arg2.LastRemapDate.Valid = true
 	}
-	return st.q.UpdateOrCreateCharacterAttributes(ctx, arg2)
+	return st.qRW.UpdateOrCreateCharacterAttributes(ctx, arg2)
 }
 
 func characterAttributeFromDBModel(o queries.CharacterAttribute) *app.CharacterAttributes {

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -129,7 +129,7 @@ func (st *Storage) CreateCharacterContract(ctx context.Context, arg CreateCharac
 	if arg.StartLocationID != 0 {
 		arg2.StartLocationID = NewNullInt64(arg.StartLocationID)
 	}
-	id, err := st.q.CreateCharacterContract(ctx, arg2)
+	id, err := st.qRW.CreateCharacterContract(ctx, arg2)
 	if err != nil {
 		return 0, fmt.Errorf("create contract: %v: %w", arg, err)
 	}
@@ -141,7 +141,7 @@ func (st *Storage) GetCharacterContract(ctx context.Context, characterID, contra
 		CharacterID: int64(characterID),
 		ContractID:  int64(contractID),
 	}
-	r, err := st.q.GetCharacterContract(ctx, arg)
+	r, err := st.qRO.GetCharacterContract(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("get contract for character %d: %w", characterID, err)
 	}
@@ -166,7 +166,7 @@ func (st *Storage) GetCharacterContract(ctx context.Context, characterID, contra
 }
 
 func (st *Storage) ListCharacterContractIDs(ctx context.Context, characterID int32) ([]int32, error) {
-	ids, err := st.q.ListCharacterContractIDs(ctx, int64(characterID))
+	ids, err := st.qRO.ListCharacterContractIDs(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list contract ids for character %d: %w", characterID, err)
 	}
@@ -174,7 +174,7 @@ func (st *Storage) ListCharacterContractIDs(ctx context.Context, characterID int
 }
 
 func (st *Storage) ListCharacterContracts(ctx context.Context, characterID int32) ([]*app.CharacterContract, error) {
-	rows, err := st.q.ListCharacterContracts(ctx, int64(characterID))
+	rows, err := st.qRO.ListCharacterContracts(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list contracts for character %d: %w", characterID, err)
 	}
@@ -206,7 +206,7 @@ func (st *Storage) ListCharacterContractsForNotify(ctx context.Context, characte
 		CharacterID: int64(characterID),
 		UpdatedAt:   earliest,
 	}
-	rows, err := st.q.ListCharacterContractsForNotify(ctx, arg)
+	rows, err := st.qRO.ListCharacterContractsForNotify(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list contracts to notify for character %d: %w", characterID, err)
 	}
@@ -258,7 +258,7 @@ func (st *Storage) UpdateCharacterContract(ctx context.Context, arg UpdateCharac
 		arg2.AcceptorID.Int64 = int64(arg.AcceptorID)
 		arg2.AcceptorID.Valid = true
 	}
-	err := st.q.UpdateCharacterContract(ctx, arg2)
+	err := st.qRW.UpdateCharacterContract(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("update character contract: %w", err)
 	}
@@ -281,7 +281,7 @@ func (st *Storage) UpdateCharacterContractNotified(ctx context.Context, id int64
 		StatusNotified: statusNotified,
 		UpdatedAt:      time.Now().UTC(),
 	}
-	err := st.q.UpdateCharacterContractNotified(ctx, arg2)
+	err := st.qRW.UpdateCharacterContractNotified(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("update character contract notified: %w", err)
 	}

--- a/internal/app/storage/charactercontractbid.go
+++ b/internal/app/storage/charactercontractbid.go
@@ -29,7 +29,7 @@ func (st *Storage) CreateCharacterContractBid(ctx context.Context, arg CreateCha
 		BidderID:   int64(arg.BidderID),
 		DateBid:    arg.DateBid,
 	}
-	if err := st.q.CreateCharacterContractBid(ctx, arg2); err != nil {
+	if err := st.qRW.CreateCharacterContractBid(ctx, arg2); err != nil {
 		return fmt.Errorf("create contract bid: %+v: %w", arg, err)
 	}
 	return nil
@@ -40,7 +40,7 @@ func (st *Storage) GetCharacterContractBid(ctx context.Context, contractID int64
 		ContractID: contractID,
 		BidID:      int64(bidID),
 	}
-	r, err := st.q.GetCharacterContractBid(ctx, arg)
+	r, err := st.qRO.GetCharacterContractBid(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("get contract bid %+v: %w", arg, err)
 	}
@@ -48,7 +48,7 @@ func (st *Storage) GetCharacterContractBid(ctx context.Context, contractID int64
 }
 
 func (st *Storage) ListCharacterContractBids(ctx context.Context, contractID int64) ([]*app.CharacterContractBid, error) {
-	rows, err := st.q.ListCharacterContractBids(ctx, contractID)
+	rows, err := st.qRO.ListCharacterContractBids(ctx, contractID)
 	if err != nil {
 		return nil, fmt.Errorf("list bids for contract %d: %w", contractID, err)
 	}
@@ -60,7 +60,7 @@ func (st *Storage) ListCharacterContractBids(ctx context.Context, contractID int
 }
 
 func (st *Storage) ListCharacterContractBidIDs(ctx context.Context, contractID int64) (set.Set[int32], error) {
-	ids, err := st.q.ListCharacterContractBidIDs(ctx, contractID)
+	ids, err := st.qRO.ListCharacterContractBidIDs(ctx, contractID)
 	if err != nil {
 		return nil, fmt.Errorf("list bid IDs for contract %d: %w", contractID, err)
 	}

--- a/internal/app/storage/charactercontratitem.go
+++ b/internal/app/storage/charactercontratitem.go
@@ -31,7 +31,7 @@ func (st *Storage) CreateCharacterContractItem(ctx context.Context, arg CreateCh
 		RecordID:    arg.RecordID,
 		TypeID:      int64(arg.TypeID),
 	}
-	if err := st.q.CreateCharacterContractItem(ctx, arg2); err != nil {
+	if err := st.qRW.CreateCharacterContractItem(ctx, arg2); err != nil {
 		return fmt.Errorf("create contract item: %+v: %w", arg, err)
 	}
 	return nil
@@ -42,7 +42,7 @@ func (st *Storage) GetCharacterContractItem(ctx context.Context, contractID, rec
 		ContractID: contractID,
 		RecordID:   recordID,
 	}
-	r, err := st.q.GetCharacterContractItem(ctx, arg)
+	r, err := st.qRO.GetCharacterContractItem(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("get contract item %+v: %w", arg, err)
 	}
@@ -50,7 +50,7 @@ func (st *Storage) GetCharacterContractItem(ctx context.Context, contractID, rec
 }
 
 func (st *Storage) ListCharacterContractItems(ctx context.Context, contractID int64) ([]*app.CharacterContractItem, error) {
-	rows, err := st.q.ListCharacterContractItems(ctx, contractID)
+	rows, err := st.qRO.ListCharacterContractItems(ctx, contractID)
 	if err != nil {
 		return nil, fmt.Errorf("list items for contract %d: %w", contractID, err)
 	}

--- a/internal/app/storage/charactermailheader.go
+++ b/internal/app/storage/charactermailheader.go
@@ -14,7 +14,7 @@ import (
 func (st *Storage) ListCharacterMailHeadersForLabelOrdered(ctx context.Context, characterID int32, labelID int32) ([]*app.CharacterMailHeader, error) {
 	switch labelID {
 	case app.MailLabelAll:
-		rows, err := st.q.ListMailsOrdered(ctx, int64(characterID))
+		rows, err := st.qRO.ListMailsOrdered(ctx, int64(characterID))
 		if err != nil {
 			return nil, fmt.Errorf("list mails for character %d: %w", characterID, err)
 		}
@@ -24,7 +24,7 @@ func (st *Storage) ListCharacterMailHeadersForLabelOrdered(ctx context.Context, 
 		}
 		return mm, nil
 	case app.MailLabelUnread:
-		rows, err := st.q.ListMailsUnreadOrdered(ctx, int64(characterID))
+		rows, err := st.qRO.ListMailsUnreadOrdered(ctx, int64(characterID))
 		if err != nil {
 			return nil, fmt.Errorf("list unread mails for character %d: %w", characterID, err)
 		}
@@ -34,7 +34,7 @@ func (st *Storage) ListCharacterMailHeadersForLabelOrdered(ctx context.Context, 
 		}
 		return mm, nil
 	case app.MailLabelNone:
-		rows, err := st.q.ListMailsNoLabelOrdered(ctx, int64(characterID))
+		rows, err := st.qRO.ListMailsNoLabelOrdered(ctx, int64(characterID))
 		if err != nil {
 			return nil, fmt.Errorf("list mails wo labels for character %d: %w", characterID, err)
 		}
@@ -48,7 +48,7 @@ func (st *Storage) ListCharacterMailHeadersForLabelOrdered(ctx context.Context, 
 			CharacterID: int64(characterID),
 			LabelID:     int64(labelID),
 		}
-		rows, err := st.q.ListMailsForLabelOrdered(ctx, arg)
+		rows, err := st.qRO.ListMailsForLabelOrdered(ctx, arg)
 		if err != nil {
 			return nil, fmt.Errorf("list mails for character %d and label %d: %w", characterID, labelID, err)
 		}
@@ -65,7 +65,7 @@ func (st *Storage) ListCharacterMailHeadersForListOrdered(ctx context.Context, c
 		CharacterID: int64(characterID),
 		EveEntityID: int64(listID),
 	}
-	rows, err := st.q.ListMailsForListOrdered(ctx, arg)
+	rows, err := st.qRO.ListMailsForListOrdered(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list mail ids for character %d and list %d: %w", characterID, listID, err)
 	}
@@ -82,7 +82,7 @@ func (st *Storage) ListCharacterMailHeadersForUnprocessed(ctx context.Context, c
 		LabelID:     app.MailLabelSent,
 		Timestamp:   earliest,
 	}
-	rows, err := st.q.ListMailsUnprocessed(ctx, arg)
+	rows, err := st.qRO.ListMailsUnprocessed(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list unprocessed mails for character %d: %w", characterID, err)
 	}

--- a/internal/app/storage/charactermaillabel.go
+++ b/internal/app/storage/charactermaillabel.go
@@ -15,7 +15,7 @@ func (st *Storage) DeleteObsoleteCharacterMailLabels(ctx context.Context, charac
 		CharacterID:   int64(characterID),
 		CharacterID_2: int64(characterID),
 	}
-	if err := st.q.DeleteObsoleteCharacterMailLabels(ctx, arg); err != nil {
+	if err := st.qRW.DeleteObsoleteCharacterMailLabels(ctx, arg); err != nil {
 		return fmt.Errorf("delete obsolete mail labels for character %d: %w", characterID, err)
 	}
 	return nil
@@ -26,7 +26,7 @@ func (st *Storage) GetCharacterMailLabel(ctx context.Context, characterID, label
 		CharacterID: int64(characterID),
 		LabelID:     int64(labelID),
 	}
-	l, err := st.q.GetCharacterMailLabel(ctx, arg)
+	l, err := st.qRO.GetCharacterMailLabel(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -48,12 +48,12 @@ type MailLabelParams struct {
 func (st *Storage) GetOrCreateCharacterMailLabel(ctx context.Context, arg MailLabelParams) (*app.CharacterMailLabel, error) {
 	label, err := func() (*app.CharacterMailLabel, error) {
 		var l queries.CharacterMailLabel
-		tx, err := st.db.Begin()
+		tx, err := st.dbRW.Begin()
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Rollback()
-		qtx := st.q.WithTx(tx)
+		qtx := st.qRW.WithTx(tx)
 		arg2 := queries.GetCharacterMailLabelParams{
 			CharacterID: int64(arg.CharacterID),
 			LabelID:     int64(arg.LabelID),
@@ -86,7 +86,7 @@ func (st *Storage) GetOrCreateCharacterMailLabel(ctx context.Context, arg MailLa
 }
 
 func (st *Storage) ListCharacterMailLabelsOrdered(ctx context.Context, characterID int32) ([]*app.CharacterMailLabel, error) {
-	ll, err := st.q.ListCharacterMailLabelsOrdered(ctx, int64(characterID))
+	ll, err := st.qRO.ListCharacterMailLabelsOrdered(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list mail label IDs for character %d: %w", characterID, err)
 	}
@@ -105,7 +105,7 @@ func (st *Storage) UpdateOrCreateCharacterMailLabel(ctx context.Context, arg Mai
 		Name:        arg.Name,
 		UnreadCount: int64(arg.UnreadCount),
 	}
-	l, err := st.q.UpdateOrCreateCharacterMailLabel(ctx, arg1)
+	l, err := st.qRW.UpdateOrCreateCharacterMailLabel(ctx, arg1)
 	if err != nil {
 		return nil, fmt.Errorf("update or create mail label for character %d with label %d: %w", arg.CharacterID, arg.LabelID, err)
 	}

--- a/internal/app/storage/charactermaillist.go
+++ b/internal/app/storage/charactermaillist.go
@@ -9,7 +9,7 @@ import (
 
 func (st *Storage) CreateCharacterMailList(ctx context.Context, characterID, mailListID int32) error {
 	arg := queries.CreateCharacterMailListParams{CharacterID: int64(characterID), EveEntityID: int64(mailListID)}
-	if err := st.q.CreateCharacterMailList(ctx, arg); err != nil {
+	if err := st.qRW.CreateCharacterMailList(ctx, arg); err != nil {
 		return fmt.Errorf("create mail list %d for character %d: %w", mailListID, characterID, err)
 	}
 	return nil
@@ -21,7 +21,7 @@ func (st *Storage) DeleteObsoleteCharacterMailLists(ctx context.Context, charact
 		CharacterID_2: int64(characterID),
 		CharacterID_3: int64(characterID),
 	}
-	if err := st.q.DeleteObsoleteCharacterMailLists(ctx, arg); err != nil {
+	if err := st.qRW.DeleteObsoleteCharacterMailLists(ctx, arg); err != nil {
 		return fmt.Errorf("delete obsolete mail lists for character %d: %w", characterID, err)
 	}
 	return nil

--- a/internal/app/storage/characterplanet.go
+++ b/internal/app/storage/characterplanet.go
@@ -29,7 +29,7 @@ func (st *Storage) CreateCharacterPlanet(ctx context.Context, arg CreateCharacte
 		LastUpdate:   arg.LastUpdate,
 		UpgradeLevel: int64(arg.UpgradeLevel),
 	}
-	id, err := st.q.CreateCharacterPlanet(ctx, arg2)
+	id, err := st.qRW.CreateCharacterPlanet(ctx, arg2)
 	if err != nil {
 		return 0, fmt.Errorf("create create planet: %+v: %w", arg2, err)
 	}
@@ -41,7 +41,7 @@ func (st *Storage) DeleteCharacterPlanet(ctx context.Context, characterID int32,
 		CharacterID:  int64(characterID),
 		EvePlanetIds: convertNumericSlice[int64](planetIDs),
 	}
-	if err := st.q.DeleteCharacterPlanets(ctx, arg); err != nil {
+	if err := st.qRW.DeleteCharacterPlanets(ctx, arg); err != nil {
 		return fmt.Errorf("delete character planets: %+v: %w", arg, err)
 	}
 	return nil
@@ -52,7 +52,7 @@ func (st *Storage) GetCharacterPlanet(ctx context.Context, characterID int32, pl
 		CharacterID: int64(characterID),
 		EvePlanetID: int64(planetID),
 	}
-	r, err := st.q.GetCharacterPlanet(ctx, arg)
+	r, err := st.qRO.GetCharacterPlanet(ctx, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (st *Storage) GetCharacterPlanet(ctx context.Context, characterID int32, pl
 }
 
 func (st *Storage) ListAllCharacterPlanets(ctx context.Context) ([]*app.CharacterPlanet, error) {
-	rows, err := st.q.ListAllCharacterPlanets(ctx)
+	rows, err := st.qRO.ListAllCharacterPlanets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list all planets: %w", err)
 	}
@@ -80,7 +80,7 @@ func (st *Storage) ListAllCharacterPlanets(ctx context.Context) ([]*app.Characte
 }
 
 func (st *Storage) ListCharacterPlanets(ctx context.Context, id int32) ([]*app.CharacterPlanet, error) {
-	rows, err := st.q.ListCharacterPlanets(ctx, int64(id))
+	rows, err := st.qRO.ListCharacterPlanets(ctx, int64(id))
 	if err != nil {
 		return nil, fmt.Errorf("list planets for character %d: %w", id, err)
 	}
@@ -126,7 +126,7 @@ func (st *Storage) UpdateCharacterPlanetLastNotified(ctx context.Context, arg Up
 		EvePlanetID:  int64(arg.EvePlanetID),
 		LastNotified: NewNullTimeFromTime(arg.LastNotified),
 	}
-	if err := st.q.UpdateCharacterPlanetLastNotified(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateCharacterPlanetLastNotified(ctx, arg2); err != nil {
 		return fmt.Errorf("update character planet last notified: %+v: %w", arg2, err)
 	}
 	return nil
@@ -149,7 +149,7 @@ func (st *Storage) UpdateOrCreateCharacterPlanet(ctx context.Context, arg Update
 		LastUpdate:   arg.LastUpdate,
 		UpgradeLevel: int64(arg.UpgradeLevel),
 	}
-	id, err := st.q.UpdateOrCreateCharacterPlanet(ctx, arg2)
+	id, err := st.qRW.UpdateOrCreateCharacterPlanet(ctx, arg2)
 	if err != nil {
 		return 0, fmt.Errorf("update or create create planet: %+v: %w", arg2, err)
 	}

--- a/internal/app/storage/charactersectionstatus.go
+++ b/internal/app/storage/charactersectionstatus.go
@@ -27,7 +27,7 @@ func (st *Storage) GetCharacterSectionStatus(ctx context.Context, characterID in
 		CharacterID: int64(characterID),
 		SectionID:   string(section),
 	}
-	s, err := st.q.GetCharacterSectionStatus(ctx, arg)
+	s, err := st.qRO.GetCharacterSectionStatus(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -39,7 +39,7 @@ func (st *Storage) GetCharacterSectionStatus(ctx context.Context, characterID in
 }
 
 func (st *Storage) ListCharacterSectionStatus(ctx context.Context, characterID int32) ([]*app.CharacterSectionStatus, error) {
-	rows, err := st.q.ListCharacterSectionStatus(ctx, int64(characterID))
+	rows, err := st.qRO.ListCharacterSectionStatus(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list character status for ID %d: %w", characterID, err)
 	}
@@ -66,12 +66,12 @@ func (st *Storage) UpdateOrCreateCharacterSectionStatus(ctx context.Context, arg
 		panic("Invalid params")
 	}
 	o, err := func() (*app.CharacterSectionStatus, error) {
-		tx, err := st.db.Begin()
+		tx, err := st.dbRW.Begin()
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Rollback()
-		qtx := st.q.WithTx(tx)
+		qtx := st.qRW.WithTx(tx)
 		var arg2 queries.UpdateOrCreateCharacterSectionStatusParams
 		old, err := qtx.GetCharacterSectionStatus(ctx, queries.GetCharacterSectionStatusParams{
 			CharacterID: int64(arg.CharacterID),

--- a/internal/app/storage/charactershipskill.go
+++ b/internal/app/storage/charactershipskill.go
@@ -14,7 +14,7 @@ func (st *Storage) ListCharacterShipsAbilities(ctx context.Context, characterID 
 		CharacterID: int64(characterID),
 		Name:        search,
 	}
-	rows, err := st.q.ListCharacterShipsAbilities(ctx, arg)
+	rows, err := st.qRO.ListCharacterShipsAbilities(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list ship abilities for character %d and search %s: %w", characterID, search, err)
 	}
@@ -35,7 +35,7 @@ func (st *Storage) ListCharacterShipSkills(ctx context.Context, characterID, shi
 		CharacterID: int64(characterID),
 		ShipTypeID:  int64(shipTypeID),
 	}
-	rows, err := st.q.ListCharacterShipSkills(ctx, arg)
+	rows, err := st.qRO.ListCharacterShipSkills(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list character ship skills for character %d and type %d: %w", characterID, shipTypeID, err)
 	}

--- a/internal/app/storage/characterskill.go
+++ b/internal/app/storage/characterskill.go
@@ -16,7 +16,7 @@ func (st *Storage) DeleteCharacterSkills(ctx context.Context, characterID int32,
 		CharacterID: int64(characterID),
 		EveTypeIds:  convertNumericSlice[int64](eveTypeIDs),
 	}
-	err := st.q.DeleteCharacterSkills(ctx, arg)
+	err := st.qRW.DeleteCharacterSkills(ctx, arg)
 	if err != nil {
 		return fmt.Errorf("delete skills for character %d: %w", characterID, err)
 	}
@@ -28,7 +28,7 @@ func (st *Storage) GetCharacterSkill(ctx context.Context, characterID int32, typ
 		CharacterID: int64(characterID),
 		EveTypeID:   int64(typeID),
 	}
-	r, err := st.q.GetCharacterSkill(ctx, arg)
+	r, err := st.qRO.GetCharacterSkill(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -40,7 +40,7 @@ func (st *Storage) GetCharacterSkill(ctx context.Context, characterID int32, typ
 }
 
 func (st *Storage) ListCharacterSkillIDs(ctx context.Context, characterID int32) (set.Set[int32], error) {
-	ids1, err := st.q.ListCharacterSkillIDs(ctx, int64(characterID))
+	ids1, err := st.qRO.ListCharacterSkillIDs(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list skill ids for character %d: %w", characterID, err)
 	}
@@ -53,7 +53,7 @@ func (st *Storage) ListCharacterSkillProgress(ctx context.Context, characterID, 
 		CharacterID: int64(characterID),
 		EveGroupID:  int64(eveGroupID),
 	}
-	rows, err := st.q.ListCharacterSkillProgress(ctx, arg)
+	rows, err := st.qRO.ListCharacterSkillProgress(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list skill progress for character %d: %w", characterID, err)
 	}
@@ -75,7 +75,7 @@ func (st *Storage) ListCharacterSkillGroupsProgress(ctx context.Context, charact
 		CharacterID:   int64(characterID),
 		EveCategoryID: app.EveCategorySkill,
 	}
-	rows, err := st.q.ListCharacterSkillGroupsProgress(ctx, arg)
+	rows, err := st.qRO.ListCharacterSkillGroupsProgress(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("list skill groups progress for character %d: %w", characterID, err)
 	}
@@ -110,7 +110,7 @@ func (st *Storage) UpdateOrCreateCharacterSkill(ctx context.Context, arg UpdateO
 		CharacterID:        int64(arg.CharacterID),
 		TrainedSkillLevel:  int64(arg.TrainedSkillLevel),
 	}
-	if err := st.q.UpdateOrCreateCharacterSkill(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateOrCreateCharacterSkill(ctx, arg2); err != nil {
 		return fmt.Errorf("update or create character skill for character %d: %w", arg.CharacterID, err)
 	}
 	return nil

--- a/internal/app/storage/characterwalletjournal.go
+++ b/internal/app/storage/characterwalletjournal.go
@@ -58,7 +58,7 @@ func (st *Storage) CreateCharacterWalletJournalEntry(ctx context.Context, arg Cr
 		arg2.TaxReceiverID.Int64 = int64(arg.TaxReceiverID)
 		arg2.TaxReceiverID.Valid = true
 	}
-	err := st.q.CreateCharacterWalletJournalEntry(ctx, arg2)
+	err := st.qRW.CreateCharacterWalletJournalEntry(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create wallet journal entry for character %d: %w", arg.CharacterID, err)
 	}
@@ -70,7 +70,7 @@ func (st *Storage) GetCharacterWalletJournalEntry(ctx context.Context, character
 		CharacterID: int64(characterID),
 		RefID:       refID,
 	}
-	r, err := st.q.GetCharacterWalletJournalEntry(ctx, arg)
+	r, err := st.qRO.GetCharacterWalletJournalEntry(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("get wallet journal entry for character %d: %w", characterID, err)
 	}
@@ -82,7 +82,7 @@ func (st *Storage) GetCharacterWalletJournalEntry(ctx context.Context, character
 }
 
 func (st *Storage) ListCharacterWalletJournalEntryIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
-	ids, err := st.q.ListCharacterWalletJournalEntryRefIDs(ctx, int64(characterID))
+	ids, err := st.qRO.ListCharacterWalletJournalEntryRefIDs(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list wallet journal entry ids for character %d: %w", characterID, err)
 	}
@@ -90,7 +90,7 @@ func (st *Storage) ListCharacterWalletJournalEntryIDs(ctx context.Context, chara
 }
 
 func (st *Storage) ListCharacterWalletJournalEntries(ctx context.Context, id int32) ([]*app.CharacterWalletJournalEntry, error) {
-	rows, err := st.q.ListCharacterWalletJournalEntries(ctx, int64(id))
+	rows, err := st.qRO.ListCharacterWalletJournalEntries(ctx, int64(id))
 	if err != nil {
 		return nil, fmt.Errorf("list wallet journal entries for character %d: %w", id, err)
 	}

--- a/internal/app/storage/characterwallettransaction.go
+++ b/internal/app/storage/characterwallettransaction.go
@@ -44,7 +44,7 @@ func (st *Storage) CreateCharacterWalletTransaction(ctx context.Context, arg Cre
 		UnitPrice:     arg.UnitPrice,
 	}
 
-	if err := st.q.CreateCharacterWalletTransaction(ctx, arg2); err != nil {
+	if err := st.qRW.CreateCharacterWalletTransaction(ctx, arg2); err != nil {
 		return fmt.Errorf("create wallet transaction: %+v: %w", arg2, err)
 	}
 	return nil
@@ -55,7 +55,7 @@ func (st *Storage) GetCharacterWalletTransaction(ctx context.Context, characterI
 		CharacterID:   int64(characterID),
 		TransactionID: transactionID,
 	}
-	r, err := st.q.GetCharacterWalletTransaction(ctx, arg)
+	r, err := st.qRO.GetCharacterWalletTransaction(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("get wallet transaction for character %d: %w", characterID, err)
 	}
@@ -70,7 +70,7 @@ func (st *Storage) GetCharacterWalletTransaction(ctx context.Context, characterI
 }
 
 func (st *Storage) ListCharacterWalletTransactionIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
-	ids, err := st.q.ListCharacterWalletTransactionIDs(ctx, int64(characterID))
+	ids, err := st.qRO.ListCharacterWalletTransactionIDs(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list wallet transaction ids for character %d: %w", characterID, err)
 	}
@@ -78,7 +78,7 @@ func (st *Storage) ListCharacterWalletTransactionIDs(ctx context.Context, charac
 }
 
 func (st *Storage) ListCharacterWalletTransactions(ctx context.Context, characterID int32) ([]*app.CharacterWalletTransaction, error) {
-	rows, err := st.q.ListCharacterWalletTransactions(ctx, int64(characterID))
+	rows, err := st.qRO.ListCharacterWalletTransactions(ctx, int64(characterID))
 	if err != nil {
 		return nil, fmt.Errorf("list wallet transactions for character %d: %w", characterID, err)
 	}

--- a/internal/app/storage/evecategory.go
+++ b/internal/app/storage/evecategory.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveCategory(ctx context.Context, arg CreateEveCategoryP
 		IsPublished: arg.IsPublished,
 		Name:        arg.Name,
 	}
-	e, err := st.q.CreateEveCategory(ctx, arg2)
+	e, err := st.qRW.CreateEveCategory(ctx, arg2)
 	if err != nil {
 		return nil, fmt.Errorf("create EveCategory %+v, %w", arg, err)
 	}
@@ -33,7 +33,7 @@ func (st *Storage) CreateEveCategory(ctx context.Context, arg CreateEveCategoryP
 }
 
 func (st *Storage) GetEveCategory(ctx context.Context, id int32) (*app.EveCategory, error) {
-	c, err := st.q.GetEveCategory(ctx, int64(id))
+	c, err := st.qRO.GetEveCategory(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evecharacter.go
+++ b/internal/app/storage/evecharacter.go
@@ -49,7 +49,7 @@ func (st *Storage) CreateEveCharacter(ctx context.Context, arg CreateEveCharacte
 		arg2.FactionID.Int64 = int64(arg.FactionID)
 		arg2.FactionID.Valid = true
 	}
-	err := st.q.CreateEveCharacter(ctx, arg2)
+	err := st.qRW.CreateEveCharacter(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveCharacter %v, %w", arg2, err)
 	}
@@ -57,7 +57,7 @@ func (st *Storage) CreateEveCharacter(ctx context.Context, arg CreateEveCharacte
 }
 
 func (st *Storage) DeleteEveCharacter(ctx context.Context, characterID int32) error {
-	err := st.q.DeleteEveCharacter(ctx, int64(characterID))
+	err := st.qRW.DeleteEveCharacter(ctx, int64(characterID))
 	if err != nil {
 		return fmt.Errorf("delete EveCharacter %d: %w", characterID, err)
 	}
@@ -65,7 +65,7 @@ func (st *Storage) DeleteEveCharacter(ctx context.Context, characterID int32) er
 }
 
 func (st *Storage) GetEveCharacter(ctx context.Context, characterID int32) (*app.EveCharacter, error) {
-	r, err := st.q.GetEveCharacter(ctx, int64(characterID))
+	r, err := st.qRO.GetEveCharacter(ctx, int64(characterID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -93,7 +93,7 @@ func (st *Storage) GetEveCharacter(ctx context.Context, characterID int32) (*app
 }
 
 func (st *Storage) ListEveCharacterIDs(ctx context.Context) (set.Set[int32], error) {
-	ids, err := st.q.ListEveCharacterIDs(ctx)
+	ids, err := st.qRO.ListEveCharacterIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list EveCharacterIDs: %w", err)
 	}
@@ -118,7 +118,7 @@ func (st *Storage) UpdateEveCharacter(ctx context.Context, c *app.EveCharacter) 
 		arg.FactionID.Int64 = int64(c.Faction.ID)
 		arg.FactionID.Valid = true
 	}
-	if err := st.q.UpdateEveCharacter(ctx, arg); err != nil {
+	if err := st.qRW.UpdateEveCharacter(ctx, arg); err != nil {
 		return fmt.Errorf("update or create EveCharacter %d: %w", c.ID, err)
 	}
 	return nil

--- a/internal/app/storage/eveconstellation.go
+++ b/internal/app/storage/eveconstellation.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveConstellation(ctx context.Context, arg CreateEveCons
 		EveRegionID: int64(arg.RegionID),
 		Name:        arg.Name,
 	}
-	err := st.q.CreateEveConstellation(ctx, arg2)
+	err := st.qRW.CreateEveConstellation(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveConstellation %v, %w", arg, err)
 	}
@@ -33,7 +33,7 @@ func (st *Storage) CreateEveConstellation(ctx context.Context, arg CreateEveCons
 }
 
 func (st *Storage) GetEveConstellation(ctx context.Context, id int32) (*app.EveConstellation, error) {
-	row, err := st.q.GetEveConstellation(ctx, int64(id))
+	row, err := st.qRO.GetEveConstellation(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evedogmatattribute.go
+++ b/internal/app/storage/evedogmatattribute.go
@@ -39,7 +39,7 @@ func (st *Storage) CreateEveDogmaAttribute(ctx context.Context, arg CreateEveDog
 		IsStackable:  arg.IsStackable,
 		UnitID:       int64(arg.UnitID),
 	}
-	o, err := st.q.CreateEveDogmaAttribute(ctx, arg2)
+	o, err := st.qRW.CreateEveDogmaAttribute(ctx, arg2)
 	if err != nil {
 		return nil, fmt.Errorf("create EveDogmaAttribute %v, %w", arg2, err)
 	}
@@ -47,7 +47,7 @@ func (st *Storage) CreateEveDogmaAttribute(ctx context.Context, arg CreateEveDog
 }
 
 func (st *Storage) GetEveDogmaAttribute(ctx context.Context, id int32) (*app.EveDogmaAttribute, error) {
-	c, err := st.q.GetEveDogmaAttribute(ctx, int64(id))
+	c, err := st.qRO.GetEveDogmaAttribute(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evegroup.go
+++ b/internal/app/storage/evegroup.go
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveGroup(ctx context.Context, arg CreateEveGroupParams)
 		IsPublished:   arg.IsPublished,
 		Name:          arg.Name,
 	}
-	err := st.q.CreateEveGroup(ctx, arg2)
+	err := st.qRW.CreateEveGroup(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveGroup %v, %w", arg, err)
 	}
@@ -35,7 +35,7 @@ func (st *Storage) CreateEveGroup(ctx context.Context, arg CreateEveGroupParams)
 }
 
 func (st *Storage) GetEveGroup(ctx context.Context, id int32) (*app.EveGroup, error) {
-	row, err := st.q.GetEveGroup(ctx, int64(id))
+	row, err := st.qRO.GetEveGroup(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evelocation.go
+++ b/internal/app/storage/evelocation.go
@@ -34,14 +34,14 @@ func (st *Storage) UpdateOrCreateEveLocation(ctx context.Context, arg UpdateOrCr
 		OwnerID:          optional.ToNullInt64(arg.OwnerID),
 		UpdatedAt:        arg.UpdatedAt,
 	}
-	if err := st.q.UpdateOrCreateLocation(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateOrCreateLocation(ctx, arg2); err != nil {
 		return fmt.Errorf("update or create eve location %v, %w", arg, err)
 	}
 	return nil
 }
 
 func (st *Storage) GetLocation(ctx context.Context, id int64) (*app.EveLocation, error) {
-	o, err := st.q.GetLocation(ctx, id)
+	o, err := st.qRO.GetLocation(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -56,7 +56,7 @@ func (st *Storage) GetLocation(ctx context.Context, id int64) (*app.EveLocation,
 }
 
 func (st *Storage) ListEveLocation(ctx context.Context) ([]*app.EveLocation, error) {
-	rows, err := st.q.ListEveLocations(ctx)
+	rows, err := st.qRO.ListEveLocations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list eve locations: %w", err)
 	}
@@ -72,7 +72,7 @@ func (st *Storage) ListEveLocation(ctx context.Context) ([]*app.EveLocation, err
 }
 
 func (st *Storage) ListEveLocationInSolarSystem(ctx context.Context, solarSystemID int32) ([]*app.EveLocation, error) {
-	rows, err := st.q.ListEveLocationsInSolarSystem(ctx, sql.NullInt64{Int64: int64(solarSystemID), Valid: true})
+	rows, err := st.qRO.ListEveLocationsInSolarSystem(ctx, sql.NullInt64{Int64: int64(solarSystemID), Valid: true})
 	if err != nil {
 		return nil, fmt.Errorf("list eve locations in solar system: %w", err)
 	}
@@ -88,7 +88,7 @@ func (st *Storage) ListEveLocationInSolarSystem(ctx context.Context, solarSystem
 }
 
 func (st *Storage) MissingEveLocations(ctx context.Context, ids []int64) ([]int64, error) {
-	currentIDs, err := st.q.ListLocationIDs(ctx)
+	currentIDs, err := st.qRO.ListLocationIDs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/storage/evemarketprice.go
+++ b/internal/app/storage/evemarketprice.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (st *Storage) GetEveMarketPrice(ctx context.Context, typeID int32) (*app.EveMarketPrice, error) {
-	row, err := st.q.GetEveMarketPrice(ctx, int64(typeID))
+	row, err := st.qRO.GetEveMarketPrice(ctx, int64(typeID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -34,7 +34,7 @@ func (st *Storage) UpdateOrCreateEveMarketPrice(ctx context.Context, arg UpdateO
 		AdjustedPrice: arg.AdjustedPrice,
 		AveragePrice:  arg.AveragePrice,
 	}
-	if err := st.q.UpdateOrCreateEveMarketPrice(ctx, arg2); err != nil {
+	if err := st.qRW.UpdateOrCreateEveMarketPrice(ctx, arg2); err != nil {
 		return fmt.Errorf("update or create eve market price %v: %w", arg, err)
 	}
 	return nil

--- a/internal/app/storage/evemoon.go
+++ b/internal/app/storage/evemoon.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveMoon(ctx context.Context, arg CreateEveMoonParams) e
 		Name:             arg.Name,
 		EveSolarSystemID: int64(arg.SolarSystemID),
 	}
-	err := st.q.CreateEveMoon(ctx, arg2)
+	err := st.qRW.CreateEveMoon(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveMoon %v, %w", arg, err)
 	}
@@ -33,7 +33,7 @@ func (st *Storage) CreateEveMoon(ctx context.Context, arg CreateEveMoonParams) e
 }
 
 func (st *Storage) GetEveMoon(ctx context.Context, id int32) (*app.EveMoon, error) {
-	row, err := st.q.GetEveMoon(ctx, int64(id))
+	row, err := st.qRO.GetEveMoon(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/eveplanet.go
+++ b/internal/app/storage/eveplanet.go
@@ -27,7 +27,7 @@ func (st *Storage) CreateEvePlanet(ctx context.Context, arg CreateEvePlanetParam
 		EveSolarSystemID: int64(arg.SolarSystemID),
 		EveTypeID:        int64(arg.TypeID),
 	}
-	err := st.q.CreateEvePlanet(ctx, arg2)
+	err := st.qRW.CreateEvePlanet(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EvePlanet %v, %w", arg, err)
 	}
@@ -35,7 +35,7 @@ func (st *Storage) CreateEvePlanet(ctx context.Context, arg CreateEvePlanetParam
 }
 
 func (st *Storage) GetEvePlanet(ctx context.Context, id int32) (*app.EvePlanet, error) {
-	row, err := st.q.GetEvePlanet(ctx, int64(id))
+	row, err := st.qRO.GetEvePlanet(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/everace.go
+++ b/internal/app/storage/everace.go
@@ -16,7 +16,7 @@ func (st *Storage) CreateEveRace(ctx context.Context, id int32, description, nam
 		Description: description,
 		Name:        name,
 	}
-	o, err := st.q.CreateEveRace(ctx, arg)
+	o, err := st.qRW.CreateEveRace(ctx, arg)
 	if err != nil {
 		return nil, fmt.Errorf("create race %d: %w", id, err)
 	}
@@ -24,7 +24,7 @@ func (st *Storage) CreateEveRace(ctx context.Context, id int32, description, nam
 }
 
 func (st *Storage) GetEveRace(ctx context.Context, id int32) (*app.EveRace, error) {
-	o, err := st.q.GetEveRace(ctx, int64(id))
+	o, err := st.qRO.GetEveRace(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/everegion.go
+++ b/internal/app/storage/everegion.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveRegion(ctx context.Context, arg CreateEveRegionParam
 		Description: arg.Description,
 		Name:        arg.Name,
 	}
-	e, err := st.q.CreateEveRegion(ctx, arg2)
+	e, err := st.qRW.CreateEveRegion(ctx, arg2)
 	if err != nil {
 		return nil, fmt.Errorf("create EveRegion %v, %w", arg2, err)
 	}
@@ -33,7 +33,7 @@ func (st *Storage) CreateEveRegion(ctx context.Context, arg CreateEveRegionParam
 }
 
 func (st *Storage) GetEveRegion(ctx context.Context, id int32) (*app.EveRegion, error) {
-	c, err := st.q.GetEveRegion(ctx, int64(id))
+	c, err := st.qRO.GetEveRegion(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/eveschematic.go
+++ b/internal/app/storage/eveschematic.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveSchematic(ctx context.Context, arg CreateEveSchemati
 		CycleTime: int64(arg.CycleTime),
 		Name:      arg.Name,
 	}
-	e, err := st.q.CreateEveSchematic(ctx, arg2)
+	e, err := st.qRW.CreateEveSchematic(ctx, arg2)
 	if err != nil {
 		return nil, fmt.Errorf("create EveSchematic %v, %w", arg, err)
 	}
@@ -33,7 +33,7 @@ func (st *Storage) CreateEveSchematic(ctx context.Context, arg CreateEveSchemati
 }
 
 func (st *Storage) GetEveSchematic(ctx context.Context, id int32) (*app.EveSchematic, error) {
-	c, err := st.q.GetEveSchematic(ctx, int64(id))
+	c, err := st.qRO.GetEveSchematic(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evesolarsystem.go
+++ b/internal/app/storage/evesolarsystem.go
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveSolarSystem(ctx context.Context, arg CreateEveSolarS
 		Name:               arg.Name,
 		SecurityStatus:     float64(arg.SecurityStatus),
 	}
-	err := st.q.CreateEveSolarSystem(ctx, arg2)
+	err := st.qRW.CreateEveSolarSystem(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveSolarSystem %v, %w", arg, err)
 	}
@@ -35,7 +35,7 @@ func (st *Storage) CreateEveSolarSystem(ctx context.Context, arg CreateEveSolarS
 }
 
 func (st *Storage) GetEveSolarSystem(ctx context.Context, id int32) (*app.EveSolarSystem, error) {
-	row, err := st.q.GetEveSolarSystem(ctx, int64(id))
+	row, err := st.qRO.GetEveSolarSystem(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/evetype.go
+++ b/internal/app/storage/evetype.go
@@ -48,7 +48,7 @@ func (st *Storage) CreateEveType(ctx context.Context, arg CreateEveTypeParams) e
 		Radius:         float64(arg.Radius),
 		Volume:         float64(arg.Volume),
 	}
-	err := st.q.CreateEveType(ctx, arg2)
+	err := st.qRW.CreateEveType(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveType %v, %w", arg, err)
 	}
@@ -56,7 +56,7 @@ func (st *Storage) CreateEveType(ctx context.Context, arg CreateEveTypeParams) e
 }
 
 func (st *Storage) GetEveType(ctx context.Context, id int32) (*app.EveType, error) {
-	row, err := st.q.GetEveType(ctx, int64(id))
+	row, err := st.qRO.GetEveType(ctx, int64(id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -68,7 +68,7 @@ func (st *Storage) GetEveType(ctx context.Context, id int32) (*app.EveType, erro
 }
 
 func (st *Storage) MissingEveTypes(ctx context.Context, ids []int32) ([]int32, error) {
-	currentIDs, err := st.q.ListEveTypeIDs(ctx)
+	currentIDs, err := st.qRO.ListEveTypeIDs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/storage/evetypedogmaattribute.go
+++ b/internal/app/storage/evetypedogmaattribute.go
@@ -25,7 +25,7 @@ func (st *Storage) CreateEveTypeDogmaAttribute(ctx context.Context, arg CreateEv
 		EveTypeID:        int64(arg.EveTypeID),
 		Value:            float64(arg.Value),
 	}
-	err := st.q.CreateEveTypeDogmaAttribute(ctx, arg2)
+	err := st.qRW.CreateEveTypeDogmaAttribute(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveTypeDogmaAttribute %v, %w", arg, err)
 	}
@@ -37,7 +37,7 @@ func (st *Storage) GetEveTypeDogmaAttribute(ctx context.Context, eveTypeID, dogm
 		DogmaAttributeID: int64(dogmaAttributeID),
 		EveTypeID:        int64(eveTypeID),
 	}
-	row, err := st.q.GetEveTypeDogmaAttribute(ctx, arg)
+	row, err := st.qRO.GetEveTypeDogmaAttribute(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -48,7 +48,7 @@ func (st *Storage) GetEveTypeDogmaAttribute(ctx context.Context, eveTypeID, dogm
 }
 
 func (st *Storage) ListEveTypeDogmaAttributesForType(ctx context.Context, typeID int32) ([]*app.EveTypeDogmaAttribute, error) {
-	rows, err := st.q.ListEveTypeDogmaAttributesForType(ctx, int64(typeID))
+	rows, err := st.qRO.ListEveTypeDogmaAttributesForType(ctx, int64(typeID))
 	if err != nil {
 		return nil, fmt.Errorf("list dogma attributes for type %d: %w", typeID, err)
 	}

--- a/internal/app/storage/evetypedogmaeffect.go
+++ b/internal/app/storage/evetypedogmaeffect.go
@@ -24,7 +24,7 @@ func (st *Storage) CreateEveTypeDogmaEffect(ctx context.Context, arg CreateEveTy
 		EveTypeID:     int64(arg.EveTypeID),
 		IsDefault:     arg.IsDefault,
 	}
-	err := st.q.CreateEveTypeDogmaEffect(ctx, arg2)
+	err := st.qRW.CreateEveTypeDogmaEffect(ctx, arg2)
 	if err != nil {
 		return fmt.Errorf("create EveTypeDogmaEffect %v, %w", arg, err)
 	}
@@ -36,7 +36,7 @@ func (st *Storage) GetEveTypeDogmaEffect(ctx context.Context, eveTypeID, dogmaAt
 		DogmaEffectID: int64(dogmaAttributeID),
 		EveTypeID:     int64(eveTypeID),
 	}
-	row, err := st.q.GetEveTypeDogmaEffect(ctx, arg)
+	row, err := st.qRO.GetEveTypeDogmaEffect(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound

--- a/internal/app/storage/generalsectionstatus.go
+++ b/internal/app/storage/generalsectionstatus.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (st *Storage) GetGeneralSectionStatus(ctx context.Context, section app.GeneralSection) (*app.GeneralSectionStatus, error) {
-	s, err := st.q.GetGeneralSectionStatus(ctx, string(section))
+	s, err := st.qRO.GetGeneralSectionStatus(ctx, string(section))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -25,7 +25,7 @@ func (st *Storage) GetGeneralSectionStatus(ctx context.Context, section app.Gene
 }
 
 func (st *Storage) ListGeneralSectionStatus(ctx context.Context) ([]*app.GeneralSectionStatus, error) {
-	rows, err := st.q.ListGeneralSectionStatus(ctx)
+	rows, err := st.qRO.ListGeneralSectionStatus(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list general section status: %w", err)
 	}
@@ -50,12 +50,12 @@ func (st *Storage) UpdateOrCreateGeneralSectionStatus(ctx context.Context, arg U
 	if string(arg.Section) == "" {
 		panic("Invalid params")
 	}
-	tx, err := st.db.Begin()
+	tx, err := st.dbRW.Begin()
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
-	qtx := st.q.WithTx(tx)
+	qtx := st.qRW.WithTx(tx)
 	var arg2 queries.UpdateOrCreateGeneralSectionStatusParams
 	old, err := qtx.GetGeneralSectionStatus(ctx, string(arg.Section))
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/app/storage/planetpin.go
+++ b/internal/app/storage/planetpin.go
@@ -39,14 +39,14 @@ func (st *Storage) CreatePlanetPin(ctx context.Context, arg CreatePlanetPinParam
 		LastCycleStart:         NewNullTimeFromTime(arg.LastCycleStart),
 		PinID:                  arg.PinID,
 	}
-	if err := st.q.CreatePlanetPin(ctx, arg2); err != nil {
+	if err := st.qRW.CreatePlanetPin(ctx, arg2); err != nil {
 		return fmt.Errorf("create PlanetPin %v, %w", arg, err)
 	}
 	return nil
 }
 
 func (st *Storage) DeletePlanetPins(ctx context.Context, characterPlanetID int64) error {
-	if err := st.q.DeletePlanetPins(ctx, characterPlanetID); err != nil {
+	if err := st.qRW.DeletePlanetPins(ctx, characterPlanetID); err != nil {
 		return fmt.Errorf("delete planet pins for %d: %w", characterPlanetID, err)
 	}
 	return nil
@@ -57,7 +57,7 @@ func (st *Storage) GetPlanetPin(ctx context.Context, characterPlanetID, pinID in
 		CharacterPlanetID: characterPlanetID,
 		PinID:             pinID,
 	}
-	r, err := st.q.GetPlanetPin(ctx, arg)
+	r, err := st.qRO.GetPlanetPin(ctx, arg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -68,7 +68,7 @@ func (st *Storage) GetPlanetPin(ctx context.Context, characterPlanetID, pinID in
 }
 
 func (st *Storage) ListPlanetPins(ctx context.Context, characterPlanetID int64) ([]*app.PlanetPin, error) {
-	rows, err := st.q.ListPlanetPins(ctx, characterPlanetID)
+	rows, err := st.qRO.ListPlanetPins(ctx, characterPlanetID)
 	if err != nil {
 		return nil, fmt.Errorf("list planet pins for %d: %w", characterPlanetID, err)
 	}

--- a/internal/app/storage/storage.go
+++ b/internal/app/storage/storage.go
@@ -22,38 +22,65 @@ var embedMigrations embed.FS
 type Storage struct {
 	MaxListEveEntitiesForIDs int // Max IDs per SQL query
 
-	db *sql.DB
-	q  *queries.Queries
+	dbRO *sql.DB
+	dbRW *sql.DB
+	qRO  *queries.Queries
+	qRW  *queries.Queries
 }
 
 // New returns a new storage object.
-func New(db *sql.DB) *Storage {
+func New(dbRW *sql.DB, dbRO *sql.DB) *Storage {
 	r := &Storage{
-		db:                       db,
+		dbRO:                     dbRO,
+		dbRW:                     dbRW,
 		MaxListEveEntitiesForIDs: 1000,
-		q:                        queries.New(db),
+		qRO:                      queries.New(dbRO),
+		qRW:                      queries.New(dbRW),
 	}
 	return r
 }
 
 // InitDB initializes the database and returns it.
-func InitDB(dsn string) (*sql.DB, error) {
+func InitDB(dsn string) (dbRW *sql.DB, dbRO *sql.DB, err error) {
+	// create RW connection
+	dsn2 := sqliteDSN(dsn, false)
+	slog.Debug("Creating RW connection to DB", "dsn", dsn2)
+	dbRW, err = sql.Open("sqlite3", dsn2)
+	if err != nil {
+		return
+	}
+	dbRW.SetMaxOpenConns(1)
+	slog.Info("Creating RO connection to DB", "DSN", dsn)
+	if err = ApplyMigrations(dbRW); err != nil {
+		return
+	}
+	// create RO connection
+	dsn2 = sqliteDSN(dsn, true)
+	slog.Debug("connecting to sqlite DB", "dsn", dsn2)
+	dbRO, err = sql.Open("sqlite3", dsn2)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func ApplyMigrations(db *sql.DB) error {
+	return migrate.Run(db, embedMigrations)
+}
+
+func sqliteDSN(dsn string, isReadonly bool) string {
 	v := url.Values{}
 	v.Add("_fk", "on")
 	v.Add("_journal_mode", "WAL")
 	v.Add("_busy_timeout", "5000") // 5000 = 5 seconds
 	v.Add("_cache_size", "-20000") // -20000 = 20 MB
 	v.Add("_synchronous", "normal")
-	v.Add("_txlock", "IMMEDIATE")
+	if isReadonly {
+		v.Add("mode", "ro")
+	} else {
+		v.Add("_txlock", "IMMEDIATE")
+		v.Add("mode", "rwc")
+	}
 	dsn2 := fmt.Sprintf("%s?%s", dsn, v.Encode())
-	slog.Debug("Connecting to sqlite", "dsn", dsn2)
-	db, err := sql.Open("sqlite3", dsn2)
-	if err != nil {
-		return nil, err
-	}
-	slog.Info("Connected to database", "DSN", dsn)
-	if err := migrate.Run(db, embedMigrations); err != nil {
-		return nil, err
-	}
-	return db, nil
+	return dsn2
 }

--- a/main.go
+++ b/main.go
@@ -177,13 +177,14 @@ func main() {
 	// init database
 	dbPath := filepath.Join(dataDir, dbFileName)
 	dsn := "file:///" + filepath.ToSlash(dbPath)
-	db, err := storage.InitDB(dsn)
+	dbRW, dbRO, err := storage.InitDB(dsn)
 	if err != nil {
 		slog.Error("Failed to initialize database", "dsn", dsn, "error", err)
 		os.Exit(1)
 	}
-	defer db.Close()
-	st := storage.New(db)
+	defer dbRW.Close()
+	defer dbRO.Close()
+	st := storage.New(dbRW, dbRO)
 
 	// Initialize caches
 	memCache := memcache.New()

--- a/tools/genchars/main.go
+++ b/tools/genchars/main.go
@@ -27,13 +27,14 @@ func main() {
 
 	// init database
 	dsn := "file:" + dbPath
-	db, err := storage.InitDB("file:" + dbPath)
+	dbRW, dbRO, err := storage.InitDB("file:" + dbPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize database %s: %s", dsn, err)
 	}
-	defer db.Close()
-	st := storage.New(db)
-	f := testutil.NewFactory(st, db)
+	defer dbRW.Close()
+	defer dbRO.Close()
+	st := storage.New(dbRW, dbRO)
+	f := testutil.NewFactory(st, dbRO)
 
 	// build character
 	fmt.Println()


### PR DESCRIPTION
DB architecture change:
- R/W connection with poolsize = 1
- R/O connection with poolsize = unlimited

Should significantly increase DB performance and help avoid lock conflicts and race conditions when writing from concurrent go-routines

Note that tests use a different setup so they can continue to use an in-memory DB for better throughput. Tests can be switched over to run against a file-based DB.