### PR TITLE
refactor: same error for invalid paramters in storage create

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ type Position struct {
 var (
 	ErrAborted  = errors.New("process aborted prematurely")
 	ErrNotFound = errors.New("object not found")
+	ErrInvalid  = errors.New("invalid parameters")
 )
 
 // VariableDateFormat returns a variable dateformat.

--- a/internal/app/characterservice/charactermail_test.go
+++ b/internal/app/characterservice/charactermail_test.go
@@ -70,7 +70,7 @@ func TestSendMail(t *testing.T) {
 		httpmock.RegisterResponder(
 			"POST",
 			fmt.Sprintf("https://esi.evetech.net/v1/characters/%d/mail/", c.ID),
-			httpmock.NewStringResponder(201, "123"))
+			httpmock.NewJsonResponderOrPanic(201, 123))
 
 		// when
 		mailID, err := s.SendCharacterMail(ctx, c.ID, "subject", []*app.EveEntity{r}, "body")

--- a/internal/app/characterservice/characternotification.go
+++ b/internal/app/characterservice/characternotification.go
@@ -108,22 +108,20 @@ func (s *CharacterService) updateCharacterNotificationsESI(ctx context.Context, 
 					continue
 				}
 				arg1 := storage.UpdateCharacterNotificationParams{
-					ID:          o.ID,
-					IsRead:      o.IsRead,
-					CharacterID: characterID,
-					Title:       o.Title,
-					Body:        o.Body,
+					ID:     o.ID,
+					IsRead: o.IsRead,
+					Title:  o.Title,
+					Body:   o.Body,
 				}
 				title, body, err := s.EveNotificationService.RenderESI(ctx, n.Type_, n.Text, n.Timestamp)
 				if err != nil {
 					slog.Error("Failed to render character notification", "characterID", characterID, "NotificationID", n.NotificationId, "error", err)
 				}
 				arg2 := storage.UpdateCharacterNotificationParams{
-					ID:          o.ID,
-					IsRead:      n.IsRead,
-					CharacterID: characterID,
-					Title:       title,
-					Body:        body,
+					ID:     o.ID,
+					IsRead: n.IsRead,
+					Title:  title,
+					Body:   body,
 				}
 				if arg2 != arg1 {
 					if err := s.st.UpdateCharacterNotification(ctx, arg2); err != nil {

--- a/internal/app/characterui/characterassets.go
+++ b/internal/app/characterui/characterassets.go
@@ -647,28 +647,3 @@ func (a *CharacterAssets) updateLocationPath(location locationNode) {
 		a.u.ShowLocationInfoWindow(path[0].containerID)
 	}
 }
-
-// func (u *ui) showNewAssetWindow(ca *app.CharacterAsset) {
-// 	var name string
-// 	if ca.Name != "" {
-// 		name = fmt.Sprintf(" \"%s\" ", ca.Name)
-// 	}
-// 	title := fmt.Sprintf("%s%s(%s): Contents", ca.EveType.Name, name, ca.EveType.Group.Name)
-// 	w := u.fyneApp.NewWindow(u.makeWindowTitle(title))
-// 	oo, err := u.CharacterService().ListCharacterAssetsInLocation(context.TODO(), ca.CharacterID, ca.ItemID)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	data := binding.NewUntypedList()
-// 	if err := data.Set(copyToUntypedSlice(oo)); err != nil {
-// 		panic(err)
-// 	}
-// 	top := widget.NewLabel(fmt.Sprintf("%s items", humanize.Comma(int64(len(oo)))))
-// 	top.TextStyle.Bold = true
-// 	assets := u.makeAssetGrid(data)
-// 	content := container.NewBorder(container.NewVBox(top, widget.NewSeparator()), nil, nil, nil, assets)
-
-// 	w.SetContent(content)
-// 	w.Resize(fyne.Size{Width: 650, Height: 500})
-// 	w.Show()
-// }

--- a/internal/app/characterui/charactercontracts.go
+++ b/internal/app/characterui/charactercontracts.go
@@ -224,7 +224,7 @@ func (a *CharacterContracts) updateEntries() error {
 }
 
 func (a *CharacterContracts) showContract(c *app.CharacterContract) {
-	w := a.u.App().NewWindow("Contract")
+	w := a.u.App().NewWindow(a.u.MakeWindowTitle("Contract"))
 	makeExpiresString := func(c *app.CharacterContract) string {
 		t := c.DateExpiredEffective()
 		ts := t.Format(app.DateTimeFormat)

--- a/internal/app/collectionui/clonesearch.go
+++ b/internal/app/collectionui/clonesearch.go
@@ -497,7 +497,8 @@ func (a *CloneSearch) showRoute(r cloneSearchRow) {
 		nil,
 		list,
 	)
-	w := a.u.App().NewWindow(fmt.Sprintf("Route: %s -> %s", a.origin.Name, r.c.Location.SolarSystem.Name))
+	title := fmt.Sprintf("Route: %s -> %s", a.origin.Name, r.c.Location.SolarSystem.Name)
+	w := a.u.App().NewWindow(a.u.MakeWindowTitle(title))
 	w.SetContent(c)
 	w.Resize(fyne.NewSize(600, 400))
 	w.Show()
@@ -590,7 +591,7 @@ func (a *CloneSearch) showClone(r cloneSearchRow) {
 		nil,
 		list,
 	)
-	w := a.u.App().NewWindow("Clone")
+	w := a.u.App().NewWindow(a.u.MakeWindowTitle("Clone"))
 	w.SetContent(c)
 	w.Resize(fyne.NewSize(600, 400))
 	w.Show()

--- a/internal/app/desktopui/statusbar.go
+++ b/internal/app/desktopui/statusbar.go
@@ -40,7 +40,7 @@ const (
 type DesktopUI interface {
 	app.UI
 
-	ShowAccountWindow()
+	ShowManageCharactersWindow()
 }
 
 type StatusBar struct {
@@ -64,7 +64,7 @@ func NewStatusBar(u DesktopUI) *StatusBar {
 	}
 	a.ExtendBaseWidget(a)
 	a.characterCount = NewStatusBarItem(theme.AccountIcon(), "?", func() {
-		u.ShowAccountWindow()
+		u.ShowManageCharactersWindow()
 	})
 	a.updateStatus = NewStatusBarItem(theme.NewThemedResource(icons.UpdateSvg), "?", func() {
 		u.ShowUpdateStatusWindow()

--- a/internal/app/eveuniverseservice/everace.go
+++ b/internal/app/eveuniverseservice/everace.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 )
 
 func (eu *EveUniverseService) GetOrCreateRaceESI(ctx context.Context, id int32) (*app.EveRace, error) {
@@ -25,7 +26,12 @@ func (eu *EveUniverseService) createEveRaceFromESI(ctx context.Context, id int32
 		}
 		for _, race := range races {
 			if race.RaceId == id {
-				return eu.st.CreateEveRace(ctx, race.RaceId, race.Description, race.Name)
+				arg := storage.CreateEveRaceParams{
+					ID:          race.RaceId,
+					Description: race.Description,
+					Name:        race.Name,
+				}
+				return eu.st.CreateEveRace(ctx, arg)
 			}
 		}
 		return nil, fmt.Errorf("race with ID %d not found: %w", id, app.ErrNotFound)

--- a/internal/app/infowindow/infowindow.go
+++ b/internal/app/infowindow/infowindow.go
@@ -22,6 +22,7 @@ const (
 )
 
 type UI interface {
+	App() fyne.App
 	CharacterService() app.CharacterService
 	CurrentCharacterID() int32
 	EveImageService() app.EveImageService
@@ -29,6 +30,7 @@ type UI interface {
 	IsDeveloperMode() bool
 	IsOffline() bool
 	MainWindow() fyne.Window
+	MakeWindowTitle(subTitle string) string
 	ShowErrorDialog(message string, err error, parent fyne.Window)
 	ShowInformationDialog(title, message string, parent fyne.Window)
 }
@@ -116,7 +118,7 @@ func (iw *InfoWindow) show(t infoVariant, id int64) {
 	}
 	ab := iwidget.NewAppBar(title+": Information", page)
 	if iw.nav == nil {
-		w := fyne.CurrentApp().NewWindow("Information")
+		w := iw.u.App().NewWindow(iw.u.MakeWindowTitle("Information"))
 		iw.w = w
 		iw.nav = iwidget.NewNavigatorWithAppBar(ab)
 		w.SetContent(iw.nav)
@@ -135,7 +137,7 @@ func (iw *InfoWindow) showZoomWindow(title string, id int32, load func(int32, in
 	}
 	i := iwidget.NewImageFromResource(r, fyne.NewSquareSize(s))
 	p := theme.Padding()
-	w2 := fyne.CurrentApp().NewWindow(title)
+	w2 := iw.u.App().NewWindow(iw.u.MakeWindowTitle(title))
 	w2.SetContent(container.New(layout.NewCustomPaddedLayout(-p, -p, -p, -p), i))
 	w2.Show()
 }

--- a/internal/app/storage/cache.go
+++ b/internal/app/storage/cache.go
@@ -39,6 +39,9 @@ func (st *Storage) CacheExists(ctx context.Context, key string) (bool, error) {
 }
 
 func (st *Storage) CacheGet(ctx context.Context, key string) ([]byte, error) {
+	if key == "" {
+		return nil, fmt.Errorf("CacheGet: key can not be empty: %w", app.ErrInvalid)
+	}
 	arg := queries.CacheGetParams{
 		Key: key,
 		Now: NewNullTimeFromTime(time.Now().UTC()),
@@ -54,6 +57,9 @@ func (st *Storage) CacheGet(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (st *Storage) CacheDelete(ctx context.Context, key string) error {
+	if key == "" {
+		return fmt.Errorf("CacheDelete: key can not be empty: %w", app.ErrInvalid)
+	}
 	err := st.qRW.CacheDelete(ctx, key)
 	if err != nil {
 		return fmt.Errorf("cache delete %s: %w", key, err)
@@ -68,6 +74,9 @@ type CacheSetParams struct {
 }
 
 func (st *Storage) CacheSet(ctx context.Context, arg CacheSetParams) error {
+	if arg.Key == "" {
+		return fmt.Errorf("CacheSet: key can not be empty: %w", app.ErrInvalid)
+	}
 	var expiresAt time.Time
 	if !arg.ExpiresAt.IsZero() {
 		expiresAt = arg.ExpiresAt.UTC()

--- a/internal/app/storage/cache_test.go
+++ b/internal/app/storage/cache_test.go
@@ -54,7 +54,7 @@ func TestCacheGet(t *testing.T) {
 		// then
 		assert.ErrorIs(t, err, app.ErrNotFound)
 	})
-	t.Run("should return entries with get which have never expiry", func(t *testing.T) {
+	t.Run("should return entries with get which never expiry", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		key := "key"
@@ -73,6 +73,13 @@ func TestCacheGet(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, value, x)
 		}
+	})
+	t.Run("should return error when key is empty", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		// when
+		_, err := r.CacheGet(ctx, "")
+		assert.ErrorIs(t, err, app.ErrInvalid)
 	})
 }
 
@@ -159,6 +166,13 @@ func TestCacheExists(t *testing.T) {
 			assert.True(t, ok)
 		}
 	})
+	t.Run("should return error when key is empty", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		// when
+		_, err := r.CacheExists(ctx, "")
+		assert.ErrorIs(t, err, app.ErrInvalid)
+	})
 }
 
 func TestCacheSet(t *testing.T) {
@@ -193,6 +207,13 @@ func TestCacheSet(t *testing.T) {
 			}
 		}
 	})
+	t.Run("should return error when key is empty", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		// when
+		err := r.CacheSet(ctx, storage.CacheSetParams{})
+		assert.ErrorIs(t, err, app.ErrInvalid)
+	})
 }
 
 func TestCacheOther(t *testing.T) {
@@ -222,6 +243,13 @@ func TestCacheOther(t *testing.T) {
 				assert.False(t, ok)
 			}
 		}
+	})
+	t.Run("should return error when delete and key is empty", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		// when
+		err := r.CacheDelete(ctx, "")
+		assert.ErrorIs(t, err, app.ErrInvalid)
 	})
 	t.Run("can clear cache", func(t *testing.T) {
 		// given

--- a/internal/app/storage/characterasset.go
+++ b/internal/app/storage/characterasset.go
@@ -27,7 +27,7 @@ type CreateCharacterAssetParams struct {
 
 func (st *Storage) CreateCharacterAsset(ctx context.Context, arg CreateCharacterAssetParams) error {
 	if arg.CharacterID == 0 || arg.EveTypeID == 0 || arg.ItemID == 0 {
-		return fmt.Errorf("IDs must not be zero %v", arg)
+		return fmt.Errorf("CreateCharacterAsset: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterAssetParams{
 		CharacterID:     int64(arg.CharacterID),

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -89,7 +89,7 @@ type CreateCharacterContractParams struct {
 
 func (st *Storage) CreateCharacterContract(ctx context.Context, arg CreateCharacterContractParams) (int64, error) {
 	if arg.CharacterID == 0 || arg.ContractID == 0 {
-		return 0, fmt.Errorf("create character contract. Mandatory fields not set: %v", arg)
+		return 0, fmt.Errorf("create character contract: %+v: %w", arg, app.ErrInvalid)
 	}
 	if arg.UpdatedAt.IsZero() {
 		arg.UpdatedAt = time.Now().UTC()

--- a/internal/app/storage/charactercontractbid.go
+++ b/internal/app/storage/charactercontractbid.go
@@ -20,7 +20,7 @@ type CreateCharacterContractBidParams struct {
 
 func (st *Storage) CreateCharacterContractBid(ctx context.Context, arg CreateCharacterContractBidParams) error {
 	if arg.ContractID == 0 || arg.BidID == 0 {
-		return fmt.Errorf("create contract bid. Mandatory fields not set: %+v", arg)
+		return fmt.Errorf("create contract bid: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterContractBidParams{
 		ContractID: arg.ContractID,

--- a/internal/app/storage/charactercontratitem.go
+++ b/internal/app/storage/charactercontratitem.go
@@ -20,7 +20,7 @@ type CreateCharacterContractItemParams struct {
 
 func (st *Storage) CreateCharacterContractItem(ctx context.Context, arg CreateCharacterContractItemParams) error {
 	if arg.ContractID == 0 || arg.TypeID == 0 {
-		return fmt.Errorf("create contract item. Mandatory fields not set: %v", arg)
+		return fmt.Errorf("create contract item: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterContractItemParams{
 		ContractID:  arg.ContractID,

--- a/internal/app/storage/characterimplant.go
+++ b/internal/app/storage/characterimplant.go
@@ -16,11 +16,7 @@ type CreateCharacterImplantParams struct {
 }
 
 func (st *Storage) CreateCharacterImplant(ctx context.Context, arg CreateCharacterImplantParams) error {
-	err := createCharacterImplant(ctx, st.qRW, arg)
-	if err != nil {
-		return fmt.Errorf("create implant for character ID %d: %w", arg.CharacterID, err)
-	}
-	return nil
+	return createCharacterImplant(ctx, st.qRW, arg)
 }
 
 func (st *Storage) GetCharacterImplant(ctx context.Context, characterID int32, typeID int32) (*app.CharacterImplant, error) {
@@ -95,7 +91,7 @@ func (st *Storage) ReplaceCharacterImplants(ctx context.Context, characterID int
 
 func createCharacterImplant(ctx context.Context, q *queries.Queries, arg CreateCharacterImplantParams) error {
 	if arg.CharacterID == 0 || arg.EveTypeID == 0 {
-		return fmt.Errorf("IDs must not be zero %v", arg)
+		return fmt.Errorf("createCharacterImplant: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterImplantParams{
 		CharacterID: int64(arg.CharacterID),

--- a/internal/app/storage/characterjumpclone.go
+++ b/internal/app/storage/characterjumpclone.go
@@ -139,8 +139,8 @@ func (st *Storage) ReplaceCharacterJumpClones(ctx context.Context, characterID i
 }
 
 func createCharacterJumpClone(ctx context.Context, q *queries.Queries, arg CreateCharacterJumpCloneParams) error {
-	if arg.CharacterID == 0 || arg.JumpCloneID == 0 {
-		return fmt.Errorf("IDs must not be zero %v", arg)
+	if arg.CharacterID == 0 || arg.JumpCloneID == 0 || arg.LocationID == 0 {
+		return fmt.Errorf("createCharacterJumpClone: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterJumpCloneParams{
 		CharacterID: int64(arg.CharacterID),
@@ -164,7 +164,12 @@ func createCharacterJumpClone(ctx context.Context, q *queries.Queries, arg Creat
 	return nil
 }
 
-func characterJumpCloneFromDBModel(o queries.CharacterJumpClone, locationName string, regionID sql.NullInt64, regionName sql.NullString) *app.CharacterJumpClone {
+func characterJumpCloneFromDBModel(
+	o queries.CharacterJumpClone,
+	locationName string,
+	regionID sql.NullInt64,
+	regionName sql.NullString,
+) *app.CharacterJumpClone {
 	if o.CharacterID == 0 {
 		panic("missing character ID")
 	}

--- a/internal/app/storage/charactermail.go
+++ b/internal/app/storage/charactermail.go
@@ -28,8 +28,8 @@ type CreateCharacterMailParams struct {
 
 func (st *Storage) CreateCharacterMail(ctx context.Context, arg CreateCharacterMailParams) (int64, error) {
 	id, err := func() (int64, error) {
-		if len(arg.RecipientIDs) == 0 {
-			return 0, fmt.Errorf("missing recipients")
+		if arg.CharacterID == 0 || arg.MailID == 0 || len(arg.RecipientIDs) == 0 {
+			return 0, app.ErrInvalid
 		}
 		characterID2 := int64(arg.CharacterID)
 		from, err := st.GetEveEntity(ctx, arg.FromID)
@@ -48,7 +48,7 @@ func (st *Storage) CreateCharacterMail(ctx context.Context, arg CreateCharacterM
 		}
 		mail, err := st.qRW.CreateMail(ctx, mailParams)
 		if err != nil {
-			return 0, fmt.Errorf("create mail: %w", err)
+			return 0, err
 		}
 		for _, id := range arg.RecipientIDs {
 			arg := queries.CreateMailRecipientParams{MailID: mail.ID, EveEntityID: int64(id)}
@@ -64,7 +64,7 @@ func (st *Storage) CreateCharacterMail(ctx context.Context, arg CreateCharacterM
 		return mail.ID, nil
 	}()
 	if err != nil {
-		return 0, fmt.Errorf("create mail for character %d and mail ID %d: %w", arg.CharacterID, arg.MailID, err)
+		return 0, fmt.Errorf("CreateCharacterMail: %+v: %w", arg, err)
 	}
 	return id, err
 }

--- a/internal/app/storage/charactermaillist.go
+++ b/internal/app/storage/charactermaillist.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/queries"
 )
 
 func (st *Storage) CreateCharacterMailList(ctx context.Context, characterID, mailListID int32) error {
+	if characterID == 0 || mailListID == 0 {
+		return fmt.Errorf("CreateCharacterMailList: %w", app.ErrInvalid)
+	}
 	arg := queries.CreateCharacterMailListParams{CharacterID: int64(characterID), EveEntityID: int64(mailListID)}
 	if err := st.qRW.CreateCharacterMailList(ctx, arg); err != nil {
 		return fmt.Errorf("create mail list %d for character %d: %w", mailListID, characterID, err)

--- a/internal/app/storage/characternotification.go
+++ b/internal/app/storage/characternotification.go
@@ -14,8 +14,8 @@ import (
 )
 
 func (st *Storage) CreateCharacterNotification(ctx context.Context, arg CreateCharacterNotificationParams) error {
-	if arg.NotificationID == 0 {
-		return fmt.Errorf("notification ID can not be zero, Character %d", arg.CharacterID)
+	if !arg.isValid() {
+		return fmt.Errorf("CreateCharacterNotification: %+v: %w", arg, app.ErrInvalid)
 	}
 	typeID, err := st.GetOrCreateNotificationType(ctx, arg.Type)
 	if err != nil {
@@ -39,14 +39,6 @@ func (st *Storage) CreateCharacterNotification(ctx context.Context, arg CreateCh
 		return fmt.Errorf("create character notification %+v: %w", arg, err)
 	}
 	return nil
-}
-
-type UpdateCharacterNotificationParams struct {
-	ID          int64
-	Body        optional.Optional[string]
-	CharacterID int32
-	IsRead      bool
-	Title       optional.Optional[string]
 }
 
 func (st *Storage) GetCharacterNotification(ctx context.Context, characterID int32, notificationID int64) (*app.CharacterNotification, error) {
@@ -155,7 +147,21 @@ type CreateCharacterNotificationParams struct {
 	Type           string
 }
 
+func (arg CreateCharacterNotificationParams) isValid() bool {
+	return arg.CharacterID != 0 && arg.NotificationID != 0 && arg.SenderID != 0
+}
+
+type UpdateCharacterNotificationParams struct {
+	ID     int64
+	Body   optional.Optional[string]
+	IsRead bool
+	Title  optional.Optional[string]
+}
+
 func (st *Storage) UpdateCharacterNotification(ctx context.Context, arg UpdateCharacterNotificationParams) error {
+	if arg.ID == 0 {
+		return fmt.Errorf("UpdateCharacterNotification: %+v: %w", arg, app.ErrInvalid)
+	}
 	arg2 := queries.UpdateCharacterNotificationParams{
 		ID:     arg.ID,
 		Body:   optional.ToNullString(arg.Body),

--- a/internal/app/storage/characternotification_test.go
+++ b/internal/app/storage/characternotification_test.go
@@ -116,7 +116,10 @@ func TestCharacterNotification(t *testing.T) {
 		testutil.TruncateTables(db)
 		n := factory.CreateCharacterNotification()
 		// when
-		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{ID: n.ID, IsRead: true})
+		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{
+			ID:     n.ID,
+			IsRead: true,
+		})
 		// then
 		if assert.NoError(t, err) {
 			o, err := r.GetCharacterNotification(ctx, n.CharacterID, n.ID)
@@ -130,7 +133,10 @@ func TestCharacterNotification(t *testing.T) {
 		testutil.TruncateTables(db)
 		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{IsRead: true})
 		// when
-		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{ID: n.ID, IsRead: false})
+		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{
+			ID:     n.ID,
+			IsRead: false,
+		})
 		// then
 		if assert.NoError(t, err) {
 			o, err := r.GetCharacterNotification(ctx, n.CharacterID, n.ID)
@@ -144,7 +150,10 @@ func TestCharacterNotification(t *testing.T) {
 		testutil.TruncateTables(db)
 		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{})
 		// when
-		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{ID: n.ID, Title: optional.New("title")})
+		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{
+			ID:    n.ID,
+			Title: optional.New("title"),
+		})
 		// then
 		if assert.NoError(t, err) {
 			o, err := r.GetCharacterNotification(ctx, n.CharacterID, n.ID)
@@ -158,7 +167,10 @@ func TestCharacterNotification(t *testing.T) {
 		testutil.TruncateTables(db)
 		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{})
 		// when
-		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{ID: n.ID, Body: optional.New("body")})
+		err := r.UpdateCharacterNotification(ctx, storage.UpdateCharacterNotificationParams{
+			ID:   n.ID,
+			Body: optional.New("body"),
+		})
 		// then
 		if assert.NoError(t, err) {
 			o, err := r.GetCharacterNotification(ctx, n.CharacterID, n.ID)

--- a/internal/app/storage/characterplanet.go
+++ b/internal/app/storage/characterplanet.go
@@ -20,7 +20,7 @@ type CreateCharacterPlanetParams struct {
 
 func (st *Storage) CreateCharacterPlanet(ctx context.Context, arg CreateCharacterPlanetParams) (int64, error) {
 	if arg.CharacterID == 0 || arg.EvePlanetID == 0 {
-		return 0, fmt.Errorf("create planet: IDs can not be zero: %+v", arg)
+		return 0, fmt.Errorf("CreateCharacterPlanet: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterPlanetParams{
 		CharacterID:  int64(arg.CharacterID),

--- a/internal/app/storage/charactersectionstatus.go
+++ b/internal/app/storage/charactersectionstatus.go
@@ -63,7 +63,7 @@ type UpdateOrCreateCharacterSectionStatusParams struct {
 
 func (st *Storage) UpdateOrCreateCharacterSectionStatus(ctx context.Context, arg UpdateOrCreateCharacterSectionStatusParams) (*app.CharacterSectionStatus, error) {
 	if arg.CharacterID == 0 || arg.Section == "" {
-		panic("Invalid params")
+		return nil, fmt.Errorf("UpdateOrCreateCharacterSectionStatus: %+v: %w", arg, app.ErrInvalid)
 	}
 	o, err := func() (*app.CharacterSectionStatus, error) {
 		tx, err := st.dbRW.Begin()

--- a/internal/app/storage/characterskillqueueitem.go
+++ b/internal/app/storage/characterskillqueueitem.go
@@ -40,6 +40,9 @@ func (st *Storage) CreateCharacterSkillqueueItem(ctx context.Context, arg Skillq
 }
 
 func createCharacterSkillqueueItem(ctx context.Context, q *queries.Queries, arg SkillqueueItemParams) error {
+	if arg.CharacterID == 0 || arg.EveTypeID == 0 {
+		return fmt.Errorf("createCharacterSkillqueueItem: %+v: %w", arg, app.ErrInvalid)
+	}
 	arg2 := queries.CreateCharacterSkillqueueItemParams{
 		EveTypeID:     int64(arg.EveTypeID),
 		FinishedLevel: int64(arg.FinishedLevel),

--- a/internal/app/storage/characterwalletjournal.go
+++ b/internal/app/storage/characterwalletjournal.go
@@ -30,8 +30,8 @@ type CreateCharacterWalletJournalEntryParams struct {
 }
 
 func (st *Storage) CreateCharacterWalletJournalEntry(ctx context.Context, arg CreateCharacterWalletJournalEntryParams) error {
-	if arg.RefID == 0 {
-		return fmt.Errorf("CharacterWalletJournalEntry ID can not be zero, Character %d", arg.CharacterID)
+	if arg.CharacterID == 0 || arg.RefID == 0 {
+		return fmt.Errorf("CreateCharacterWalletJournalEntry: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterWalletJournalEntryParams{
 		Amount:        arg.Amount,

--- a/internal/app/storage/characterwallettransaction.go
+++ b/internal/app/storage/characterwallettransaction.go
@@ -27,8 +27,8 @@ type CreateCharacterWalletTransactionParams struct {
 }
 
 func (st *Storage) CreateCharacterWalletTransaction(ctx context.Context, arg CreateCharacterWalletTransactionParams) error {
-	if arg.TransactionID == 0 {
-		return fmt.Errorf("WalletTransaction ID can not be zero, Character %d", arg.CharacterID)
+	if arg.CharacterID == 0 || arg.EveTypeID == 0 || arg.ClientID == 0 || arg.JournalRefID == 0 || arg.LocationID == 0 || arg.TransactionID == 0 {
+		return fmt.Errorf("CreateCharacterWalletTransaction: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateCharacterWalletTransactionParams{
 		ClientID:      int64(arg.ClientID),

--- a/internal/app/storage/evecategory.go
+++ b/internal/app/storage/evecategory.go
@@ -18,7 +18,7 @@ type CreateEveCategoryParams struct {
 
 func (st *Storage) CreateEveCategory(ctx context.Context, arg CreateEveCategoryParams) (*app.EveCategory, error) {
 	if arg.ID == 0 {
-		return nil, fmt.Errorf("create EveCategory. invalid ID %+v", arg)
+		return nil, fmt.Errorf("CreateEveCategory: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveCategoryParams{
 		ID:          int64(arg.ID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveCategory(ctx context.Context, arg CreateEveCategoryP
 	}
 	e, err := st.qRW.CreateEveCategory(ctx, arg2)
 	if err != nil {
-		return nil, fmt.Errorf("create EveCategory %+v, %w", arg, err)
+		return nil, fmt.Errorf("CreateEveCategory: %+v: %w", arg, err)
 	}
 	return eveCategoryFromDBModel(e), nil
 }

--- a/internal/app/storage/evecharacter.go
+++ b/internal/app/storage/evecharacter.go
@@ -27,8 +27,8 @@ type CreateEveCharacterParams struct {
 }
 
 func (st *Storage) CreateEveCharacter(ctx context.Context, arg CreateEveCharacterParams) error {
-	if arg.ID == 0 {
-		return fmt.Errorf("invalid EveCharacter ID %d", arg.ID)
+	if arg.ID == 0 || arg.CorporationID == 0 {
+		return fmt.Errorf("CreateEveCharacter: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveCharacterParams{
 		ID:             int64(arg.ID),
@@ -51,7 +51,7 @@ func (st *Storage) CreateEveCharacter(ctx context.Context, arg CreateEveCharacte
 	}
 	err := st.qRW.CreateEveCharacter(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveCharacter %v, %w", arg2, err)
+		return fmt.Errorf("CreateEveCharacter: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/eveconstellation.go
+++ b/internal/app/storage/eveconstellation.go
@@ -17,8 +17,8 @@ type CreateEveConstellationParams struct {
 }
 
 func (st *Storage) CreateEveConstellation(ctx context.Context, arg CreateEveConstellationParams) error {
-	if arg.ID == 0 {
-		return fmt.Errorf("invalid ID %d", arg.ID)
+	if arg.ID == 0 || arg.RegionID == 0 {
+		return fmt.Errorf("CreateEveConstellation: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveConstellationParams{
 		ID:          int64(arg.ID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveConstellation(ctx context.Context, arg CreateEveCons
 	}
 	err := st.qRW.CreateEveConstellation(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveConstellation %v, %w", arg, err)
+		return fmt.Errorf("CreateEveConstellation: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/evedogmatattribute.go
+++ b/internal/app/storage/evedogmatattribute.go
@@ -25,7 +25,7 @@ type CreateEveDogmaAttributeParams struct {
 
 func (st *Storage) CreateEveDogmaAttribute(ctx context.Context, arg CreateEveDogmaAttributeParams) (*app.EveDogmaAttribute, error) {
 	if arg.ID == 0 {
-		return nil, fmt.Errorf("invalid ID %d", arg.ID)
+		return nil, fmt.Errorf("CreateEveDogmaAttribute: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveDogmaAttributeParams{
 		ID:           int64(arg.ID),
@@ -41,7 +41,7 @@ func (st *Storage) CreateEveDogmaAttribute(ctx context.Context, arg CreateEveDog
 	}
 	o, err := st.qRW.CreateEveDogmaAttribute(ctx, arg2)
 	if err != nil {
-		return nil, fmt.Errorf("create EveDogmaAttribute %v, %w", arg2, err)
+		return nil, fmt.Errorf("CreateEveDogmaAttribute: %+v: %w", arg, err)
 	}
 	return eveDogmaAttributeFromDBModel(o), nil
 }

--- a/internal/app/storage/eveentity_test.go
+++ b/internal/app/storage/eveentity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
@@ -57,7 +58,7 @@ func TestEveEntity(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		// when
-		_, err := st.CreateEveEntity(ctx, 42, "Dummy", app.EveEntityAlliance)
+		_, err := st.CreateEveEntity(ctx, storage.CreateEveEntityParams{42, "Dummy", app.EveEntityAlliance})
 		// then
 		if assert.NoError(t, err) {
 			e, err := st.GetEveEntity(ctx, 42)
@@ -114,7 +115,7 @@ func TestEveEntity(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		// when
-		_, err := st.CreateEveEntity(ctx, 0, "Dummy", app.EveEntityAlliance)
+		_, err := st.CreateEveEntity(ctx, storage.CreateEveEntityParams{0, "Dummy", app.EveEntityAlliance})
 		// then
 		assert.Error(t, err)
 	})
@@ -122,7 +123,12 @@ func TestEveEntity(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		// when
-		_, err := st.GetOrCreateEveEntity(ctx, 0, "Dummy", app.EveEntityAlliance)
+		arg := storage.CreateEveEntityParams{
+			ID:       0,
+			Name:     "Dummy",
+			Category: app.EveEntityAlliance,
+		}
+		_, err := st.GetOrCreateEveEntity(ctx, arg)
 		// then
 		assert.Error(t, err)
 	})
@@ -209,8 +215,13 @@ func TestEveEntityGetOrCreate(t *testing.T) {
 	t.Run("should create new when not exist", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
+		arg := storage.CreateEveEntityParams{
+			ID:       42,
+			Name:     "Dummy",
+			Category: app.EveEntityAlliance,
+		}
 		// when
-		_, err := r.GetOrCreateEveEntity(ctx, 42, "Dummy", app.EveEntityAlliance)
+		_, err := r.GetOrCreateEveEntity(ctx, arg)
 		// then
 		if assert.NoError(t, err) {
 			e, err := r.GetEveEntity(ctx, 42)
@@ -231,8 +242,13 @@ func TestEveEntityGetOrCreate(t *testing.T) {
 				Name:     "Alpha",
 				Category: app.EveEntityCharacter,
 			})
+		arg := storage.CreateEveEntityParams{
+			ID:       42,
+			Name:     "Erik",
+			Category: app.EveEntityCorporation,
+		}
 		// when
-		e, err := r.GetOrCreateEveEntity(ctx, 42, "Erik", app.EveEntityCorporation)
+		e, err := r.GetOrCreateEveEntity(ctx, arg)
 		// then
 		if assert.NoError(t, err) {
 			assert.Equal(t, int32(42), e.ID)

--- a/internal/app/storage/evegroup.go
+++ b/internal/app/storage/evegroup.go
@@ -18,8 +18,8 @@ type CreateEveGroupParams struct {
 }
 
 func (st *Storage) CreateEveGroup(ctx context.Context, arg CreateEveGroupParams) error {
-	if arg.ID == 0 {
-		return fmt.Errorf("invalid ID %d", arg.ID)
+	if arg.ID == 0 || arg.CategoryID == 0 {
+		return fmt.Errorf("CreateEveGroup: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveGroupParams{
 		ID:            int64(arg.ID),
@@ -29,7 +29,7 @@ func (st *Storage) CreateEveGroup(ctx context.Context, arg CreateEveGroupParams)
 	}
 	err := st.qRW.CreateEveGroup(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveGroup %v, %w", arg, err)
+		return fmt.Errorf("CreateEveGroup: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/evelocation.go
+++ b/internal/app/storage/evelocation.go
@@ -24,7 +24,7 @@ type UpdateOrCreateLocationParams struct {
 
 func (st *Storage) UpdateOrCreateEveLocation(ctx context.Context, arg UpdateOrCreateLocationParams) error {
 	if arg.ID == 0 {
-		return fmt.Errorf("invalid ID for eve location %d", arg.ID)
+		return fmt.Errorf("UpdateOrCreateEveLocation: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.UpdateOrCreateLocationParams{
 		ID:               int64(arg.ID),

--- a/internal/app/storage/evemoon.go
+++ b/internal/app/storage/evemoon.go
@@ -18,7 +18,7 @@ type CreateEveMoonParams struct {
 
 func (st *Storage) CreateEveMoon(ctx context.Context, arg CreateEveMoonParams) error {
 	if arg.ID == 0 || arg.SolarSystemID == 0 {
-		return fmt.Errorf("invalid IDs %v", arg)
+		return fmt.Errorf("CreateEveMoon: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveMoonParams{
 		ID:               int64(arg.ID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveMoon(ctx context.Context, arg CreateEveMoonParams) e
 	}
 	err := st.qRW.CreateEveMoon(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveMoon %v, %w", arg, err)
+		return fmt.Errorf("CreateEveMoon: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/eveplanet.go
+++ b/internal/app/storage/eveplanet.go
@@ -19,7 +19,7 @@ type CreateEvePlanetParams struct {
 
 func (st *Storage) CreateEvePlanet(ctx context.Context, arg CreateEvePlanetParams) error {
 	if arg.ID == 0 || arg.SolarSystemID == 0 || arg.TypeID == 0 {
-		return fmt.Errorf("invalid IDs %v", arg)
+		return fmt.Errorf("CreateEvePlanet: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEvePlanetParams{
 		ID:               int64(arg.ID),

--- a/internal/app/storage/everace.go
+++ b/internal/app/storage/everace.go
@@ -10,15 +10,24 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/queries"
 )
 
-func (st *Storage) CreateEveRace(ctx context.Context, id int32, description, name string) (*app.EveRace, error) {
-	arg := queries.CreateEveRaceParams{
-		ID:          int64(id),
-		Description: description,
-		Name:        name,
+type CreateEveRaceParams struct {
+	ID          int32
+	Name        string
+	Description string
+}
+
+func (st *Storage) CreateEveRace(ctx context.Context, arg CreateEveRaceParams) (*app.EveRace, error) {
+	if arg.ID == 0 {
+		return nil, fmt.Errorf("CreateEveRace: %+v, %w", arg, app.ErrInvalid)
 	}
-	o, err := st.qRW.CreateEveRace(ctx, arg)
+	arg2 := queries.CreateEveRaceParams{
+		ID:          int64(arg.ID),
+		Description: arg.Description,
+		Name:        arg.Name,
+	}
+	o, err := st.qRW.CreateEveRace(ctx, arg2)
 	if err != nil {
-		return nil, fmt.Errorf("create race %d: %w", id, err)
+		return nil, fmt.Errorf("CreateEveRace: %+v, %w", arg, err)
 	}
 	return eveRaceFromDBModel(o), nil
 }

--- a/internal/app/storage/everace_test.go
+++ b/internal/app/storage/everace_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
 )
 
@@ -17,7 +18,12 @@ func TestEveRace(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		// when
-		x1, err := r.CreateEveRace(ctx, 42, "description", "name")
+		arg := storage.CreateEveRaceParams{
+			ID:          42,
+			Description: "description",
+			Name:        "name",
+		}
+		x1, err := r.CreateEveRace(ctx, arg)
 		// then
 		if assert.NoError(t, err) {
 			assert.Equal(t, int32(42), x1.ID)

--- a/internal/app/storage/everegion.go
+++ b/internal/app/storage/everegion.go
@@ -18,7 +18,7 @@ type CreateEveRegionParams struct {
 
 func (st *Storage) CreateEveRegion(ctx context.Context, arg CreateEveRegionParams) (*app.EveRegion, error) {
 	if arg.ID == 0 {
-		return nil, fmt.Errorf("invalid ID %d", arg.ID)
+		return nil, fmt.Errorf("CreateEveRegion: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveRegionParams{
 		ID:          int64(arg.ID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveRegion(ctx context.Context, arg CreateEveRegionParam
 	}
 	e, err := st.qRW.CreateEveRegion(ctx, arg2)
 	if err != nil {
-		return nil, fmt.Errorf("create EveRegion %v, %w", arg2, err)
+		return nil, fmt.Errorf("CreateEveRegion: %+v: %w", arg2, err)
 	}
 	return eveRegionFromDBModel(e), nil
 }

--- a/internal/app/storage/evesolarsystem.go
+++ b/internal/app/storage/evesolarsystem.go
@@ -18,8 +18,8 @@ type CreateEveSolarSystemParams struct {
 }
 
 func (st *Storage) CreateEveSolarSystem(ctx context.Context, arg CreateEveSolarSystemParams) error {
-	if arg.ID == 0 {
-		return fmt.Errorf("invalid ID %d", arg.ID)
+	if arg.ID == 0 || arg.ConstellationID == 0 {
+		return fmt.Errorf("CreateEveSolarSystem: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveSolarSystemParams{
 		ID:                 int64(arg.ID),

--- a/internal/app/storage/evetype.go
+++ b/internal/app/storage/evetype.go
@@ -29,8 +29,8 @@ type CreateEveTypeParams struct {
 }
 
 func (st *Storage) CreateEveType(ctx context.Context, arg CreateEveTypeParams) error {
-	if arg.ID == 0 {
-		return fmt.Errorf("invalid ID %d", arg.ID)
+	if arg.ID == 0 || arg.GroupID == 0 {
+		return fmt.Errorf("CreateEveType: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveTypeParams{
 		ID:             int64(arg.ID),
@@ -50,7 +50,7 @@ func (st *Storage) CreateEveType(ctx context.Context, arg CreateEveTypeParams) e
 	}
 	err := st.qRW.CreateEveType(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveType %v, %w", arg, err)
+		return fmt.Errorf("CreateEveType %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/evetypedogmaattribute.go
+++ b/internal/app/storage/evetypedogmaattribute.go
@@ -18,7 +18,7 @@ type CreateEveTypeDogmaAttributeParams struct {
 
 func (st *Storage) CreateEveTypeDogmaAttribute(ctx context.Context, arg CreateEveTypeDogmaAttributeParams) error {
 	if arg.DogmaAttributeID == 0 || arg.EveTypeID == 0 {
-		return fmt.Errorf("invalid IDs for EveTypeDogmaAttribute: %v", arg)
+		return fmt.Errorf("CreateEveTypeDogmaAttribute: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveTypeDogmaAttributeParams{
 		DogmaAttributeID: int64(arg.DogmaAttributeID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveTypeDogmaAttribute(ctx context.Context, arg CreateEv
 	}
 	err := st.qRW.CreateEveTypeDogmaAttribute(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveTypeDogmaAttribute %v, %w", arg, err)
+		return fmt.Errorf("CreateEveTypeDogmaAttribute: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/evetypedogmaeffect.go
+++ b/internal/app/storage/evetypedogmaeffect.go
@@ -18,7 +18,7 @@ type CreateEveTypeDogmaEffectParams struct {
 
 func (st *Storage) CreateEveTypeDogmaEffect(ctx context.Context, arg CreateEveTypeDogmaEffectParams) error {
 	if arg.DogmaEffectID == 0 || arg.EveTypeID == 0 {
-		return fmt.Errorf("invalid IDs for EveTypeDogmaEffect: %v", arg)
+		return fmt.Errorf("CreateEveTypeDogmaEffect: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreateEveTypeDogmaEffectParams{
 		DogmaEffectID: int64(arg.DogmaEffectID),
@@ -27,7 +27,7 @@ func (st *Storage) CreateEveTypeDogmaEffect(ctx context.Context, arg CreateEveTy
 	}
 	err := st.qRW.CreateEveTypeDogmaEffect(ctx, arg2)
 	if err != nil {
-		return fmt.Errorf("create EveTypeDogmaEffect %v, %w", arg, err)
+		return fmt.Errorf("CreateEveTypeDogmaEffect: %+v: %w", arg, err)
 	}
 	return nil
 }

--- a/internal/app/storage/generalsectionstatus.go
+++ b/internal/app/storage/generalsectionstatus.go
@@ -48,7 +48,7 @@ type UpdateOrCreateGeneralSectionStatusParams struct {
 
 func (st *Storage) UpdateOrCreateGeneralSectionStatus(ctx context.Context, arg UpdateOrCreateGeneralSectionStatusParams) (*app.GeneralSectionStatus, error) {
 	if string(arg.Section) == "" {
-		panic("Invalid params")
+		return nil, fmt.Errorf("UpdateOrCreateGeneralSectionStatus: %+v: %w", arg, app.ErrInvalid)
 	}
 	tx, err := st.dbRW.Begin()
 	if err != nil {

--- a/internal/app/storage/planetpin.go
+++ b/internal/app/storage/planetpin.go
@@ -25,8 +25,8 @@ type CreatePlanetPinParams struct {
 }
 
 func (st *Storage) CreatePlanetPin(ctx context.Context, arg CreatePlanetPinParams) error {
-	if arg.CharacterPlanetID == 0 {
-		return fmt.Errorf("create PlanetPin - invalid IDs %+v", arg)
+	if arg.CharacterPlanetID == 0 || arg.PinID == 0 || arg.TypeID == 0 {
+		return fmt.Errorf("CreatePlanetPin: %+v: %w", arg, app.ErrInvalid)
 	}
 	arg2 := queries.CreatePlanetPinParams{
 		CharacterPlanetID:      arg.CharacterPlanetID,

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -213,7 +213,12 @@ func (f Factory) CreateCharacterContract(args ...storage.CreateCharacterContract
 		if err != nil {
 			panic(err)
 		}
-		_, err = f.st.GetOrCreateEveEntity(ctx, c.ID, c.EveCharacter.Name, app.EveEntityCharacter)
+		arg2 := storage.CreateEveEntityParams{
+			ID:       c.ID,
+			Name:     c.EveCharacter.Name,
+			Category: app.EveEntityCharacter,
+		}
+		_, err = f.st.GetOrCreateEveEntity(ctx, arg2)
 		if err != nil {
 			panic(err)
 		}
@@ -846,6 +851,12 @@ func (f Factory) CreateCharacterWalletTransaction(args ...storage.CreateCharacte
 	if arg.Quantity == 0 {
 		arg.Quantity = rand.Int32N(100_000)
 	}
+	if arg.JournalRefID == 0 {
+		x := f.CreateCharacterWalletJournalEntry(storage.CreateCharacterWalletJournalEntryParams{
+			CharacterID: arg.CharacterID,
+		})
+		arg.JournalRefID = x.ID
+	}
 	err := f.st.CreateCharacterWalletTransaction(ctx, arg)
 	if err != nil {
 		panic(err)
@@ -976,6 +987,8 @@ func (f Factory) CreateGeneralSectionStatus(args ...GeneralSectionStatusParams) 
 	return o
 }
 
+// TODO: Refactor to use storage.CreateEveEntityParams
+
 func (f Factory) CreateEveEntity(args ...app.EveEntity) *app.EveEntity {
 	var arg app.EveEntity
 	ctx := context.TODO()
@@ -1018,7 +1031,7 @@ func (f Factory) CreateEveEntity(args ...app.EveEntity) *app.EveEntity {
 			arg.Name = fmt.Sprintf("%s #%d", arg.Category, arg.ID)
 		}
 	}
-	e, err := f.st.CreateEveEntity(ctx, arg.ID, arg.Name, arg.Category)
+	e, err := f.st.CreateEveEntity(ctx, storage.CreateEveEntityParams{ID: arg.ID, Name: arg.Name, Category: arg.Category})
 	if err != nil {
 		panic(fmt.Sprintf("create EveEntity %v: %s", arg, err))
 	}
@@ -1359,6 +1372,8 @@ func (f Factory) CreateEveMoon(args ...storage.CreateEveMoonParams) *app.EveMoon
 	return o
 }
 
+// TODO: Refactor to storage.CreateEveRaceParams
+
 func (f Factory) CreateEveRace(args ...app.EveRace) *app.EveRace {
 	var arg app.EveRace
 	ctx := context.TODO()
@@ -1374,7 +1389,12 @@ func (f Factory) CreateEveRace(args ...app.EveRace) *app.EveRace {
 	if arg.Description == "" {
 		arg.Description = fake.Paragraph()
 	}
-	r, err := f.st.CreateEveRace(ctx, arg.ID, arg.Description, arg.Name)
+	arg2 := storage.CreateEveRaceParams{
+		ID:          arg.ID,
+		Description: arg.Description,
+		Name:        arg.Name,
+	}
+	r, err := f.st.CreateEveRace(ctx, arg2)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/app/ui.go
+++ b/internal/app/ui.go
@@ -72,4 +72,5 @@ type UI interface {
 	ShowInfoWindow(c EveEntityCategory, id int32)
 	ShowSnackbar(text string)
 	WebsiteRootURL() *url.URL
+	MakeWindowTitle(subTitle string) string
 }

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -269,7 +269,7 @@ func (u *UIBase) IsMobile() bool {
 	return u.isMobile
 }
 
-func (u *UIBase) makeWindowTitle(subTitle string) string {
+func (u *UIBase) MakeWindowTitle(subTitle string) string {
 	if u.IsMobile() {
 		return subTitle
 	}
@@ -941,7 +941,7 @@ func (u *UIBase) ShowUpdateStatusWindow() {
 		u.statusWindow.Show()
 		return
 	}
-	w := u.app.NewWindow(u.makeWindowTitle("Update Status"))
+	w := u.app.NewWindow(u.MakeWindowTitle("Update Status"))
 	a := toolui.NewUpdateStatus(u)
 	a.Update()
 	w.SetContent(a)

--- a/internal/app/ui/uidesktop.go
+++ b/internal/app/ui/uidesktop.go
@@ -305,7 +305,7 @@ func (u *UIDesktop) showSettingsWindow() {
 		u.settingsWindow.Show()
 		return
 	}
-	w := u.App().NewWindow(u.makeWindowTitle("Settings"))
+	w := u.App().NewWindow(u.MakeWindowTitle("Settings"))
 	u.userSettings.SetWindow(w)
 	w.SetContent(u.userSettings)
 	w.Resize(fyne.Size{Width: 700, Height: 500})
@@ -316,8 +316,8 @@ func (u *UIDesktop) showSettingsWindow() {
 }
 
 func (u *UIDesktop) showSendMailWindow(c *app.Character, mode app.SendMailMode, mail *app.CharacterMail) {
-	title := u.makeWindowTitle(fmt.Sprintf("New message [%s]", c.EveCharacter.Name))
-	w := u.App().NewWindow(title)
+	title := fmt.Sprintf("New message [%s]", c.EveCharacter.Name)
+	w := u.App().NewWindow(u.MakeWindowTitle(title))
 	page := characterui.NewSendMail(u, c, mode, mail)
 	page.SetWindow(w)
 	send := widget.NewButtonWithIcon("Send", theme.MailSendIcon(), func() {
@@ -339,12 +339,12 @@ func (u *UIDesktop) showSendMailWindow(c *app.Character, mode app.SendMailMode, 
 	w.Show()
 }
 
-func (u *UIDesktop) ShowAccountWindow() {
+func (u *UIDesktop) ShowManageCharactersWindow() {
 	if u.accountWindow != nil {
 		u.accountWindow.Show()
 		return
 	}
-	w := u.App().NewWindow(u.makeWindowTitle("Characters"))
+	w := u.App().NewWindow(u.MakeWindowTitle("Manage Characters"))
 	u.accountWindow = w
 	w.SetOnClosed(func() {
 		u.accountWindow = nil
@@ -370,7 +370,7 @@ func (u *UIDesktop) showSearchWindow() {
 	} else {
 		n = "No Character"
 	}
-	w := u.App().NewWindow(u.makeWindowTitle(fmt.Sprintf("Search New Eden [%s]", n)))
+	w := u.App().NewWindow(u.MakeWindowTitle(fmt.Sprintf("Search New Eden [%s]", n)))
 	u.searchWindow = w
 	w.SetOnClosed(func() {
 		u.searchWindow = nil
@@ -461,7 +461,7 @@ func (u *UIDesktop) makeMenu() *fyne.MainMenu {
 	}
 	u.menuItemsWithShortcut = append(u.menuItemsWithShortcut, settingsItem)
 
-	charactersItem := fyne.NewMenuItem("Manage characters...", u.ShowAccountWindow)
+	charactersItem := fyne.NewMenuItem("Manage characters...", u.ShowManageCharactersWindow)
 	charactersItem.Shortcut = &desktop.CustomShortcut{
 		KeyName:  fyne.KeyC,
 		Modifier: fyne.KeyModifierAlt,


### PR DESCRIPTION
- All storage create methods now return the same error (`app.ErrInvalid`) and a better error message (that always includes method name) when called with invalid parameters. This e.g. protects against creating objects with ID = 0, which usually is a bug.
- Consolidates creating the title for all windows on desktop and always add the app's name to it.