### PR TITLE
feat: improve set type

### DIFF
--- a/internal/app/characterservice/characterservice_internal_test.go
+++ b/internal/app/characterservice/characterservice_internal_test.go
@@ -103,7 +103,7 @@ func TestUpdateCharacterAssetsESI(t *testing.T) {
 			assert.True(t, changed)
 			ids, err := st.ListCharacterAssetIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2)
+				assert.Equal(t, 2, ids.Size())
 				x, err := st.GetCharacterAsset(ctx, c.ID, 1000000016835)
 				if assert.NoError(t, err) {
 					assert.Equal(t, eveType.ID, x.Type.ID)
@@ -248,7 +248,7 @@ func TestUpdateCharacterAssetsESI(t *testing.T) {
 			assert.True(t, changed)
 			ids, err := st.ListCharacterAssetIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2)
+				assert.Equal(t, 2, ids.Size())
 				x, err := st.GetCharacterAsset(ctx, c.ID, 1000000016835)
 				if assert.NoError(t, err) {
 					assert.Equal(t, eveType.ID, x.Type.ID)
@@ -1206,7 +1206,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -1249,7 +1249,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2)
+				assert.Equal(t, 2, ids.Size())
 			}
 		}
 	})
@@ -1290,7 +1290,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -1992,7 +1992,7 @@ func TestUpdateWalletJournalEntryESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterWalletJournalEntryIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -2037,7 +2037,7 @@ func TestUpdateWalletJournalEntryESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterWalletJournalEntryIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2)
+				assert.Equal(t, 2, ids.Size())
 			}
 		}
 	})
@@ -2085,7 +2085,7 @@ func TestUpdateWalletJournalEntryESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterWalletJournalEntryIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -2142,7 +2142,7 @@ func TestUpdateWalletJournalEntryESI(t *testing.T) {
 			assert.True(t, changed)
 			ids, err := st.ListCharacterWalletJournalEntryIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				if assert.Len(t, ids, 2) {
+				if assert.Equal(t, 2, ids.Size()) {
 					x1, err := st.GetCharacterWalletJournalEntry(ctx, c.ID, 89)
 					if assert.NoError(t, err) {
 						assert.Equal(t, "First", x1.Description)
@@ -2233,7 +2233,7 @@ func TestUpdateWalletTransactionESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterWalletTransactionIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -2286,7 +2286,7 @@ func TestUpdateWalletTransactionESI(t *testing.T) {
 			}
 			ids, err := st.ListCharacterWalletTransactionIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2)
+				assert.Equal(t, 2, ids.Size())
 			}
 		}
 	})
@@ -2326,7 +2326,7 @@ func TestUpdateWalletTransactionESI(t *testing.T) {
 		if assert.NoError(t, err) {
 			ids, err := st.ListCharacterWalletTransactionIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 1)
+				assert.Equal(t, 1, ids.Size())
 			}
 		}
 	})
@@ -2385,7 +2385,7 @@ func TestUpdateWalletTransactionESI(t *testing.T) {
 		if assert.NoError(t, err) {
 			ids, err := st.ListCharacterWalletTransactionIDs(ctx, c.ID)
 			if assert.NoError(t, err) {
-				assert.Len(t, ids, 2501)
+				assert.Equal(t, 2501, ids.Size())
 			}
 		}
 	})

