### PR TITLE
fix: some char data is deleted when re-adding a char

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -32,9 +32,10 @@ type Position struct {
 
 // App errors
 var (
-	ErrAborted  = errors.New("process aborted prematurely")
-	ErrNotFound = errors.New("object not found")
-	ErrInvalid  = errors.New("invalid parameters")
+	ErrAborted       = errors.New("process aborted prematurely")
+	ErrNotFound      = errors.New("object not found")
+	ErrAlreadyExists = errors.New("object already exists")
+	ErrInvalid       = errors.New("invalid parameters")
 )
 
 // VariableDateFormat returns a variable dateformat.

--- a/internal/app/characterservice/character_test.go
+++ b/internal/app/characterservice/character_test.go
@@ -94,7 +94,7 @@ func TestTrainingWatchers(t *testing.T) {
 	t.Run("should disable all training watchers", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
-		c1 := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{IsTrainingWatched: true})
+		c1 := factory.CreateCharacter(storage.CreateCharacterParams{IsTrainingWatched: true})
 		c2 := factory.CreateCharacter()
 		// when
 		err := cs.DisableAllTrainingWatchers(ctx)

--- a/internal/app/characterservice/contract_test.go
+++ b/internal/app/characterservice/contract_test.go
@@ -46,7 +46,7 @@ func TestNotifyUpdatedContracts(t *testing.T) {
 				factory.CreateEveEntityCharacter(app.EveEntity{ID: tc.acceptorID})
 			}
 			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{ID: characterID})
-			c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{ID: ec.ID})
+			c := factory.CreateCharacter(storage.CreateCharacterParams{ID: ec.ID})
 			o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
 				AcceptorID:     tc.acceptorID,
 				CharacterID:    c.ID,

