### PR TITLE
feat: config for prefering market tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ deploy-android:
 install-android:
 	adb install -r -d EVE_Buddy.apk
 
+interface_settings:
+	ifacemaker -s Settings -i Settings -p app -f internal/app/settings/settings.go -o internal/app/settings.go
+
 interfaces:
 	ifacemaker -s BaseUI -i UI -p app -f internal/app/ui/ui.go -o internal/app/ui.go
-	ifacemaker -s Settings -i Settings -p app -f internal/app/settings/settings.go -o internal/app/settings.go
+	interface_settings
 	ifacemaker -s EveUniverseService -i EveUniverseService -p app -o internal/app/eveuniverseservice.go -f internal/app/eveuniverseservice/eveuniverseservice.go
 	ifacemaker -s CharacterService -i CharacterService -p app -o internal/app/characterservice.go -f internal/app/characterservice/characterservice.go

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -75,4 +75,7 @@ type Settings interface {
 	TabsMainID() int
 	RecentSearches() []int32
 	SetRecentSearches(v []int32)
+	PreferMarketTab() bool
+	ResetPreferMarketTab()
+	SetPreferMarketTab(v bool)
 }

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -45,6 +45,7 @@ const (
 	settingNotifyTrainingEarliest             = "settingNotifyTrainingEarliest"
 	settingNotifyTrainingEnabled              = "settingNotifyTrainingEnabled"
 	settingNotifyTrainingEnabledDefault       = false
+	settingRecentSearches                     = "settingRecentSearches"
 	settingSysTrayEnabled                     = "settingSysTrayEnabled"
 	settingSysTrayEnabledDefault              = false
 	settingTabsMainID                         = "tabs-main-id"
@@ -52,7 +53,7 @@ const (
 	settingWindowHeightDefault                = 600
 	settingWindowsSize                        = "window-size"
 	settingWindowWidthDefault                 = 1000
-	settingRecentSearches                     = "settingRecentSearches"
+	settingPreferMarketTab                    = "settingPreferMarketTab"
 )
 
 // Settings represents the settings for the app and provides an API for reading and writing settings.
@@ -390,6 +391,17 @@ func (s Settings) SetRecentSearches(v []int32) {
 	s.p.SetIntList(settingRecentSearches, xslices.Map(v, func(x int32) int {
 		return int(x)
 	}))
+}
+
+func (s Settings) PreferMarketTab() bool {
+	return s.p.Bool(settingPreferMarketTab)
+}
+func (s Settings) ResetPreferMarketTab() {
+	s.SetPreferMarketTab(false)
+}
+
+func (s Settings) SetPreferMarketTab(v bool) {
+	s.p.SetBool(settingPreferMarketTab, v)
 }
 
 // Keys returns all setting keys. Mostly to know what to delete.

--- a/internal/app/ui/infowindow/infowindow.go
+++ b/internal/app/ui/infowindow/infowindow.go
@@ -39,6 +39,7 @@ type UI interface {
 	IsOffline() bool
 	MainWindow() fyne.Window
 	MakeWindowTitle(subTitle string) string
+	Settings() app.Settings
 	ShowErrorDialog(message string, err error, parent fyne.Window)
 	ShowInformationDialog(title, message string, parent fyne.Window)
 	StatusCacheService() app.StatusCacheService

--- a/internal/app/ui/infowindow/inventorytype.go
+++ b/internal/app/ui/infowindow/inventorytype.go
@@ -122,11 +122,12 @@ func (a *inventoryTypeInfo) CreateRenderer() fyne.WidgetRenderer {
 		requirementsTab = container.NewTabItem("Requirements", a.makeRequirementsTab())
 		tabs.Append(requirementsTab)
 	}
-	if a.price != nil {
-		tabs.Append(container.NewTabItem("Market", a.makeMarketTab()))
-	}
+	marketTab := container.NewTabItem("Market", a.makeMarketTab())
+	tabs.Append(marketTab)
 	// Set initial tab
-	if requirementsTab != nil && a.et.Group.Category.ID == app.EveCategorySkill {
+	if a.iw.u.Settings().PreferMarketTab() && a.et.IsTradeable() {
+		tabs.Select(marketTab)
+	} else if requirementsTab != nil && a.et.Group.Category.ID == app.EveCategorySkill {
 		tabs.Select(requirementsTab)
 	} else if attributeTab != nil &&
 		set.NewFromSlice([]int32{

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -142,6 +142,16 @@ func (a *UserSettings) makeGeneralSettingsPage() (fyne.CanvasObject, []app.Setti
 		},
 		a.currentWindow,
 	)
+	preferMarketTab := iwidget.NewSettingItemSwitch(
+		"Prefer market tab",
+		"Show market tab for tradeable items",
+		func() bool {
+			return a.u.Settings().PreferMarketTab()
+		},
+		func(v bool) {
+			a.u.Settings().SetPreferMarketTab(v)
+		},
+	)
 	developerMode := iwidget.NewSettingItemSwitch(
 		"Developer Mode",
 		"App shows addditional technical information like Character IDs",
@@ -156,6 +166,7 @@ func (a *UserSettings) makeGeneralSettingsPage() (fyne.CanvasObject, []app.Setti
 	items := []iwidget.SettingItem{
 		iwidget.NewSettingItemHeading("Application"),
 		logLevel,
+		preferMarketTab,
 		developerMode,
 		iwidget.NewSettingItemSeperator(),
 		iwidget.NewSettingItemHeading("EVE Online"),
@@ -214,6 +225,7 @@ func (a *UserSettings) makeGeneralSettingsPage() (fyne.CanvasObject, []app.Setti
 	reset := app.SettingAction{
 		Label: "Reset to defaults",
 		Action: func() {
+			a.u.Settings().ResetPreferMarketTab()
 			a.u.Settings().ResetDeveloperMode()
 			a.u.Settings().ResetLogLevel()
 			a.u.Settings().ResetMaxMails()


### PR DESCRIPTION
Users can choose to always show the market tab first when opening an info window for a trade-able type.

This can be configured through a setting.

Fixes #126 