### PR TITLE
fix: logs are not written on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ profile*.gif
 __debug_*
 *.apk
 fyne_metadata_init.go
+EVE Buddy.exe

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -154,8 +155,14 @@ func main() {
 		MaxSize:    logMaxSizeMB,
 		MaxBackups: logMaxBackups,
 	}
-	multi := io.MultiWriter(os.Stderr, logger)
-	log.SetOutput(multi)
+	defer logger.Close()
+	var logWriter io.Writer
+	if runtime.GOOS == "windows" {
+		logWriter = logger
+	} else {
+		logWriter = io.MultiWriter(os.Stderr, logger)
+	}
+	log.SetOutput(logWriter)
 
 	if isDesktop {
 		// ensure single instance


### PR DESCRIPTION
- The windows release version does not write log files, while the development version does
- This fix re-enables file logging for windows