### PR TITLE
feat: add sso landing page

### DIFF
--- a/internal/sso/logger.go
+++ b/internal/sso/logger.go
@@ -42,7 +42,7 @@ func WithLogger(handlerToWrap http.Handler) *Logger {
 // ServeHTTP handles the request by passing it to the real
 // handler and logging the request and response.
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	slog.Info("SSO server request", "method", r.Method, "path", r.URL.Path)
+	slog.Debug("SSO server request", "method", r.Method, "path", r.URL.Path)
 	lw := &loggingResponseWriter{ResponseWriter: rw}
 	l.handler.ServeHTTP(lw, r)
 	slog.Info("SSO server response", "method", r.Method, "path", r.URL.Path, "status", lw.info.Status())

--- a/internal/sso/logger.go
+++ b/internal/sso/logger.go
@@ -1,0 +1,49 @@
+package sso
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// struct for holding response details
+type responseInfo struct {
+	status int
+}
+
+func (i responseInfo) Status() int {
+	if i.status == 0 {
+		// Status will usually only be set if it differs from 200
+		return http.StatusOK
+	}
+	return i.status
+}
+
+// our http.ResponseWriter implementation
+type loggingResponseWriter struct {
+	http.ResponseWriter // compose original http.ResponseWriter
+	info                responseInfo
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.info.status = statusCode
+}
+
+// Logger is a middleware handler that does request logging
+type Logger struct {
+	handler http.Handler
+}
+
+// WithLogger constructs a new Logger middleware handler
+func WithLogger(handlerToWrap http.Handler) *Logger {
+	return &Logger{handlerToWrap}
+}
+
+// ServeHTTP handles the request by passing it to the real
+// handler and logging the request and response.
+func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	slog.Info("SSO server request", "method", r.Method, "path", r.URL.Path)
+	lw := &loggingResponseWriter{ResponseWriter: rw}
+	l.handler.ServeHTTP(lw, r)
+	slog.Info("SSO server response", "method", r.Method, "path", r.URL.Path, "status", lw.info.Status())
+}

--- a/internal/sso/template/authenticated.html
+++ b/internal/sso/template/authenticated.html
@@ -1,2 +1,0 @@
-<p>SSO authentication successful for <b>{{.Name}}</b>.</p>
-<p>You can close this tab now and return to the app.</p>

--- a/internal/sso/template/authenticated.html
+++ b/internal/sso/template/authenticated.html
@@ -1,0 +1,2 @@
+<p>SSO authentication successful for <b>{{.Name}}</b>.</p>
+<p>You can close this tab now and return to the app.</p>

--- a/internal/sso/tmpl/authenticated.html
+++ b/internal/sso/tmpl/authenticated.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Authenticated - EVE Buddy</title>
+        <link href="https://login.eveonline.com/css/Site.min.css" rel="stylesheet" type="text/css" />
+        <link href="https://login.eveonline.com/css/themes/default/style.min.css" rel="stylesheet" type="text/css" />
+    </head>
+    <body id="loginbody" class="en">
+        <div id="container">
+            <header>
+                <a href="#" class="logo">
+                    <img src="https://web-cdn.eveonline.com/aws/eveonline/sso/eve-logo.svg" />
+                </a>
+            </header>
+            <section id="main">
+                <h1>Authentication successfull</h1>
+                <p><strong>{{.Name}}</strong> has been authenticated successfully for <strong>EVE Buddy</strong>.</p>
+                <br>
+                <p>You can now close this tab and return to the app.</p>
+            </section>
+        </div>
+    </body>
+</html>

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ var (
 	pprofFlag          = flag.Bool("pprof", false, "Enable pprof web server")
 	resetSettingsFlag  = flag.Bool("reset-settings", false, "Resets desktop settings")
 	versionFlag        = flag.Bool("v", false, "Show version")
+	ssoDemoFlag        = flag.Bool("sso-demo", false, "Start SSO serer in demo mode")
 )
 
 func main() {
@@ -167,6 +168,13 @@ func main() {
 		logWriter = io.MultiWriter(os.Stderr, logger)
 	}
 	log.SetOutput(logWriter)
+
+	if *ssoDemoFlag {
+		sso := sso.New("", http.DefaultClient)
+		sso.DemoMode = true
+		sso.Authenticate(context.Background(), []string{})
+		return
+	}
 
 	if isDesktop {
 		// ensure single instance


### PR DESCRIPTION
Adds a landing page that is shown to users when they completed the SSO process successfully.

The landing page uses the original styling from the Eve online login page to not break the user experience.

Screenshot

![Screenshot from 2025-04-11 19-40-19](https://github.com/user-attachments/assets/fecd1574-ff41-441a-ae24-e252d9785973)
