### PR TITLE
feat: ability to update all entities at once & fixes

### DIFF
--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -2822,7 +2822,7 @@ func (s *CharacterService) UpdateSectionIfNeeded(ctx context.Context, arg app.Ch
 		return false, fmt.Errorf("update character section from ESI for %v: %w", arg, err)
 	}
 	changed := x.(bool)
-	slog.Info("Character section update completed", "characterID", arg.CharacterID, "section", arg.Section, "changed", changed)
+	slog.Info("Character section update completed", "characterID", arg.CharacterID, "section", arg.Section, "forced", arg.ForceUpdate, "changed", changed)
 	return changed, err
 }
 

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -1141,6 +1141,10 @@ func (s *CharacterService) updateIndustryJobsESI(ctx context.Context, arg app.Ch
 				if !ok {
 					status = app.JobUndefined
 				}
+				if status == app.JobActive && !j.EndDate.IsZero() && j.EndDate.Before(time.Now()) {
+					// Workaround for known bug: https://github.com/esi/esi-issues/issues/752
+					status = app.JobReady
+				}
 				arg := storage.UpdateOrCreateCharacterIndustryJobParams{
 					ActivityID:           j.ActivityId,
 					BlueprintID:          j.BlueprintId,

--- a/internal/app/characterservice/character_internal_test.go
+++ b/internal/app/characterservice/character_internal_test.go
@@ -762,8 +762,7 @@ func TestUpdateCharacterIndustryJobsESI(t *testing.T) {
 				assert.EqualValues(t, 1, x.Runs)
 				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
 				assert.EqualValues(t, 60006382, x.Station.ID)
-				assert.Equal(t, app.JobActive, x.Status)
-
+				assert.Equal(t, app.JobReady, x.Status)
 			}
 		}
 	})
