### PR TITLE
fix: asset tree widget crashes when no character

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.23.1"
+  Version = "0.23.2"
   Build = 1
 
 [Release]

--- a/internal/app/ui/characterassets.go
+++ b/internal/app/ui/characterassets.go
@@ -255,7 +255,7 @@ func (a *CharacterAssets) Update() {
 
 func (a *CharacterAssets) makeLocationData() (*iwidget.TreeData[locationNode], error) {
 	if !a.u.HasCharacter() {
-		return nil, nil
+		return iwidget.NewTreeData[locationNode](), nil
 	}
 	characterID := a.u.CurrentCharacterID()
 	ctx := context.Background()

--- a/internal/app/ui/characterassets_internal_test.go
+++ b/internal/app/ui/characterassets_internal_test.go
@@ -3,15 +3,11 @@ package ui
 import (
 	"testing"
 
+	"fyne.io/fyne/v2/test"
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/assetcollection"
-	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
 	"github.com/stretchr/testify/assert"
 )
-
-type FakeEveUniverseService struct {
-	eveuniverseservice.EveUniverseService
-}
 
 func TestCharacterAssetsMakeLocationTreeData(t *testing.T) {
 	t.Run("can create simple tree", func(t *testing.T) {
@@ -79,4 +75,13 @@ func TestSplitLines(t *testing.T) {
 			assert.Equal(t, tc.want2, got2)
 		})
 	}
+}
+
+func TestCharacterAssets(t *testing.T) {
+	t.Run("can update without data", func(t *testing.T) {
+		app := test.NewTempApp(t)
+		ui := NewBaseUI(BaseUIParams{App: app})
+		w := NewCharacterAssets(ui)
+		w.Update()
+	})
 }


### PR DESCRIPTION
Alternative fix for issue reporting in #113 
