### PR TITLE
feat: make the asset search case insensitive (asset and search term both lower case)

### DIFF
--- a/internal/app/collectivewidget/assetsearch.go
+++ b/internal/app/collectivewidget/assetsearch.go
@@ -195,7 +195,7 @@ func (a *AllAssetSearch) processData(sortCol int) {
 		}
 	}
 	rows := make([]*assetSearchRow, 0)
-	search := a.entry.Text
+	search := strings.ToLower(a.entry.Text)
 	for _, r := range a.assets {
 		var matches bool
 		if search == "" {


### PR DESCRIPTION
Out of typing habbit, when I was searching assets, I was doing so with correct item casing ('Hobgoblin') but the match is made on the characters assets where `cell` is lowercased, so it wasn't matching anything. 😅 

This changes makes the search term also lowercase, so now both the search and the asset are checked as lower case.