@@ -784,9 +783,70 @@ func TestUpdateCharacterIndustryJobsESI(t *testing.T) {
 			OutputLocationID:    location.ID,
 			FacilityID:          location.ID,
 			StationID:           location.ID,
-			Status:              app.JobDelivered,
+			Status:              app.JobActive,
 			EndDate:             time.Now(),
 		})
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/v1/characters/%d/industry/jobs/?include_completed=true", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{
+					"activity_id":           1,
+					"blueprint_id":          1015116533326,
+					"blueprint_location_id": 60006382,
+					"blueprint_type_id":     2047,
+					"cost":                  118.01,
+					"duration":              548,
+					"end_date":              "2014-07-19T15:56:14Z",
+					"facility_id":           60006382,
+					"installer_id":          498338451,
+					"job_id":                229136101,
+					"licensed_runs":         200,
+					"output_location_id":    60006382,
+					"runs":                  1,
+					"start_date":            "2014-07-19T15:47:06Z",
+					"station_id":            60006382,
+					"status":                "delivered",
+				},
+			}))
+
+		// when
+		changed, err := s.updateIndustryJobsESI(ctx, app.CharacterUpdateSectionParams{
+			CharacterID: c.ID,
+			Section:     app.SectionIndustryJobs,
+		})
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			x, err := st.GetCharacterIndustryJob(ctx, c.ID, 229136101)
+			if assert.NoError(t, err) {
+				assert.Equal(t, app.Manufacturing, x.Activity)
+				assert.EqualValues(t, 1015116533326, x.BlueprintID)
+				assert.EqualValues(t, 60006382, x.BlueprintLocation.ID)
+				assert.EqualValues(t, 118.01, x.Cost.MustValue())
+				assert.EqualValues(t, 548, x.Duration)
+				assert.Equal(t, time.Date(2014, 7, 19, 15, 56, 14, 0, time.UTC), x.EndDate)
+				assert.EqualValues(t, 60006382, x.Facility.ID)
+				assert.EqualValues(t, 498338451, x.Installer.ID)
+				assert.EqualValues(t, 229136101, x.JobID)
+				assert.EqualValues(t, 200, x.LicensedRuns.MustValue())
+				assert.EqualValues(t, 60006382, x.OutputLocation.ID)
+				assert.EqualValues(t, 1, x.Runs)
+				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
+				assert.EqualValues(t, 60006382, x.Station.ID)
+				assert.Equal(t, app.JobDelivered, x.Status)
+			}
+		}
+	})
+	t.Run("should fix incorrect status", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID})
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2047})
+		factory.CreateEveEntityCharacter(app.EveEntity{ID: 498338451})
+		factory.CreateEveLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60006382})
 		httpmock.RegisterResponder(
 			"GET",
 			fmt.Sprintf("https://esi.evetech.net/v1/characters/%d/industry/jobs/?include_completed=true", c.ID),
@@ -821,22 +881,57 @@ func TestUpdateCharacterIndustryJobsESI(t *testing.T) {
 			assert.True(t, changed)
 			x, err := st.GetCharacterIndustryJob(ctx, c.ID, 229136101)
 			if assert.NoError(t, err) {
-				assert.Equal(t, app.Manufacturing, x.Activity)
-				assert.EqualValues(t, 1015116533326, x.BlueprintID)
-				assert.EqualValues(t, 60006382, x.BlueprintLocation.ID)
-				assert.EqualValues(t, 118.01, x.Cost.MustValue())
-				assert.EqualValues(t, 548, x.Duration)
-				assert.Equal(t, time.Date(2014, 7, 19, 15, 56, 14, 0, time.UTC), x.EndDate)
-				assert.EqualValues(t, 60006382, x.Facility.ID)
-				assert.EqualValues(t, 498338451, x.Installer.ID)
-				assert.EqualValues(t, 229136101, x.JobID)
-				assert.EqualValues(t, 200, x.LicensedRuns.MustValue())
-				assert.EqualValues(t, 60006382, x.OutputLocation.ID)
-				assert.EqualValues(t, 1, x.Runs)
-				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
-				assert.EqualValues(t, 60006382, x.Station.ID)
-				assert.Equal(t, app.JobActive, x.Status)
 
+				assert.Equal(t, app.JobReady, x.Status)
+			}
+		}
+	})
+	t.Run("should not fix status when correct", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID})
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2047})
+		factory.CreateEveEntityCharacter(app.EveEntity{ID: 498338451})
+		factory.CreateEveLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60006382})
+		startDate := time.Now().Add(-24 * time.Hour)
+		endDate := time.Now().Add(+3 * time.Hour)
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/v1/characters/%d/industry/jobs/?include_completed=true", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{
+					"activity_id":           1,
+					"blueprint_id":          1015116533326,
+					"blueprint_location_id": 60006382,
+					"blueprint_type_id":     2047,
+					"cost":                  118.01,
+					"duration":              548,
+					"end_date":              endDate.Format("2006-01-02T15:04:05Z"),
+					"facility_id":           60006382,
+					"installer_id":          498338451,
+					"job_id":                229136101,
+					"licensed_runs":         200,
+					"output_location_id":    60006382,
+					"runs":                  1,
+					"start_date":            startDate.Format("2006-01-02T15:04:05Z"),
+					"station_id":            60006382,
+					"status":                "active",
+				},
+			}))
+
+		// when
+		changed, err := s.updateIndustryJobsESI(ctx, app.CharacterUpdateSectionParams{
+			CharacterID: c.ID,
+			Section:     app.SectionIndustryJobs,
+		})
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			x, err := st.GetCharacterIndustryJob(ctx, c.ID, 229136101)
+			if assert.NoError(t, err) {
+				assert.Equal(t, app.JobActive, x.Status)
 			}
 		}
 	})