--- a/internal/app/characterservice/jumpclone_internal_test.go
+++ b/internal/app/characterservice/jumpclone_internal_test.go
@@ -124,7 +124,7 @@ func TestCharacterNextAvailableCloneJump(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		now := time.Now().UTC()
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{
+		c := factory.CreateCharacter(storage.CreateCharacterParams{
 			LastCloneJumpAt: optional.New(now.Add(-6 * time.Hour)),
 		})
 		factory.CreateEveType(storage.CreateEveTypeParams{ID: app.EveTypeInfomorphSynchronizing})
@@ -142,7 +142,7 @@ func TestCharacterNextAvailableCloneJump(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		now := time.Now().UTC()
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{
+		c := factory.CreateCharacter(storage.CreateCharacterParams{
 			LastCloneJumpAt: optional.New(now.Add(-6 * time.Hour)),
 		})
 		x, err := cs.calcNextCloneJump(ctx, c)
@@ -153,7 +153,7 @@ func TestCharacterNextAvailableCloneJump(t *testing.T) {
 	t.Run("should return time of next available jump without skill and never jumped before", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{
+		c := factory.CreateCharacter(storage.CreateCharacterParams{
 			LastCloneJumpAt: optional.New(time.Time{}),
 		})
 		x, err := cs.calcNextCloneJump(ctx, c)
@@ -165,7 +165,7 @@ func TestCharacterNextAvailableCloneJump(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		now := time.Now().UTC()
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{
+		c := factory.CreateCharacter(storage.CreateCharacterParams{
 			LastCloneJumpAt: optional.New(now.Add(-20 * time.Hour)),
 		})
 		factory.CreateEveType(storage.CreateEveTypeParams{ID: app.EveTypeInfomorphSynchronizing})

--- a/internal/app/characterservice/skillqueue_test.go
+++ b/internal/app/characterservice/skillqueue_test.go
@@ -17,7 +17,7 @@ func TestUpdateTickerNotifyExpiredTraining(t *testing.T) {
 	t.Run("send notification when watched & expired", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{IsTrainingWatched: true})
+		c := factory.CreateCharacter(storage.CreateCharacterParams{IsTrainingWatched: true})
 		var sendCount int
 		// when
 		err := cs.NotifyExpiredTraining(ctx, c.ID, func(title, content string) {
@@ -45,7 +45,7 @@ func TestUpdateTickerNotifyExpiredTraining(t *testing.T) {
 	t.Run("don't send notification when watched and training ongoing", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{IsTrainingWatched: true})
+		c := factory.CreateCharacter(storage.CreateCharacterParams{IsTrainingWatched: true})
 		factory.CreateCharacterSkillqueueItem(storage.SkillqueueItemParams{CharacterID: c.ID})
 		var sendCount int
 		// when

--- a/internal/app/statuscacheservice/statuscache_test.go
+++ b/internal/app/statuscacheservice/statuscache_test.go
@@ -24,7 +24,7 @@ func TestStatusCache(t *testing.T) {
 		testutil.TruncateTables(db)
 		cache.Clear()
 		ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{Name: "Bruce"})
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{ID: ec.ID})
+		c := factory.CreateCharacter(storage.CreateCharacterParams{ID: ec.ID})
 		section1 := app.SectionImplants
 		x1 := factory.CreateCharacterSectionStatus(testutil.CharacterSectionStatusParams{
 			CharacterID: c.ID,
@@ -101,7 +101,7 @@ func TestStatusCache(t *testing.T) {
 		testutil.TruncateTables(db)
 		cache.Clear()
 		ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{Name: "Bruce"})
-		c := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{ID: ec.ID})
+		c := factory.CreateCharacter(storage.CreateCharacterParams{ID: ec.ID})
 		// when
 		if err := sc.UpdateCharacters(ctx, st); err != nil {
 			t.Fatal(err)

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -24,7 +24,7 @@ func TestCharacter(t *testing.T) {
 		a := factory.CreateEveEntityAlliance()
 		f := factory.CreateEveEntity(app.EveEntity{Category: app.EveEntityFaction})
 		eveC := factory.CreateEveCharacter(storage.CreateEveCharacterParams{AllianceID: a.ID, FactionID: f.ID})
-		c1 := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{ID: eveC.ID})
+		c1 := factory.CreateCharacter(storage.CreateCharacterParams{ID: eveC.ID})
 		// when
 		c2, err := r.GetCharacter(ctx, c1.ID)
 		// then
@@ -38,87 +38,6 @@ func TestCharacter(t *testing.T) {
 			assert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
 			assert.Equal(t, c1.EveCharacter.Alliance, c2.EveCharacter.Alliance)
 			assert.Equal(t, c1.EveCharacter.Faction, c2.EveCharacter.Faction)
-		}
-	})
-	t.Run("can create new minimal", func(t *testing.T) {
-		// given
-		testutil.TruncateTables(db)
-		character := factory.CreateEveCharacter()
-		arg := storage.UpdateOrCreateCharacterParams{
-			ID: character.ID,
-		}
-		// when
-		err := r.UpdateOrCreateCharacter(ctx, arg)
-		// then
-		if assert.NoError(t, err) {
-			r, err := r.GetCharacter(ctx, arg.ID)
-			if assert.NoError(t, err) {
-				assert.Equal(t, character.ID, r.ID)
-			}
-		}
-	})
-	t.Run("can create new full", func(t *testing.T) {
-		// given
-		testutil.TruncateTables(db)
-		character := factory.CreateEveCharacter()
-		home := factory.CreateEveLocationStructure()
-		location := factory.CreateEveLocationStructure()
-		ship := factory.CreateEveType()
-		login := time.Now()
-		cloneJump := time.Now()
-		arg := storage.UpdateOrCreateCharacterParams{
-			ID:              character.ID,
-			AssetValue:      optional.New(3.4),
-			HomeID:          optional.New(home.ID),
-			LastCloneJumpAt: optional.New(cloneJump),
-			LastLoginAt:     optional.New(login),
-			LocationID:      optional.New(location.ID),
-			ShipID:          optional.New(ship.ID),
-			TotalSP:         optional.New(123),
-			WalletBalance:   optional.New(1.2),
-		}
-		// when
-		err := r.UpdateOrCreateCharacter(ctx, arg)
-		// then
-		if assert.NoError(t, err) {
-			r, err := r.GetCharacter(ctx, arg.ID)
-			if assert.NoError(t, err) {
-				assert.Equal(t, home, r.Home)
-				assert.Equal(t, cloneJump.UTC(), r.LastCloneJumpAt.ValueOrZero().UTC())
-				assert.Equal(t, login.UTC(), r.LastLoginAt.ValueOrZero().UTC())
-				assert.Equal(t, location, r.Location)
-				assert.Equal(t, ship, r.Ship)
-				assert.Equal(t, 123, r.TotalSP.ValueOrZero())
-				assert.Equal(t, 1.2, r.WalletBalance.ValueOrZero())
-				assert.Equal(t, 3.4, r.AssetValue.ValueOrZero())
-			}
-		}
-	})
-	t.Run("can update existing", func(t *testing.T) {
-		// given
-		testutil.TruncateTables(db)
-		c1 := factory.CreateCharacter()
-		// when
-		newLocation := factory.CreateEveLocationStructure()
-		newShip := factory.CreateEveType()
-		assetValue := optional.New(1.2)
-		walletBalance := optional.New(3.4)
-		err := r.UpdateOrCreateCharacter(ctx, storage.UpdateOrCreateCharacterParams{
-			ID:            c1.ID,
-			LocationID:    optional.New(newLocation.ID),
-			ShipID:        optional.New(newShip.ID),
-			AssetValue:    assetValue,
-			WalletBalance: walletBalance,
-		})
-		// then
-		if assert.NoError(t, err) {
-			c2, err := r.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				assert.Equal(t, newLocation, c2.Location)
-				assert.Equal(t, newShip, c2.Ship)
-				assert.Equal(t, assetValue, c2.AssetValue)
-				assert.Equal(t, walletBalance, c2.WalletBalance)
-			}
 		}
 	})
 	t.Run("can delete", func(t *testing.T) {
@@ -172,6 +91,76 @@ func TestCharacter(t *testing.T) {
 			assert.Equal(t, c1.ID, c2.ID)
 			assert.Equal(t, c1.Location, c2.Location)
 		}
+	})
+}
+
+func TestCharacterCreate(t *testing.T) {
+	db, r, factory := testutil.New()
+	defer db.Close()
+	ctx := context.Background()
+	t.Run("can create new minimal", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		character := factory.CreateEveCharacter()
+		arg := storage.CreateCharacterParams{
+			ID: character.ID,
+		}
+		// when
+		err := r.CreateCharacter(ctx, arg)
+		// then
+		if assert.NoError(t, err) {
+			r, err := r.GetCharacter(ctx, arg.ID)
+			if assert.NoError(t, err) {
+				assert.Equal(t, character.ID, r.ID)
+			}
+		}
+	})
+	t.Run("can create new full", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		character := factory.CreateEveCharacter()
+		home := factory.CreateEveLocationStructure()
+		location := factory.CreateEveLocationStructure()
+		ship := factory.CreateEveType()
+		login := time.Now()
+		cloneJump := time.Now()
+		arg := storage.CreateCharacterParams{
+			ID:              character.ID,
+			AssetValue:      optional.New(3.4),
+			HomeID:          optional.New(home.ID),
+			LastCloneJumpAt: optional.New(cloneJump),
+			LastLoginAt:     optional.New(login),
+			LocationID:      optional.New(location.ID),
+			ShipID:          optional.New(ship.ID),
+			TotalSP:         optional.New(123),
+			WalletBalance:   optional.New(1.2),
+		}
+		// when
+		err := r.CreateCharacter(ctx, arg)
+		// then
+		if assert.NoError(t, err) {
+			r, err := r.GetCharacter(ctx, arg.ID)
+			if assert.NoError(t, err) {
+				assert.Equal(t, home, r.Home)
+				assert.Equal(t, cloneJump.UTC(), r.LastCloneJumpAt.ValueOrZero().UTC())
+				assert.Equal(t, login.UTC(), r.LastLoginAt.ValueOrZero().UTC())
+				assert.Equal(t, location, r.Location)
+				assert.Equal(t, ship, r.Ship)
+				assert.Equal(t, 123, r.TotalSP.ValueOrZero())
+				assert.Equal(t, 1.2, r.WalletBalance.ValueOrZero())
+				assert.Equal(t, 3.4, r.AssetValue.ValueOrZero())
+			}
+		}
+	})
+	t.Run("report error when character already exists", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		c1 := factory.CreateCharacter()
+		arg := storage.CreateCharacterParams{ID: c1.ID}
+		// when
+		err := r.CreateCharacter(ctx, arg)
+		// then
+		assert.ErrorIs(t, err, app.ErrAlreadyExists)
 	})
 }
 
@@ -358,7 +347,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 	t.Run("can update is training watched 2", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
-		c1 := factory.CreateCharacter(storage.UpdateOrCreateCharacterParams{IsTrainingWatched: true})
+		c1 := factory.CreateCharacter(storage.CreateCharacterParams{IsTrainingWatched: true})
 		c2, err := r.GetCharacter(ctx, c1.ID)
 		if assert.NoError(t, err) {
 			assert.True(t, c2.IsTrainingWatched)

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -1,3 +1,21 @@
+-- name: CreateCharacter :exec
+INSERT INTO
+    characters (
+        id,
+        home_id,
+        last_login_at,
+        location_id,
+        ship_id,
+        total_sp,
+        unallocated_sp,
+        wallet_balance,
+        asset_value,
+        is_training_watched,
+        last_clone_jump_at
+    )
+VALUES
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
 -- name: DeleteCharacter :exec
 DELETE FROM
     characters
@@ -152,35 +170,3 @@ SET
     asset_value = ?
 WHERE
     id = ?;
-
--- name: UpdateOrCreateCharacter :exec
-INSERT INTO
-    characters (
-        id,
-        home_id,
-        last_login_at,
-        location_id,
-        ship_id,
-        total_sp,
-        unallocated_sp,
-        wallet_balance,
-        asset_value,
-        is_training_watched,
-        last_clone_jump_at
-    )
-VALUES
-    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) ON CONFLICT(id) DO
-UPDATE
-SET
-    home_id = ?2,
-    last_login_at = ?3,
-    location_id = ?4,
-    ship_id = ?5,
-    total_sp = ?6,
-    unallocated_sp = ?7,
-    wallet_balance = ?8,
-    asset_value = ?9,
-    is_training_watched = ?10,
-    last_clone_jump_at = ?11
-WHERE
-    id = ?1;

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -10,6 +10,56 @@ import (
 	"database/sql"
 )
 
+const createCharacter = `-- name: CreateCharacter :exec
+INSERT INTO
+    characters (
+        id,
+        home_id,
+        last_login_at,
+        location_id,
+        ship_id,
+        total_sp,
+        unallocated_sp,
+        wallet_balance,
+        asset_value,
+        is_training_watched,
+        last_clone_jump_at
+    )
+VALUES
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`
+
+type CreateCharacterParams struct {
+	ID                int64
+	HomeID            sql.NullInt64
+	LastLoginAt       sql.NullTime
+	LocationID        sql.NullInt64
+	ShipID            sql.NullInt64
+	TotalSp           sql.NullInt64
+	UnallocatedSp     sql.NullInt64
+	WalletBalance     sql.NullFloat64
+	AssetValue        sql.NullFloat64
+	IsTrainingWatched bool
+	LastCloneJumpAt   sql.NullTime
+}
+
+func (q *Queries) CreateCharacter(ctx context.Context, arg CreateCharacterParams) error {
+	_, err := q.db.ExecContext(ctx, createCharacter,
+		arg.ID,
+		arg.HomeID,
+		arg.LastLoginAt,
+		arg.LocationID,
+		arg.ShipID,
+		arg.TotalSp,
+		arg.UnallocatedSp,
+		arg.WalletBalance,
+		arg.AssetValue,
+		arg.IsTrainingWatched,
+		arg.LastCloneJumpAt,
+	)
+	return err
+}
+
 const deleteCharacter = `-- name: DeleteCharacter :exec
 DELETE FROM
     characters
@@ -467,69 +517,5 @@ type UpdateCharacterWalletBalanceParams struct {
 
 func (q *Queries) UpdateCharacterWalletBalance(ctx context.Context, arg UpdateCharacterWalletBalanceParams) error {
 	_, err := q.db.ExecContext(ctx, updateCharacterWalletBalance, arg.WalletBalance, arg.ID)
-	return err
-}
-
-const updateOrCreateCharacter = `-- name: UpdateOrCreateCharacter :exec
-INSERT INTO
-    characters (
-        id,
-        home_id,
-        last_login_at,
-        location_id,
-        ship_id,
-        total_sp,
-        unallocated_sp,
-        wallet_balance,
-        asset_value,
-        is_training_watched,
-        last_clone_jump_at
-    )
-VALUES
-    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) ON CONFLICT(id) DO
-UPDATE
-SET
-    home_id = ?2,
-    last_login_at = ?3,
-    location_id = ?4,
-    ship_id = ?5,
-    total_sp = ?6,
-    unallocated_sp = ?7,
-    wallet_balance = ?8,
-    asset_value = ?9,
-    is_training_watched = ?10,
-    last_clone_jump_at = ?11
-WHERE
-    id = ?1
-`
-
-type UpdateOrCreateCharacterParams struct {
-	ID                int64
-	HomeID            sql.NullInt64
-	LastLoginAt       sql.NullTime
-	LocationID        sql.NullInt64
-	ShipID            sql.NullInt64
-	TotalSp           sql.NullInt64
-	UnallocatedSp     sql.NullInt64
-	WalletBalance     sql.NullFloat64
-	AssetValue        sql.NullFloat64
-	IsTrainingWatched bool
-	LastCloneJumpAt   sql.NullTime
-}
-
-func (q *Queries) UpdateOrCreateCharacter(ctx context.Context, arg UpdateOrCreateCharacterParams) error {
-	_, err := q.db.ExecContext(ctx, updateOrCreateCharacter,
-		arg.ID,
-		arg.HomeID,
-		arg.LastLoginAt,
-		arg.LocationID,
-		arg.ShipID,
-		arg.TotalSp,
-		arg.UnallocatedSp,
-		arg.WalletBalance,
-		arg.AssetValue,
-		arg.IsTrainingWatched,
-		arg.LastCloneJumpAt,
-	)
 	return err
 }

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -52,9 +52,9 @@ func (f Factory) RandomTime() time.Time {
 	return time.Now().Add(-d).UTC()
 }
 
-func (f Factory) CreateCharacter(args ...storage.UpdateOrCreateCharacterParams) *app.Character {
+func (f Factory) CreateCharacter(args ...storage.CreateCharacterParams) *app.Character {
 	ctx := context.TODO()
-	var arg storage.UpdateOrCreateCharacterParams
+	var arg storage.CreateCharacterParams
 	if len(args) > 0 {
 		arg = args[0]
 	}
@@ -86,7 +86,7 @@ func (f Factory) CreateCharacter(args ...storage.UpdateOrCreateCharacterParams) 
 	if arg.AssetValue.IsEmpty() {
 		arg.AssetValue = optional.New(rand.Float64() * 100_000_000_000)
 	}
-	err := f.st.UpdateOrCreateCharacter(ctx, arg)
+	err := f.st.CreateCharacter(ctx, arg)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/genchars/builder.go
+++ b/tools/genchars/builder.go
@@ -116,7 +116,7 @@ func (b *CharacterBuilder) createCharacter() {
 		Name:       c.Name,
 		ID:         c.ID,
 	})
-	b.c = b.f.CreateCharacter(storage.UpdateOrCreateCharacterParams{
+	b.c = b.f.CreateCharacter(storage.CreateCharacterParams{
 		ID: ec.ID,
 	})
 	b.f.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID})


### PR DESCRIPTION
This PR replaces the UpdateOrCreateCharater() method with a CreateCharater() and makes it return a new error code `app.ErrAlreadyExists` to signal when the character already exists.