### PR TITLE
fix: wallet transaction total always positive

### DIFF
--- a/internal/app/ui/characterwallettransaction.go
+++ b/internal/app/ui/characterwallettransaction.go
@@ -45,6 +45,9 @@ func NewCharacterWalletTransaction(u *BaseUI) *CharacterWalletTransaction {
 			return iwidget.NewRichTextSegmentFromText(humanize.FormatFloat(app.FloatFormat, r.UnitPrice))
 		case 4:
 			total := r.UnitPrice * float64(r.Quantity)
+			if r.IsBuy {
+				total = total * -1
+			}
 			text := humanize.FormatFloat(app.FloatFormat, total)
 			var color fyne.ThemeColorName
 			switch {


### PR DESCRIPTION
Totals in the wallet transactions table are always showing as positive value, even when item is bought.