--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -159,6 +159,10 @@ func (s *CorporationService) updateIndustryJobsESI(ctx context.Context, arg app.
 				if !ok {
 					status = app.JobUndefined
 				}
+				if status == app.JobActive && !j.EndDate.IsZero() && j.EndDate.Before(time.Now()) {
+					// Workaround for known bug: https://github.com/esi/esi-issues/issues/752
+					status = app.JobReady
+				}
 				arg := storage.UpdateOrCreateCorporationIndustryJobParams{
 					ActivityID:           j.ActivityId,
 					BlueprintID:          j.BlueprintId,

--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -243,7 +243,7 @@ func (s *CorporationService) UpdateSectionIfNeeded(ctx context.Context, arg app.
 		return false, fmt.Errorf("update corporation section from ESI for %v: %w", arg, err)
 	}
 	changed := x.(bool)
-	slog.Info("Corporation section update completed", "corporationID", arg.CorporationID, "section", arg.Section, "changed", changed)
+	slog.Info("Corporation section update completed", "corporationID", arg.CorporationID, "section", arg.Section, "forced", arg.ForceUpdate, "changed", changed)
 	return changed, err
 }
 

--- a/internal/app/corporationservice/corporation_internal_test.go
+++ b/internal/app/corporationservice/corporation_internal_test.go
@@ -109,7 +109,7 @@ func TestUpdateIndustryJobsESI(t *testing.T) {
 				assert.EqualValues(t, 1, x.Runs)
 				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
 				assert.EqualValues(t, 60006382, x.Location.ID)
-				assert.Equal(t, app.JobActive, x.Status)
+				assert.Equal(t, app.JobReady, x.Status)
 			}
 		}
 	})
@@ -133,8 +133,73 @@ func TestUpdateIndustryJobsESI(t *testing.T) {
 			LocationID:          location.ID,
 			OutputLocationID:    location.ID,
 			ProductTypeID:       productType.ID,
-			Status:              app.JobDelivered,
+			Status:              app.JobActive,
 		})
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi\.evetech\.net/v\d+/corporations/\d+/industry/jobs/\?include_completed=true`,
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{
+					"activity_id":           1,
+					"blueprint_id":          1015116533326,
+					"blueprint_location_id": 11,
+					"blueprint_type_id":     2047,
+					"cost":                  118.01,
+					"duration":              548,
+					"end_date":              "2014-07-19T15:56:14Z",
+					"facility_id":           12,
+					"installer_id":          498338451,
+					"job_id":                229136101,
+					"licensed_runs":         200,
+					"location_id":           60006382,
+					"output_location_id":    13,
+					"product_type_id":       2046,
+					"runs":                  1,
+					"start_date":            "2014-07-19T15:47:06Z",
+					"status":                "delivered",
+				},
+			}),
+		)
+		// when
+		changed, err := s.updateIndustryJobsESI(ctx, app.CorporationUpdateSectionParams{
+			CorporationID: c.ID,
+			Section:       app.SectionCorporationIndustryJobs,
+		})
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			x, err := st.GetCorporationIndustryJob(ctx, c.ID, 229136101)
+			if assert.NoError(t, err) {
+				assert.Equal(t, app.Manufacturing, x.Activity)
+				assert.EqualValues(t, 1015116533326, x.BlueprintID)
+				assert.EqualValues(t, 2047, x.BlueprintType.ID)
+				assert.EqualValues(t, 11, x.BlueprintLocationID)
+				assert.EqualValues(t, 118.01, x.Cost.MustValue())
+				assert.EqualValues(t, 548, x.Duration)
+				assert.Equal(t, time.Date(2014, 7, 19, 15, 56, 14, 0, time.UTC), x.EndDate)
+				assert.EqualValues(t, 12, x.FacilityID)
+				assert.EqualValues(t, 498338451, x.Installer.ID)
+				assert.EqualValues(t, 229136101, x.JobID)
+				assert.EqualValues(t, 200, x.LicensedRuns.MustValue())
+				assert.EqualValues(t, 13, x.OutputLocationID)
+				assert.EqualValues(t, 1, x.Runs)
+				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
+				assert.EqualValues(t, 60006382, x.Location.ID)
+				assert.Equal(t, app.JobDelivered, x.Status)
+
+			}
+		}
+	})
+	t.Run("should fix incorrect status", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		httpmock.Reset()
+		s := NewFake(st, Params{CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+		c := factory.CreateCorporation()
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2047})
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2046})
+		factory.CreateEveEntityCharacter(app.EveEntity{ID: 498338451})
+		factory.CreateEveLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60006382})
 		httpmock.RegisterResponder(
 			"GET",
 			`=~^https://esi\.evetech\.net/v\d+/corporations/\d+/industry/jobs/\?include_completed=true`,