--- a/internal/app/eveuniverseservice/eveuniverseservice.go
+++ b/internal/app/eveuniverseservice/eveuniverseservice.go
@@ -482,7 +482,7 @@ func (s *EveUniverseService) ToEntities(ctx context.Context, ids []int32) (map[i
 		return r, nil
 	}
 	ids2 := set.NewFromSlice(ids)
-	ids2.Remove(0)
+	ids2.Discard(0)
 	ids3 := ids2.ToSlice()
 	if _, err := s.AddMissingEntities(ctx, ids3); err != nil {
 		return nil, err
@@ -512,11 +512,11 @@ func (s *EveUniverseService) AddMissingEntities(ctx context.Context, ids []int32
 	var badIDs, missingIDs []int32
 	err := func() error {
 		ids2 := set.NewFromSlice(ids)
-		ids2.Remove(0) // do nothing with ID 0
+		ids2.Discard(0) // do nothing with ID 0
 		for _, id := range invalidEveEntityIDs {
 			if ids2.Contains(id) {
 				badIDs = append(badIDs, 1)
-				ids2.Remove(1)
+				ids2.Discard(1)
 			}
 		}
 		if ids2.Size() == 0 {

--- a/internal/app/eveuniverseservice/eveuniverseservice.go
+++ b/internal/app/eveuniverseservice/eveuniverseservice.go
@@ -179,10 +179,10 @@ func (s *EveUniverseService) UpdateAllCharactersESI(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(ids) == 0 {
+	if ids.Size() == 0 {
 		return nil
 	}
-	slog.Info("Started updating eve characters", "count", len(ids))
+	slog.Info("Started updating eve characters", "count", ids.Size())
 	g := new(errgroup.Group)
 	g.SetLimit(10)
 	for id := range ids.Values() {
@@ -194,7 +194,7 @@ func (s *EveUniverseService) UpdateAllCharactersESI(ctx context.Context) error {
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("update EveCharacters: %w", err)
 	}
-	slog.Info("Finished updating eve characters", "count", len(ids))
+	slog.Info("Finished updating eve characters", "count", ids.Size())
 	return nil
 }
 

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -172,7 +172,7 @@ func (st *Storage) ListCharactersShort(ctx context.Context) ([]*app.CharacterSho
 func (st *Storage) ListCharacterIDs(ctx context.Context) (set.Set[int32], error) {
 	ids, err := st.qRO.ListCharacterIDs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list character IDs: %w", err)
+		return set.Set[int32]{}, fmt.Errorf("list character IDs: %w", err)
 	}
 	ids2 := set.NewFromSlice(convertNumericSlice[int32](ids))
 	return ids2, nil

--- a/internal/app/storage/characterasset.go
+++ b/internal/app/storage/characterasset.go
@@ -82,7 +82,7 @@ func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, charac
 func (st *Storage) ListCharacterAssetIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
 	ids, err := st.qRO.ListCharacterAssetIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list character asset IDs: %w", err)
+		return set.Set[int64]{}, fmt.Errorf("list character asset IDs: %w", err)
 	}
 	return set.NewFromSlice(ids), nil
 }

--- a/internal/app/storage/charactercontractbid.go
+++ b/internal/app/storage/charactercontractbid.go
@@ -62,7 +62,7 @@ func (st *Storage) ListCharacterContractBids(ctx context.Context, contractID int
 func (st *Storage) ListCharacterContractBidIDs(ctx context.Context, contractID int64) (set.Set[int32], error) {
 	ids, err := st.qRO.ListCharacterContractBidIDs(ctx, contractID)
 	if err != nil {
-		return nil, fmt.Errorf("list bid IDs for contract %d: %w", contractID, err)
+		return set.Set[int32]{}, fmt.Errorf("list bid IDs for contract %d: %w", contractID, err)
 	}
 	return set.NewFromSlice(convertNumericSlice[int32](ids)), err
 }

--- a/internal/app/storage/charactermail.go
+++ b/internal/app/storage/charactermail.go
@@ -194,7 +194,7 @@ func (st *Storage) GetCharacterMailListUnreadCounts(ctx context.Context, charact
 func (st *Storage) ListCharacterMailIDs(ctx context.Context, characterID int32) (set.Set[int32], error) {
 	ids, err := st.qRO.ListMailIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list mail IDs for character %d: %w", characterID, err)
+		return set.Set[int32]{}, fmt.Errorf("list mail IDs for character %d: %w", characterID, err)
 	}
 	return set.NewFromSlice(convertNumericSlice[int32](ids)), nil
 }

--- a/internal/app/storage/characternotification.go
+++ b/internal/app/storage/characternotification.go
@@ -94,7 +94,7 @@ func (st *Storage) GetOrCreateNotificationType(ctx context.Context, name string)
 func (st *Storage) ListCharacterNotificationIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
 	ids, err := st.qRO.ListCharacterNotificationIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list character notification ids for character %d: %w", characterID, err)
+		return set.Set[int64]{}, fmt.Errorf("list character notification ids for character %d: %w", characterID, err)
 	}
 	return set.NewFromSlice(ids), nil
 }

--- a/internal/app/storage/characterskill.go
+++ b/internal/app/storage/characterskill.go
@@ -42,7 +42,7 @@ func (st *Storage) GetCharacterSkill(ctx context.Context, characterID int32, typ
 func (st *Storage) ListCharacterSkillIDs(ctx context.Context, characterID int32) (set.Set[int32], error) {
 	ids1, err := st.qRO.ListCharacterSkillIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list skill ids for character %d: %w", characterID, err)
+		return set.Set[int32]{}, fmt.Errorf("list skill ids for character %d: %w", characterID, err)
 	}
 	ids2 := set.NewFromSlice(convertNumericSlice[int32](ids1))
 	return ids2, nil

--- a/internal/app/storage/characterwalletjournal.go
+++ b/internal/app/storage/characterwalletjournal.go
@@ -84,7 +84,7 @@ func (st *Storage) GetCharacterWalletJournalEntry(ctx context.Context, character
 func (st *Storage) ListCharacterWalletJournalEntryIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
 	ids, err := st.qRO.ListCharacterWalletJournalEntryRefIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list wallet journal entry ids for character %d: %w", characterID, err)
+		return set.Set[int64]{}, fmt.Errorf("list wallet journal entry ids for character %d: %w", characterID, err)
 	}
 	return set.NewFromSlice(ids), nil
 }

--- a/internal/app/storage/characterwallettransaction.go
+++ b/internal/app/storage/characterwallettransaction.go
@@ -72,7 +72,7 @@ func (st *Storage) GetCharacterWalletTransaction(ctx context.Context, characterI
 func (st *Storage) ListCharacterWalletTransactionIDs(ctx context.Context, characterID int32) (set.Set[int64], error) {
 	ids, err := st.qRO.ListCharacterWalletTransactionIDs(ctx, int64(characterID))
 	if err != nil {
-		return nil, fmt.Errorf("list wallet transaction ids for character %d: %w", characterID, err)
+		return set.Set[int64]{}, fmt.Errorf("list wallet transaction ids for character %d: %w", characterID, err)
 	}
 	return set.NewFromSlice(ids), nil
 }

--- a/internal/app/storage/evecharacter.go
+++ b/internal/app/storage/evecharacter.go
@@ -95,7 +95,7 @@ func (st *Storage) GetEveCharacter(ctx context.Context, characterID int32) (*app
 func (st *Storage) ListEveCharacterIDs(ctx context.Context) (set.Set[int32], error) {
 	ids, err := st.qRO.ListEveCharacterIDs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list EveCharacterIDs: %w", err)
+		return set.Set[int32]{}, fmt.Errorf("list EveCharacterIDs: %w", err)
 	}
 	ids2 := set.NewFromSlice(convertNumericSlice[int32](ids))
 	return ids2, nil

--- a/internal/app/storage/eveentity.go
+++ b/internal/app/storage/eveentity.go
@@ -184,7 +184,7 @@ func (st *Storage) ListEveEntitiesForIDs(ctx context.Context, ids []int32) ([]*a
 // IDs with value 0 are ignored.
 func (st *Storage) MissingEveEntityIDs(ctx context.Context, ids []int32) (set.Set[int32], error) {
 	incoming := set.NewFromSlice(ids)
-	incoming.Remove(0)
+	incoming.Discard(0)
 	current, err := st.ListEveEntityIDs(ctx)
 	if err != nil {
 		return set.New[int32](), err

--- a/internal/app/storage/eveentity.go
+++ b/internal/app/storage/eveentity.go
@@ -135,7 +135,7 @@ func (st *Storage) ListEveEntitiesByPartialName(ctx context.Context, partial str
 func (st *Storage) ListEveEntityIDs(ctx context.Context) (set.Set[int32], error) {
 	ids, err := st.qRO.ListEveEntityIDs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list eve entity id: %w", err)
+		return set.Set[int32]{}, fmt.Errorf("list eve entity id: %w", err)
 	}
 	ids2 := set.NewFromSlice(convertNumericSlice[int32](ids))
 	return ids2, nil

--- a/internal/app/ui/overviewlocations.go
+++ b/internal/app/ui/overviewlocations.go
@@ -133,6 +133,6 @@ func (a *OverviewLocations) updateCharacters() (int, error) {
 		}
 		return 0
 	}))
-	locationIDs.Remove(0)
+	locationIDs.Discard(0)
 	return locationIDs.Size(), nil
 }

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -487,7 +487,7 @@ func (a *UserSettings) makeNotificationPage() (fyne.CanvasObject, []settingActio
 						if on {
 							typesEnabled.Add(ntStr)
 						} else {
-							typesEnabled.Remove(ntStr)
+							typesEnabled.Discard(ntStr)
 						}
 						a.u.settings.SetNotificationTypesEnabled(typesEnabled)
 					},

--- a/internal/deleteapp/deleteapp.go
+++ b/internal/deleteapp/deleteapp.go
@@ -132,6 +132,6 @@ func (u *UI) removeFolders(ctx context.Context, pb *widget.ProgressBar) error {
 	for k := range keys.Values() {
 		u.app.Preferences().RemoveValue(k)
 	}
-	slog.Info("Deleted setting keys", "count", len(keys))
+	slog.Info("Deleted setting keys", "count", keys.Size())
 	return nil
 }

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -14,13 +14,17 @@ var ErrNotFound = errors.New("not found")
 //
 // Sets are not thread safe.
 // Sets must be initialized with New() before use.
-type Set[T comparable] map[T]struct{}
+type Set[T comparable] struct {
+	m map[T]struct{}
+}
 
 // New returns a new Set.
 func New[T comparable](vals ...T) Set[T] {
-	s := Set[T]{}
+	s := Set[T]{
+		m: make(map[T]struct{}),
+	}
 	for _, v := range vals {
-		s[v] = struct{}{}
+		s.m[v] = struct{}{}
 	}
 	return s
 }
@@ -41,13 +45,13 @@ func Collect[T comparable](seq iter.Seq[T]) Set[T] {
 
 // Add adds an element to the set
 func (s Set[T]) Add(v T) {
-	s[v] = struct{}{}
+	s.m[v] = struct{}{}
 }
 
 // Clear removes all elements from a set.
 func (s Set[T]) Clear() {
-	for k := range s {
-		delete(s, k)
+	for k := range s.m {
+		delete(s.m, k)
 	}
 }
 
@@ -58,7 +62,7 @@ func (s Set[T]) Clone() Set[T] {
 
 // Contains reports whether an item is in this set.
 func (s Set[T]) Contains(v T) bool {
-	_, ok := s[v]
+	_, ok := s.m[v]
 	return ok
 }
 
@@ -66,7 +70,7 @@ func (s Set[T]) Contains(v T) bool {
 // that does not exist in other set.
 func (s Set[T]) Difference(u Set[T]) Set[T] {
 	n := New[T]()
-	for v := range s {
+	for v := range s.m {
 		if !u.Contains(v) {
 			n.Add(v)
 		}
@@ -87,7 +91,7 @@ func (s Set[T]) Equal(u Set[T]) bool {
 // Intersect returns a new set which contains elements found in both sets only.
 func (s Set[T]) Intersect(u Set[T]) Set[T] {
 	n := New[T]()
-	for v := range s {
+	for v := range s.m {
 		if u.Contains(v) {
 			n.Add(v)
 		}
@@ -116,14 +120,14 @@ func (s Set[T]) IsSuperset(u Set[T]) bool {
 // Remove removes an element from a set.
 // It does nothing when the element doesn't exist.
 func (s Set[T]) Remove(v T) {
-	delete(s, v)
+	delete(s.m, v)
 }
 
 // Pop removes a random element from a set and returns it.
 // Or if the set is empty an error is returned.
 func (s Set[T]) Pop() (T, error) {
-	for v := range s {
-		delete(s, v)
+	for v := range s.m {
+		delete(s.m, v)
 		return v, nil
 	}
 	var x T
@@ -132,7 +136,7 @@ func (s Set[T]) Pop() (T, error) {
 
 // Size returns the number of elements in a set.
 func (s Set[T]) Size() int {
-	return len(s)
+	return len(s.m)
 }
 
 func (s Set[T]) String() string {
@@ -143,7 +147,7 @@ func (s Set[T]) String() string {
 // Note that the elements in the slice have no defined order.
 func (s Set[T]) ToSlice() []T {
 	slice := make([]T, 0, s.Size())
-	for v := range s {
+	for v := range s.m {
 		slice = append(slice, v)
 	}
 	return slice
@@ -152,7 +156,7 @@ func (s Set[T]) ToSlice() []T {
 // Union returns a new set containing the combined elements from both sets.
 func (s Set[T]) Union(u Set[T]) Set[T] {
 	n := s.Clone()
-	for v := range u {
+	for v := range u.m {
 		n.Add(v)
 	}
 	return n
@@ -162,5 +166,5 @@ func (s Set[T]) Union(u Set[T]) Set[T] {
 //
 // Since sets are unordered, elements will be returned in no particular order.
 func (s Set[T]) Values() iter.Seq[T] {
-	return maps.Keys(s)
+	return maps.Keys(s.m)
 }


### PR DESCRIPTION
The current set type needs to be initialized with New(). If a zero value of a set is used in the wrong way it will panic.

This PR improves the set type so that the zero value is an empty set and can be used normally.

It also adds MustPop() to the API.

And it improves the test suite and documentation for the set package.