@@ -170,23 +235,58 @@ func TestUpdateIndustryJobsESI(t *testing.T) {
 			assert.True(t, changed)
 			x, err := st.GetCorporationIndustryJob(ctx, c.ID, 229136101)
 			if assert.NoError(t, err) {
-				assert.Equal(t, app.Manufacturing, x.Activity)
-				assert.EqualValues(t, 1015116533326, x.BlueprintID)
-				assert.EqualValues(t, 2047, x.BlueprintType.ID)
-				assert.EqualValues(t, 11, x.BlueprintLocationID)
-				assert.EqualValues(t, 118.01, x.Cost.MustValue())
-				assert.EqualValues(t, 548, x.Duration)
-				assert.Equal(t, time.Date(2014, 7, 19, 15, 56, 14, 0, time.UTC), x.EndDate)
-				assert.EqualValues(t, 12, x.FacilityID)
-				assert.EqualValues(t, 498338451, x.Installer.ID)
-				assert.EqualValues(t, 229136101, x.JobID)
-				assert.EqualValues(t, 200, x.LicensedRuns.MustValue())
-				assert.EqualValues(t, 13, x.OutputLocationID)
-				assert.EqualValues(t, 1, x.Runs)
-				assert.Equal(t, time.Date(2014, 7, 19, 15, 47, 6, 0, time.UTC), x.StartDate)
-				assert.EqualValues(t, 60006382, x.Location.ID)
-				assert.Equal(t, app.JobActive, x.Status)
+				assert.Equal(t, app.JobReady, x.Status)
+			}
+		}
+	})
+	t.Run("should not fix correct status", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		httpmock.Reset()
+		s := NewFake(st, Params{CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+		c := factory.CreateCorporation()
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2047})
+		factory.CreateEveType(storage.CreateEveTypeParams{ID: 2046})
+		factory.CreateEveEntityCharacter(app.EveEntity{ID: 498338451})
+		factory.CreateEveLocationStructure(storage.UpdateOrCreateLocationParams{ID: 60006382})
+		startDate := time.Now().Add(-24 * time.Hour)
+		endDate := time.Now().Add(+3 * time.Hour)
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi\.evetech\.net/v\d+/corporations/\d+/industry/jobs/\?include_completed=true`,
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{
+					"activity_id":           1,
+					"blueprint_id":          1015116533326,
+					"blueprint_location_id": 11,
+					"blueprint_type_id":     2047,
+					"cost":                  118.01,
+					"duration":              548,
+					"end_date":              endDate.Format("2006-01-02T15:04:05Z"),
+					"facility_id":           12,
+					"installer_id":          498338451,
+					"job_id":                229136101,
+					"licensed_runs":         200,
+					"location_id":           60006382,
+					"output_location_id":    13,
+					"product_type_id":       2046,
+					"runs":                  1,
+					"start_date":            startDate.Format("2006-01-02T15:04:05Z"),
+					"status":                "active",
+				},
+			}))
 
+		// when
+		changed, err := s.updateIndustryJobsESI(ctx, app.CorporationUpdateSectionParams{
+			CorporationID: c.ID,
+			Section:       app.SectionCorporationIndustryJobs,
+		})
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			x, err := st.GetCorporationIndustryJob(ctx, c.ID, 229136101)
+			if assert.NoError(t, err) {
+				assert.Equal(t, app.JobActive, x.Status)
 			}
 		}
 	})

--- a/internal/app/eveuniverseservice/eveuniverseservice.go
+++ b/internal/app/eveuniverseservice/eveuniverseservice.go
@@ -839,6 +839,7 @@ func (s *EveUniverseService) AddMissingTypes(ctx context.Context, ids set.Set[in
 
 func (s *EveUniverseService) UpdateCategoryWithChildrenESI(ctx context.Context, categoryID int32) error {
 	_, err, _ := s.sfg.Do(fmt.Sprintf("UpdateCategoryWithChildrenESI-%d", categoryID), func() (any, error) {
+		var typeIds set.Set[int32]
 		_, err := s.GetOrCreateCategoryESI(ctx, categoryID)
 		if err != nil {
 			return nil, err
@@ -872,13 +873,13 @@ func (s *EveUniverseService) UpdateCategoryWithChildrenESI(ctx context.Context, 
 		if err := g.Wait(); err != nil {
 			return nil, err
 		}
-		var typeIds set.Set[int32]
 		for _, ids := range groupTypes {
 			typeIds.AddSeq(slices.Values(ids))
 		}
 		if err := s.AddMissingTypes(ctx, typeIds); err != nil {
 			return nil, err
 		}
+		slog.Info("Updated eve types", "categoryID", categoryID, "count", typeIds.Size())
 		return nil, nil
 	})
 	if err != nil {

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -445,13 +445,6 @@ func (a *industryJobs) update() {
 			a.bottom.Show()
 		})
 	}
-	fixStatus := func(s app.IndustryJobStatus, endDate time.Time) app.IndustryJobStatus {
-		if s == app.JobActive && !endDate.IsZero() && endDate.Before(time.Now()) {
-			// Workaround for known bug: https://github.com/esi/esi-issues/issues/752
-			return app.JobReady
-		}
-		return s
-	}
 	cj, err := a.u.cs.ListAllCharacterIndustryJob(context.Background())
 	if err != nil {
 		reportError(err)
@@ -502,7 +495,7 @@ func (a *industryJobs) update() {
 			productType:        cj.ProductType,
 			runs:               cj.Runs,
 			startDate:          cj.StartDate,
-			status:             fixStatus(cj.Status, cj.EndDate),
+			status:             cj.Status,
 			successfulRuns:     cj.SuccessfulRuns,
 			isInstallerMe:      true,
 			isOwnerMe:          true,
@@ -529,7 +522,7 @@ func (a *industryJobs) update() {
 			productType:        rj.ProductType,
 			runs:               rj.Runs,
 			startDate:          rj.StartDate,
-			status:             fixStatus(rj.Status, rj.EndDate),
+			status:             rj.Status,
 			successfulRuns:     rj.SuccessfulRuns,
 			isInstallerMe:      myCharacters.Contains(rj.Installer.ID),
 			isOwnerMe:          false,

--- a/internal/app/ui/updatestatus.go
+++ b/internal/app/ui/updatestatus.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -29,7 +30,7 @@ type sectionCategory uint
 
 const (
 	sectionCharacter sectionCategory = iota + 1
-	sectionCorpoation
+	sectionCorporation
 	sectionGeneral
 	sectionHeader
 )
@@ -40,10 +41,6 @@ type sectionEntity struct {
 	name     string
 	category sectionCategory
 	ss       app.StatusSummary
-}
-
-func (se sectionEntity) isGeneralSection() bool {
-	return se.category == sectionGeneral
 }
 
 type detailsItem struct {
@@ -57,10 +54,8 @@ type updateStatus struct {
 
 	charactersTop     *widget.Label
 	details           *updateStatusDetail
-	detailsButton     *widget.Button
 	detailsTop        *widget.Label
 	entities          fyne.CanvasObject
-	entitiesButton    *widget.Button
 	entityList        *widget.List
 	nav               *iwidget.Navigator
 	onEntitySelected  func(int)
@@ -74,6 +69,8 @@ type updateStatus struct {
 	top2              fyne.CanvasObject
 	top3              fyne.CanvasObject
 	u                 *baseUI
+	updateAllSections *widget.Button
+	updateSection     *widget.Button
 }
 
 func newUpdateStatus(u *baseUI) *updateStatus {
@@ -99,10 +96,10 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 	)
 
 	a.sectionList = a.makeSectionList()
-	a.entitiesButton = widget.NewButton("Force update all sections", nil)
-	a.entitiesButton.Disable()
-	a.detailsButton = widget.NewButton("Force update section", nil)
-	a.detailsButton.Disable()
+	a.updateAllSections = widget.NewButton("Force update all sections", nil)
+	a.updateAllSections.Disable()
+	a.updateSection = widget.NewButton("Force update section", nil)
+	a.updateSection.Disable()
 
 	a.top2 = container.NewVBox(a.sectionsTop, widget.NewSeparator())
 	a.top3 = container.NewVBox(a.detailsTop, widget.NewSeparator())
@@ -111,7 +108,7 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 		details := container.NewBorder(a.top3, nil, nil, nil, a.details)
 		menu := iwidget.NewIconButtonWithMenu(
 			theme.MoreVerticalIcon(),
-			fyne.NewMenu("", fyne.NewMenuItem(a.entitiesButton.Text, a.makeUpdateAllAction())),
+			fyne.NewMenu("", fyne.NewMenuItem(a.updateAllSections.Text, a.makeUpdateAllAction())),
 		)
 		a.onEntitySelected = func(id int) {
 			a.nav.Push(
@@ -123,7 +120,7 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 			menu := iwidget.NewIconButtonWithMenu(
 				theme.MoreVerticalIcon(),
 				fyne.NewMenu(
-					"", fyne.NewMenuItem(a.detailsButton.Text, a.makeDetailsAction(s.EntityID, s.SectionID))),
+					"", fyne.NewMenuItem(a.updateSection.Text, a.makeUpdateSectionAction(s.EntityID, s.SectionID))),
 			)
 			a.nav.Push(
 				iwidget.NewAppBar("Section Detail", details, menu),
@@ -140,8 +137,8 @@ func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {
 		a.nav = iwidget.NewNavigatorWithAppBar(ab)
 		c = a.nav
 	} else {
-		sections := container.NewBorder(a.top2, a.entitiesButton, nil, nil, a.sectionList)
-		details := container.NewBorder(a.top3, a.detailsButton, nil, nil, a.details)
+		sections := container.NewBorder(a.top2, a.updateAllSections, nil, nil, a.sectionList)
+		details := container.NewBorder(a.top3, a.updateSection, nil, nil, a.details)
 		vs := container.NewHSplit(sections, details)
 		vs.SetOffset(0.5)
 		hs := container.NewHSplit(a.entities, vs)
@@ -183,14 +180,14 @@ func (a *updateStatus) makeEntityList() *widget.List {
 				name.Refresh()
 				icon.Resource = eveicon.FromName(eveicon.StarMap)
 				icon.Refresh()
-			case sectionCharacter, sectionCorpoation:
+			case sectionCharacter, sectionCorporation:
 				name.TextStyle.Bold = false
 				name.Refresh()
 				iwidget.RefreshImageAsync(icon, func() (fyne.Resource, error) {
 					switch c.category {
 					case sectionCharacter:
 						return a.u.eis.CharacterPortrait(c.id, app.IconPixelSize)
-					case sectionCorpoation:
+					case sectionCorporation:
 						return a.u.eis.CorporationLogo(c.id, app.IconPixelSize)
 					}
 					return icons.BlankSvg, nil
@@ -233,8 +230,8 @@ func (a *updateStatus) makeEntityList() *widget.List {
 		a.sectionList.UnselectAll()
 
 		if !a.u.IsOffline() {
-			a.entitiesButton.OnTapped = a.makeUpdateAllAction()
-			a.entitiesButton.Enable()
+			a.updateAllSections.OnTapped = a.makeUpdateAllAction()
+			a.updateAllSections.Enable()
 		}
 		if a.onEntitySelected != nil {
 			a.onEntitySelected(id)
@@ -249,10 +246,15 @@ func (a *updateStatus) makeEntityList() *widget.List {
 func (a *updateStatus) makeUpdateAllAction() func() {
 	return func() {
 		c := a.sectionEntities[a.selectedEntityID]
-		if c.isGeneralSection() {
+		switch c.category {
+		case sectionGeneral:
 			a.u.updateGeneralSectionsAndRefreshIfNeeded(true)
-		} else {
+		case sectionCharacter:
 			a.u.updateCharacterAndRefreshIfNeeded(context.Background(), c.id, true)
+		case sectionCorporation:
+			a.u.updateCorporationAndRefreshIfNeeded(context.Background(), c.id, true)
+		default:
+			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}
 	}
 }
@@ -294,7 +296,7 @@ func (*updateStatus) updateEntityList(s services) ([]sectionEntity, int) {
 		for _, r := range rr {
 			ss := s.scs.CorporationSectionSummary(r.ID)
 			o := sectionEntity{
-				category: sectionCorpoation,
+				category: sectionCorporation,
 				id:       r.ID,
 				name:     r.Name,
 				ss:       ss,
@@ -377,7 +379,7 @@ func (a *updateStatus) refreshSections() {
 	switch se.category {
 	case sectionCharacter:
 		a.sections = a.u.scs.ListCharacterSections(se.id)
-	case sectionCorpoation:
+	case sectionCorporation:
 		a.sections = a.u.scs.ListCorporationSections(se.id)
 	case sectionGeneral:
 		a.sections = a.u.scs.ListGeneralSections()
@@ -390,7 +392,7 @@ func (a *updateStatus) refreshDetails() {
 	id := a.selectedSectionID
 	if id == -1 || id >= len(a.sections) {
 		a.details.Hide()
-		a.detailsButton.Disable()
+		a.updateSection.Disable()
 		a.detailsTop.SetText("")
 		return
 	}
@@ -401,21 +403,32 @@ func (a *updateStatus) refreshDetails() {
 		a.detailsTop.SetText("")
 	}
 	if !a.u.IsOffline() {
-		a.detailsButton.OnTapped = a.makeDetailsAction(ss.EntityID, ss.SectionID)
-		a.detailsButton.Enable()
+		a.updateSection.OnTapped = a.makeUpdateSectionAction(ss.EntityID, ss.SectionID)
+		a.updateSection.Enable()
 	}
 	a.details.set(ss)
 	a.details.Show()
 }
 
-func (a *updateStatus) makeDetailsAction(entityID int32, sectionID string) func() {
+func (a *updateStatus) makeUpdateSectionAction(entityID int32, sectionID string) func() {
 	return func() {
-		if entityID == app.GeneralSectionEntityID {
+		ctx := context.Background()
+		c := a.sectionEntities[a.selectedEntityID]
+		switch c.category {
+		case sectionGeneral:
 			go a.u.updateGeneralSectionAndRefreshIfNeeded(
-				context.TODO(), app.GeneralSection(sectionID), true)
-		} else {
+				ctx, app.GeneralSection(sectionID), true,
+			)
+		case sectionCharacter:
 			go a.u.updateCharacterSectionAndRefreshIfNeeded(
-				context.TODO(), entityID, app.CharacterSection(sectionID), true)
+				ctx, entityID, app.CharacterSection(sectionID), true,
+			)
+		case sectionCorporation:
+			go a.u.updateCorporationSectionAndRefreshIfNeeded(
+				ctx, entityID, app.CorporationSection(sectionID), true,
+			)
+		default:
+			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}
 	}
 }

--- a/internal/app/ui/updatestatus.go
+++ b/internal/app/ui/updatestatus.go
@@ -131,9 +131,24 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 }
 
 func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {
+	updateMenu := fyne.NewMenu("",
+		fyne.NewMenuItem("Update all characters", func() {
+			a.u.updateCharactersIfNeeded(context.Background(), true)
+		}),
+		fyne.NewMenuItem("Update all corporations", func() {
+			a.u.updateCorporationsIfNeeded(context.Background(), true)
+		}),
+		fyne.NewMenuItem("Update all general topics", func() {
+			a.u.updateGeneralSectionsIfNeeded(context.Background(), true)
+		}),
+	)
+	updateEntities := iwidget.NewContextMenuButton("Force update all entities", updateMenu)
 	var c fyne.CanvasObject
 	if !a.u.isDesktop {
-		ab := iwidget.NewAppBar("Home", a.entities)
+		ab := iwidget.NewAppBar("Home", a.entities, iwidget.NewIconButtonWithMenu(
+			theme.MoreVerticalIcon(),
+			updateMenu,
+		))
 		a.nav = iwidget.NewNavigatorWithAppBar(ab)
 		c = a.nav
 	} else {
@@ -141,7 +156,7 @@ func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {
 		details := container.NewBorder(a.top3, a.updateSection, nil, nil, a.details)
 		vs := container.NewHSplit(sections, details)
 		vs.SetOffset(0.5)
-		hs := container.NewHSplit(a.entities, vs)
+		hs := container.NewHSplit(container.NewBorder(nil, updateEntities, nil, nil, a.entities), vs)
 		hs.SetOffset(0.33)
 		c = hs
 	}
@@ -245,14 +260,15 @@ func (a *updateStatus) makeEntityList() *widget.List {
 
 func (a *updateStatus) makeUpdateAllAction() func() {
 	return func() {
+		ctx := context.Background()
 		c := a.sectionEntities[a.selectedEntityID]
 		switch c.category {
 		case sectionGeneral:
-			a.u.updateGeneralSectionsAndRefreshIfNeeded(true)
+			a.u.updateGeneralSectionsIfNeeded(ctx, true)
 		case sectionCharacter:
-			a.u.updateCharacterAndRefreshIfNeeded(context.Background(), c.id, true)
+			a.u.updateCharacterAndRefreshIfNeeded(ctx, c.id, true)
 		case sectionCorporation:
-			a.u.updateCorporationAndRefreshIfNeeded(context.Background(), c.id, true)
+			a.u.updateCorporationAndRefreshIfNeeded(ctx, c.id, true)
 		default:
 			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}

--- a/internal/widget/contextmenu.go
+++ b/internal/widget/contextmenu.go
@@ -10,13 +10,19 @@ type ContextMenuButton struct {
 	menu *fyne.Menu
 }
 
+// NewContextMenuButton is a button that shows a context menu.
+func NewContextMenuButton(label string, menu *fyne.Menu) *ContextMenuButton {
+	return NewContextMenuButtonWithIcon(nil, label, menu)
+}
+
 // NewContextMenuButtonWithIcon is an icon button that shows a context menu. The label is optional.
 func NewContextMenuButtonWithIcon(icon fyne.Resource, label string, menu *fyne.Menu) *ContextMenuButton {
 	b := &ContextMenuButton{menu: menu}
-	b.Text = label
-	b.Icon = icon
-
 	b.ExtendBaseWidget(b)
+	b.Text = label
+	if icon != nil {
+		b.Icon = icon
+	}
 	return b
 }
 


### PR DESCRIPTION
- Fix: forcing an update of a corporation section is not working
- Change: the job status is now fixed when receiving data from ESI, so the jobs are stored in the DB with the corrected status
- Added: Ability to force update all entities at once

> [!NOTE]  
> All industry jobs need to be force updated to ensure they have the correct status. Tip: This can be done quickly with the new "Update all" feature