### PR TITLE
feat: improve wallet lists on mobile

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,11 +17,12 @@ import (
 
 // Default formats and sizes
 const (
-	DateTimeFormat = "2006.01.02 15:04"
-	DateFormat     = "2006.01.02"
-	FloatFormat    = "#,###.##"
-	IconPixelSize  = 64
-	IconUnitSize   = 28
+	DateTimeFormat            = "2006.01.02 15:04"
+	DateTimeFormatWithSeconds = "2006.01.02 15:04:05"
+	DateFormat                = "2006.01.02"
+	FloatFormat               = "#,###.##"
+	IconPixelSize             = 64
+	IconUnitSize              = 28
 )
 
 // EntityShort is a short representation of an entity.

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -797,6 +797,10 @@ type CharacterWalletTransaction struct {
 	UnitPrice     float64
 }
 
+func (wt *CharacterWalletTransaction) Total() float64 {
+	return wt.UnitPrice * float64(wt.Quantity)
+}
+
 type NotificationGroup uint
 
 const (

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -1075,6 +1075,10 @@ func (s *CharacterService) updateImplantsESI(ctx context.Context, arg app.Charac
 		})
 }
 
+func (s *CharacterService) GetCharacterIndustryJob(ctx context.Context, characterID, jobID int32) (*app.CharacterIndustryJob, error) {
+	return s.st.GetCharacterIndustryJob(ctx, characterID, jobID)
+}
+
 // ListAllCharacterIndustryJob returns all industry jobs from characters.
 func (s *CharacterService) ListAllCharacterIndustryJob(ctx context.Context) ([]*app.CharacterIndustryJob, error) {
 	return s.st.ListAllCharacterIndustryJob(ctx)

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -2602,6 +2602,10 @@ func (s *CharacterService) ensureValidCharacterToken(ctx context.Context, t *app
 	return nil
 }
 
+func (s *CharacterService) GetWalletJournalEntry(ctx context.Context, characterID int32, refID int64) (*app.CharacterWalletJournalEntry, error) {
+	return s.st.GetCharacterWalletJournalEntry(ctx, characterID, refID)
+}
+
 func (s *CharacterService) ListWalletJournalEntries(ctx context.Context, characterID int32) ([]*app.CharacterWalletJournalEntry, error) {
 	return s.st.ListCharacterWalletJournalEntries(ctx, characterID)
 }

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -2695,6 +2695,10 @@ const (
 	maxTransactionsPerPage = 2_500 // maximum objects returned per page
 )
 
+func (s *CharacterService) GetWalletTransactions(ctx context.Context, characterID int32, transactionID int64) (*app.CharacterWalletTransaction, error) {
+	return s.st.GetCharacterWalletTransaction(ctx, characterID, transactionID)
+}
+
 func (s *CharacterService) ListWalletTransactions(ctx context.Context, characterID int32) ([]*app.CharacterWalletTransaction, error) {
 	return s.st.ListCharacterWalletTransactions(ctx, characterID)
 }

--- a/internal/app/eveuniverseservice/location.go
+++ b/internal/app/eveuniverseservice/location.go
@@ -26,10 +26,10 @@ func (s *EveUniverseService) ListLocations(ctx context.Context) ([]*app.EveLocat
 	return s.st.ListEveLocation(ctx)
 }
 
-// GetOrCreateLocationESI return a structure when it already exists
-// or else tries to fetch and create a new structure from ESI.
+// GetOrCreateLocationESI return a location.
+// When the location does not yet exist in storage it tries to fetch and create a new location from ESI.
 //
-// Important: A token with the structure scope must be set in the context
+// Important: For creating structures a valid token with the structure scope must be set in the context or an error will be returned
 func (s *EveUniverseService) GetOrCreateLocationESI(ctx context.Context, id int64) (*app.EveLocation, error) {
 	o, err := s.st.GetLocation(ctx, id)
 	if errors.Is(err, app.ErrNotFound) {
@@ -38,9 +38,9 @@ func (s *EveUniverseService) GetOrCreateLocationESI(ctx context.Context, id int6
 	return o, err
 }
 
-// UpdateOrCreateLocationESI tries to fetch and create a new structure from ESI.
+// UpdateOrCreateLocationESI tries to fetch and create a new location from ESI.
 //
-// Important: A token with the structure scope must be set in the context when trying to fetch a structure.
+// Important: For creating structures a valid token with the structure scope must be set in the context or an error will be returned
 func (s *EveUniverseService) UpdateOrCreateLocationESI(ctx context.Context, id int64) (*app.EveLocation, error) {
 	y, err, _ := s.sfg.Do(fmt.Sprintf("updateOrCreateLocationESI-%d", id), func() (any, error) {
 		o, err := s.st.GetLocation(ctx, id)

--- a/internal/app/storage/queries/character_contracts.sql
+++ b/internal/app/storage/queries/character_contracts.sql
@@ -81,7 +81,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc
@@ -122,7 +121,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc
@@ -135,7 +133,7 @@ FROM
     LEFT JOIN eve_solar_systems AS end_solar_systems ON end_solar_systems.id = end_locations.eve_solar_system_id
     LEFT JOIN eve_solar_systems AS start_solar_systems ON start_solar_systems.id = start_locations.eve_solar_system_id
 GROUP BY
-    contract_id
+    character_id, contract_id
 ORDER BY
     date_issued DESC;
 
@@ -164,7 +162,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc

--- a/internal/app/storage/queries/character_contracts.sql.go
+++ b/internal/app/storage/queries/character_contracts.sql.go
@@ -156,7 +156,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc
@@ -275,7 +274,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc
@@ -288,7 +286,7 @@ FROM
     LEFT JOIN eve_solar_systems AS end_solar_systems ON end_solar_systems.id = end_locations.eve_solar_system_id
     LEFT JOIN eve_solar_systems AS start_solar_systems ON start_solar_systems.id = start_locations.eve_solar_system_id
 GROUP BY
-    contract_id
+    character_id, contract_id
 ORDER BY
     date_issued DESC
 `
@@ -438,7 +436,6 @@ SELECT
             LEFT JOIN eve_types et ON et.id = cci.type_id
         WHERE
             cci.contract_id = cc.id
-            AND cci.is_included IS TRUE
     ) as items
 FROM
     character_contracts cc

--- a/internal/app/ui/characterwallettransaction.go
+++ b/internal/app/ui/characterwallettransaction.go
@@ -340,7 +340,7 @@ func (a *characterWalletTransaction) fetchRows(characterID int32, s services) ([
 func showCharacterWalletTransaction(u *baseUI, characterID int32, transactionID int64) {
 	o, err := u.cs.GetWalletTransactions(context.Background(), characterID, transactionID)
 	if err != nil {
-		u.showErrorDialog("Failed to fetch wallet transaction", err, u.window)
+		u.showErrorDialog("Failed to fetch market transaction", err, u.window)
 		return
 	}
 	location := iwidget.NewTappableRichText(o.Location.DisplayRichText(), func() {
@@ -361,7 +361,7 @@ func showCharacterWalletTransaction(u *baseUI, characterID int32, transactionID 
 		widget.NewFormItem("Total", total),
 		widget.NewFormItem("Client", makeEveEntityActionLabel(o.Client, u.ShowEveEntityInfoWindow)),
 		widget.NewFormItem("Location", location),
-		widget.NewFormItem("Journal Entry", makeTappableLabelWithWrap(
+		widget.NewFormItem("Related Journal Entry", makeTappableLabelWithWrap(
 			fmt.Sprintf("#%d", o.JournalRefID), func() {
 				showCharacterWalletJournalEntry(u, characterID, o.JournalRefID)
 			},
@@ -374,9 +374,9 @@ func showCharacterWalletTransaction(u *baseUI, characterID int32, transactionID 
 			u.makeCopyToClipboardLabel(fmt.Sprint(transactionID)),
 		))
 	}
-	title := fmt.Sprintf("Wallet Transaction #%d", transactionID)
+	title := fmt.Sprintf("Market Transaction #%d", transactionID)
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
-	w := u.makeDetailWindow("Wallet Transaction Entry", title, f)
+	w := u.makeDetailWindow("Market Transaction Entry", title, f)
 	w.Show()
 }

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"slices"
 	"strings"
 	"time"
@@ -410,13 +409,6 @@ func (a *contracts) showContract(r contractRow) {
 		})
 		return x
 	}
-	makeISKString := func(v float64) string {
-		t := humanize.Commaf(v) + " ISK"
-		if math.Abs(v) > 999 {
-			t += fmt.Sprintf(" (%s)", ihumanize.Number(v, 1))
-		}
-		return t
-	}
 
 	availability := container.NewHBox(widget.NewLabel(c.AvailabilityDisplay()))
 	if c.Assignee != nil {
@@ -454,22 +446,22 @@ func (a *contracts) showContract(r contractRow) {
 		if c.Collateral == 0 {
 			collateral = "(None)"
 		} else {
-			collateral = makeISKString(c.Collateral)
+			collateral = formatISKAmount(c.Collateral)
 		}
 		fi = slices.Concat(fi, []*widget.FormItem{
 			{Text: "Complete In", Widget: widget.NewLabel(fmt.Sprintf("%d days", c.DaysToComplete))},
 			{Text: "Volume", Widget: widget.NewLabel(fmt.Sprintf("%f m3", c.Volume))},
-			{Text: "Reward", Widget: widget.NewLabel(makeISKString(c.Reward))},
+			{Text: "Reward", Widget: widget.NewLabel(formatISKAmount(c.Reward))},
 			{Text: "Collateral", Widget: widget.NewLabel(collateral)},
 			{Text: "Destination", Widget: makeLocation(c.EndLocation)},
 		})
 	case app.ContractTypeItemExchange:
 		if c.Price > 0 {
-			x := widget.NewLabel(makeISKString(c.Price))
+			x := widget.NewLabel(formatISKAmount(c.Price))
 			x.Importance = widget.DangerImportance
 			fi = append(fi, widget.NewFormItem("Buyer Will Pay", x))
 		} else {
-			x := widget.NewLabel(makeISKString(c.Reward))
+			x := widget.NewLabel(formatISKAmount(c.Reward))
 			x.Importance = widget.SuccessImportance
 			fi = append(fi, widget.NewFormItem("Buyer Will Get", x))
 		}
@@ -491,11 +483,11 @@ func (a *contracts) showContract(r contractRow) {
 				d.SetOnClosed(w.Hide)
 				d.Show()
 			}
-			currentBid = fmt.Sprintf("%s (%d bids so far)", makeISKString(float64(top.Amount)), total)
+			currentBid = fmt.Sprintf("%s (%d bids so far)", formatISKAmount(float64(top.Amount)), total)
 		}
 		fi = slices.Concat(fi, []*widget.FormItem{
-			{Text: "Starting Bid", Widget: widget.NewLabel(makeISKString(c.Price))},
-			{Text: "Buyout Price", Widget: widget.NewLabel(makeISKString(c.Buyout))},
+			{Text: "Starting Bid", Widget: widget.NewLabel(formatISKAmount(c.Price))},
+			{Text: "Buyout Price", Widget: widget.NewLabel(formatISKAmount(c.Buyout))},
 			{Text: "Current Bid", Widget: widget.NewLabel(currentBid)},
 			{Text: "Expires", Widget: widget.NewLabel(makeExpiresString(c))},
 		})

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -108,7 +108,7 @@ func newContracts(u *baseUI) *contracts {
 				}
 				return iwidget.NewRichTextSegmentFromText("?")
 			}, a.columnSorter, a.filterRows, func(column int, r contractRow) {
-				a.showContract(r)
+				showContract(a.u, r.characterID, r.contractID)
 			},
 		)
 	} else {
@@ -218,7 +218,8 @@ func (a *contracts) makeDataList() *widget.List {
 		if id < 0 || id >= len(a.rowsFiltered) {
 			return
 		}
-		a.showContract(a.rowsFiltered[id])
+		r := a.rowsFiltered[id]
+		showContract(a.u, r.characterID, r.contractID)
 	}
 	return l
 }
@@ -379,10 +380,10 @@ func (a *contracts) fetchRows(s services) ([]contractRow, int, error) {
 	return rows, activeCount, nil
 }
 
-func (a *contracts) showContract(r contractRow) {
-	c, err := a.u.cs.GetContract(context.Background(), r.characterID, r.contractID)
+func showContract(u *baseUI, characterID, contractID int32) {
+	o, err := u.cs.GetContract(context.Background(), characterID, contractID)
 	if err != nil {
-		panic(err)
+		u.showErrorDialog("Failed to show contacts", err, u.window)
 	}
 	var w fyne.Window
 	makeExpiresString := func(c *app.CharacterContract) string {
@@ -395,81 +396,76 @@ func (a *contracts) showContract(r contractRow) {
 		}
 		return fmt.Sprintf("%s (%s)", ts, ds)
 	}
-	makeEntity := func(ee *app.EveEntity) *kxwidget.TappableLabel {
-		return kxwidget.NewTappableLabel(ee.Name, func() {
-			a.u.ShowEveEntityInfoWindow(ee)
-		})
-	}
 	makeLocation := func(l *app.EveLocationShort) *iwidget.TappableRichText {
 		if l == nil {
 			return iwidget.NewTappableRichTextWithText("?", nil)
 		}
 		x := iwidget.NewTappableRichText(l.DisplayRichText(), func() {
-			a.u.ShowLocationInfoWindow(l.ID)
+			u.ShowLocationInfoWindow(l.ID)
 		})
 		return x
 	}
 
-	availability := container.NewHBox(widget.NewLabel(c.AvailabilityDisplay()))
-	if c.Assignee != nil {
-		availability.Add(makeEntity(c.Assignee))
+	availability := container.NewHBox(widget.NewLabel(o.AvailabilityDisplay()))
+	if o.Assignee != nil {
+		availability.Add(makeEveEntityActionLabel(o.Assignee, u.ShowEveEntityInfoWindow))
 	}
 	fi := []*widget.FormItem{
-		widget.NewFormItem("Info by issuer", widget.NewLabel(c.TitleDisplay())),
-		widget.NewFormItem("Type", widget.NewLabel(c.TypeDisplay())),
-		widget.NewFormItem("Issued By", makeEntity(c.IssuerEffective())),
+		widget.NewFormItem("Info by issuer", widget.NewLabel(o.TitleDisplay())),
+		widget.NewFormItem("Type", widget.NewLabel(o.TypeDisplay())),
+		widget.NewFormItem("Issued By", makeEveEntityActionLabel(o.IssuerEffective(), u.ShowEveEntityInfoWindow)),
 		widget.NewFormItem("Availability", availability),
 	}
-	if a.u.IsDeveloperMode() {
-		fi = append(fi, widget.NewFormItem("Contract ID", a.u.makeCopyToClipboardLabel(fmt.Sprint(c.ContractID))))
+	if u.IsDeveloperMode() {
+		fi = append(fi, widget.NewFormItem("Contract ID", u.makeCopyToClipboardLabel(fmt.Sprint(o.ContractID))))
 	}
-	if c.Type == app.ContractTypeCourier {
-		fi = append(fi, widget.NewFormItem("Contractor", widget.NewLabel(c.AcceptorDisplay())))
+	if o.Type == app.ContractTypeCourier {
+		fi = append(fi, widget.NewFormItem("Contractor", widget.NewLabel(o.AcceptorDisplay())))
 	}
-	fi = append(fi, widget.NewFormItem("Status", iwidget.NewRichText(c.StatusDisplayRichText()...)))
-	fi = append(fi, widget.NewFormItem("Location", makeLocation(c.StartLocation)))
+	fi = append(fi, widget.NewFormItem("Status", iwidget.NewRichText(o.StatusDisplayRichText()...)))
+	fi = append(fi, widget.NewFormItem("Location", makeLocation(o.StartLocation)))
 
-	if c.Type == app.ContractTypeCourier || c.Type == app.ContractTypeItemExchange {
-		fi = append(fi, widget.NewFormItem("Date Issued", widget.NewLabel(c.DateIssued.Format(app.DateTimeFormat))))
-		fi = append(fi, widget.NewFormItem("Date Accepted", widget.NewLabel(c.DateAccepted.StringFunc("", func(v time.Time) string {
+	if o.Type == app.ContractTypeCourier || o.Type == app.ContractTypeItemExchange {
+		fi = append(fi, widget.NewFormItem("Date Issued", widget.NewLabel(o.DateIssued.Format(app.DateTimeFormat))))
+		fi = append(fi, widget.NewFormItem("Date Accepted", widget.NewLabel(o.DateAccepted.StringFunc("", func(v time.Time) string {
 			return v.Format(app.DateTimeFormat)
 		}))))
-		fi = append(fi, widget.NewFormItem("Date Expired", widget.NewLabel(makeExpiresString(c))))
-		fi = append(fi, widget.NewFormItem("Date Completed", widget.NewLabel(c.DateCompleted.StringFunc("", func(v time.Time) string {
+		fi = append(fi, widget.NewFormItem("Date Expired", widget.NewLabel(makeExpiresString(o))))
+		fi = append(fi, widget.NewFormItem("Date Completed", widget.NewLabel(o.DateCompleted.StringFunc("", func(v time.Time) string {
 			return v.Format(app.DateTimeFormat)
 		}))))
 	}
 
-	switch c.Type {
+	switch o.Type {
 	case app.ContractTypeCourier:
 		var collateral string
-		if c.Collateral == 0 {
+		if o.Collateral == 0 {
 			collateral = "(None)"
 		} else {
-			collateral = formatISKAmount(c.Collateral)
+			collateral = formatISKAmount(o.Collateral)
 		}
 		fi = slices.Concat(fi, []*widget.FormItem{
-			{Text: "Complete In", Widget: widget.NewLabel(fmt.Sprintf("%d days", c.DaysToComplete))},
-			{Text: "Volume", Widget: widget.NewLabel(fmt.Sprintf("%f m3", c.Volume))},
-			{Text: "Reward", Widget: widget.NewLabel(formatISKAmount(c.Reward))},
+			{Text: "Complete In", Widget: widget.NewLabel(fmt.Sprintf("%d days", o.DaysToComplete))},
+			{Text: "Volume", Widget: widget.NewLabel(fmt.Sprintf("%f m3", o.Volume))},
+			{Text: "Reward", Widget: widget.NewLabel(formatISKAmount(o.Reward))},
 			{Text: "Collateral", Widget: widget.NewLabel(collateral)},
-			{Text: "Destination", Widget: makeLocation(c.EndLocation)},
+			{Text: "Destination", Widget: makeLocation(o.EndLocation)},
 		})
 	case app.ContractTypeItemExchange:
-		if c.Price > 0 {
-			x := widget.NewLabel(formatISKAmount(c.Price))
+		if o.Price > 0 {
+			x := widget.NewLabel(formatISKAmount(o.Price))
 			x.Importance = widget.DangerImportance
 			fi = append(fi, widget.NewFormItem("Buyer Will Pay", x))
 		} else {
-			x := widget.NewLabel(formatISKAmount(c.Reward))
+			x := widget.NewLabel(formatISKAmount(o.Reward))
 			x.Importance = widget.SuccessImportance
 			fi = append(fi, widget.NewFormItem("Buyer Will Get", x))
 		}
 	case app.ContractTypeAuction:
 		ctx := context.TODO()
-		total, err := a.u.cs.CountContractBids(ctx, c.ID)
+		total, err := u.cs.CountContractBids(ctx, o.ID)
 		if err != nil {
-			d := a.u.NewErrorDialog("Failed to count contract bids", err, w)
+			d := u.NewErrorDialog("Failed to count contract bids", err, w)
 			d.SetOnClosed(w.Hide)
 			d.Show()
 		}
@@ -477,27 +473,27 @@ func (a *contracts) showContract(r contractRow) {
 		if total == 0 {
 			currentBid = "(None)"
 		} else {
-			top, err := a.u.cs.GetContractTopBid(ctx, c.ID)
+			top, err := u.cs.GetContractTopBid(ctx, o.ID)
 			if err != nil {
-				d := a.u.NewErrorDialog("Failed to get top bid", err, w)
+				d := u.NewErrorDialog("Failed to get top bid", err, w)
 				d.SetOnClosed(w.Hide)
 				d.Show()
 			}
 			currentBid = fmt.Sprintf("%s (%d bids so far)", formatISKAmount(float64(top.Amount)), total)
 		}
 		fi = slices.Concat(fi, []*widget.FormItem{
-			{Text: "Starting Bid", Widget: widget.NewLabel(formatISKAmount(c.Price))},
-			{Text: "Buyout Price", Widget: widget.NewLabel(formatISKAmount(c.Buyout))},
+			{Text: "Starting Bid", Widget: widget.NewLabel(formatISKAmount(o.Price))},
+			{Text: "Buyout Price", Widget: widget.NewLabel(formatISKAmount(o.Buyout))},
 			{Text: "Current Bid", Widget: widget.NewLabel(currentBid)},
-			{Text: "Expires", Widget: widget.NewLabel(makeExpiresString(c))},
+			{Text: "Expires", Widget: widget.NewLabel(makeExpiresString(o))},
 		})
 	}
 
 	makeItemsInfo := func(c *app.CharacterContract) fyne.CanvasObject {
 		vb := container.NewVBox()
-		items, err := a.u.cs.ListContractItems(context.TODO(), c.ID)
+		items, err := u.cs.ListContractItems(context.TODO(), c.ID)
 		if err != nil {
-			d := a.u.NewErrorDialog("Failed to fetch contract items", err, w)
+			d := u.NewErrorDialog("Failed to fetch contract items", err, w)
 			d.SetOnClosed(w.Hide)
 			d.Show()
 		}
@@ -511,7 +507,7 @@ func (a *contracts) showContract(r contractRow) {
 		}
 		makeItem := func(it *app.CharacterContractItem) fyne.CanvasObject {
 			x := kxwidget.NewTappableLabel(it.Type.Name, func() {
-				a.u.ShowTypeInfoWindow(it.Type.ID)
+				u.ShowTypeInfoWindow(it.Type.ID)
 			})
 			return container.NewHBox(
 				x,
@@ -540,14 +536,14 @@ func (a *contracts) showContract(r contractRow) {
 		return vb
 	}
 
-	subTitle := fmt.Sprintf("%s (%s)", c.NameDisplay(), c.TypeDisplay())
+	subTitle := fmt.Sprintf("%s (%s)", o.NameDisplay(), o.TypeDisplay())
 	f := widget.NewForm(fi...)
 	f.Orientation = widget.Adaptive
 	main := container.NewVBox(f)
-	if c.Type == app.ContractTypeItemExchange || c.Type == app.ContractTypeAuction {
+	if o.Type == app.ContractTypeItemExchange || o.Type == app.ContractTypeAuction {
 		main.Add(widget.NewSeparator())
-		main.Add(makeItemsInfo(c))
+		main.Add(makeItemsInfo(o))
 	}
-	w = a.u.makeDetailWindow("Contract", subTitle, main)
+	w = u.makeDetailWindow("Contract", subTitle, main)
 	w.Show()
 }

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -406,15 +406,6 @@ func showContract(u *baseUI, characterID, contractID int32) {
 		}
 		return fmt.Sprintf("%s (%s)", ts, ds)
 	}
-	makeLocation := func(l *app.EveLocationShort) *iwidget.TappableRichText {
-		if l == nil {
-			return iwidget.NewTappableRichTextWithText("?", nil)
-		}
-		x := iwidget.NewTappableRichText(l.DisplayRichText(), func() {
-			u.ShowLocationInfoWindow(l.ID)
-		})
-		return x
-	}
 
 	var availability fyne.CanvasObject
 	availabilityLabel := widget.NewLabel(o.AvailabilityDisplay())
@@ -443,7 +434,7 @@ func showContract(u *baseUI, characterID, contractID int32) {
 		fi = append(fi, widget.NewFormItem("Contractor", widget.NewLabel(o.AcceptorDisplay())))
 	}
 	fi = append(fi, widget.NewFormItem("Status", iwidget.NewRichText(o.StatusDisplayRichText()...)))
-	fi = append(fi, widget.NewFormItem("Location", makeLocation(o.StartLocation)))
+	fi = append(fi, widget.NewFormItem("Location", makeLocationLabel(o.StartLocation, u.ShowLocationInfoWindow)))
 
 	if o.Type == app.ContractTypeCourier || o.Type == app.ContractTypeItemExchange {
 		fi = append(fi, widget.NewFormItem("Date Issued", widget.NewLabel(o.DateIssued.Format(app.DateTimeFormat))))
@@ -469,7 +460,7 @@ func showContract(u *baseUI, characterID, contractID int32) {
 			{Text: "Volume", Widget: widget.NewLabel(fmt.Sprintf("%f m3", o.Volume))},
 			{Text: "Reward", Widget: widget.NewLabel(formatISKAmount(o.Reward))},
 			{Text: "Collateral", Widget: widget.NewLabel(collateral)},
-			{Text: "Destination", Widget: makeLocation(o.EndLocation)},
+			{Text: "Destination", Widget: makeLocationLabel(o.EndLocation, u.ShowLocationInfoWindow)},
 		})
 	case app.ContractTypeItemExchange:
 		if o.Price > 0 {

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
+	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	"github.com/dustin/go-humanize"
 )
@@ -76,4 +77,15 @@ func makeLabelWithWrap(s string) *widget.Label {
 	l := widget.NewLabel(s)
 	l.Wrapping = fyne.TextWrapWord
 	return l
+}
+
+func makeLocationLabel(o *app.EveLocationShort, show func(int64)) *iwidget.TappableRichText {
+	if o == nil {
+		return iwidget.NewTappableRichTextWithText("?", nil)
+	}
+	x := iwidget.NewTappableRichText(o.DisplayRichText(), func() {
+		show(o.ID)
+	})
+	x.Wrapping = fyne.TextWrapWord
+	return x
 }

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -6,7 +6,9 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/widget"
+	"github.com/ErikKalkoken/evebuddy/internal/app"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
+	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	"github.com/dustin/go-humanize"
 )
 
@@ -44,4 +46,34 @@ func formatISKAmount(v float64) string {
 		t += fmt.Sprintf(" (%s)", ihumanize.Number(v, 2))
 	}
 	return t
+}
+
+func importanceISKAmount(v float64) widget.Importance {
+	if v > 0 {
+		return widget.SuccessImportance
+	} else if v < 0 {
+		return widget.DangerImportance
+	}
+	return widget.MediumImportance
+}
+
+func makeTappableLabelWithWrap(text string, action func()) *kxwidget.TappableLabel {
+	x := kxwidget.NewTappableLabel(text, action)
+	x.Wrapping = fyne.TextWrapWord
+	return x
+}
+
+func makeEveEntityActionLabel(o *app.EveEntity, action func(o *app.EveEntity)) *kxwidget.TappableLabel {
+	if o == nil {
+		return kxwidget.NewTappableLabel("-", nil)
+	}
+	return makeTappableLabelWithWrap(o.Name, func() {
+		action(o)
+	})
+}
+
+func makeLabelWithWrap(s string) *widget.Label {
+	l := widget.NewLabel(s)
+	l.Wrapping = fyne.TextWrapWord
+	return l
 }

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -1,8 +1,13 @@
 package ui
 
 import (
+	"fmt"
+	"math"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/widget"
+	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
+	"github.com/dustin/go-humanize"
 )
 
 // makeGridOrList makes and returns a GridWrap on desktop and a List on mobile.
@@ -31,4 +36,12 @@ func makeTopLabel() *widget.Label {
 	l := widget.NewLabel("")
 	l.Wrapping = fyne.TextWrapWord
 	return l
+}
+
+func formatISKAmount(v float64) string {
+	t := humanize.Commaf(v) + " ISK"
+	if math.Abs(v) > 999 {
+		t += fmt.Sprintf(" (%s)", ihumanize.Number(v, 2))
+	}
+	return t
 }

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -152,7 +152,7 @@ func newIndustryJobs(u *baseUI) *industryJobs {
 
 	if a.u.isDesktop {
 		a.body = makeDataTable(headers, &a.rowsFiltered, makeCell, a.columnSorter, a.filterRows, func(_ int, j industryJobRow) {
-			a.showJob(j)
+			a.showIndustryJob(j)
 		})
 	} else {
 		a.body = a.makeDataList()
@@ -439,7 +439,7 @@ func (a *industryJobs) makeDataList() *widget.List {
 		if id >= len(a.rowsFiltered) || id < 0 {
 			return
 		}
-		a.showJob(a.rowsFiltered[id])
+		a.showIndustryJob(a.rowsFiltered[id])
 	}
 	return l
 }
@@ -585,22 +585,10 @@ func (a *industryJobs) update() {
 	})
 }
 
-func (a *industryJobs) showJob(r industryJobRow) {
-	makeLocationWidget := func(o *app.EveLocationShort) *iwidget.TappableRichText {
-		x := iwidget.NewTappableRichText(o.DisplayRichText(), func() {
-			a.u.ShowLocationInfoWindow(o.ID)
-		})
-		x.Wrapping = fyne.TextWrapWord
-		return x
-	}
-	newTappableLabelWithWrap := func(text string, f func()) *kxwidget.TappableLabel {
-		x := kxwidget.NewTappableLabel(text, f)
-		x.Wrapping = fyne.TextWrapWord
-		return x
-	}
+func (a *industryJobs) showIndustryJob(r industryJobRow) {
 	activity := fmt.Sprintf("%s (%s)", r.activity.Display(), r.activity.JobType().Display())
 	items := []*widget.FormItem{
-		widget.NewFormItem("Blueprint", newTappableLabelWithWrap(r.blueprintType.Name, func() {
+		widget.NewFormItem("Blueprint", makeTappableLabelWithWrap(r.blueprintType.Name, func() {
 			a.u.ShowInfoWindow(app.EveEntityInventoryType, r.blueprintType.ID)
 		})),
 		widget.NewFormItem("Activity", widget.NewLabel(activity)),
@@ -609,7 +597,7 @@ func (a *industryJobs) showJob(r industryJobRow) {
 		x := r.productType.MustValue()
 		items = append(items, widget.NewFormItem(
 			"Product Type",
-			newTappableLabelWithWrap(x.Name, func() {
+			makeTappableLabelWithWrap(x.Name, func() {
 				a.u.ShowInfoWindow(app.EveEntityInventoryType, x.ID)
 			}),
 		))
@@ -652,18 +640,18 @@ func (a *industryJobs) showJob(r industryJobRow) {
 		)
 	}
 	items = slices.Concat(items, []*widget.FormItem{
-		widget.NewFormItem("Location", makeLocationWidget(r.location)),
-		widget.NewFormItem("Installer", newTappableLabelWithWrap(r.installer.Name, func() {
+		widget.NewFormItem("Location", makeLocationLabel(r.location, a.u.ShowLocationInfoWindow)),
+		widget.NewFormItem("Installer", makeTappableLabelWithWrap(r.installer.Name, func() {
 			a.u.ShowEveEntityInfoWindow(r.installer)
 		})),
-		widget.NewFormItem("Owner", newTappableLabelWithWrap(r.owner.Name, func() {
+		widget.NewFormItem("Owner", makeTappableLabelWithWrap(r.owner.Name, func() {
 			a.u.ShowEveEntityInfoWindow(r.owner)
 		})),
 		widget.NewFormItem("Type", widget.NewLabel(r.owner.CategoryDisplay())),
 	})
 	if !r.completedCharacter.IsEmpty() {
 		x := r.completedCharacter.MustValue()
-		items = append(items, widget.NewFormItem("Completed By", newTappableLabelWithWrap(x.Name, func() {
+		items = append(items, widget.NewFormItem("Completed By", makeTappableLabelWithWrap(x.Name, func() {
 			a.u.ShowEveEntityInfoWindow(x)
 		})))
 	}

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -56,7 +56,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		if mode != app.SendMailNew {
 			characterNav.Pop() // FIXME: Workaround to avoid pushing upon page w/o navbar
 		}
-		characterNav.PushHideNavBar(
+		characterNav.PushAndHideNavBar(
 			newCharacterAppBar(
 				"",
 				page,
@@ -76,7 +76,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			u.characterAsset.OnSelected = func() {
 				characterNav.Push(newCharacterAppBar("Assets", u.characterAsset.LocationAssets))
 			}
-			characterNav.Push(newCharacterAppBar("Assets", container.NewHScroll(u.characterAsset.Locations)))
+			characterNav.PushAndHideNavBar(newCharacterAppBar("Assets", container.NewHScroll(u.characterAsset.Locations)))
 		},
 	)
 	navItemCommunications := iwidget.NewListItemWithIcon(
@@ -84,11 +84,11 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		theme.NewThemedResource(icons.MessageSvg),
 		func() {
 			u.characterCommunications.OnSelected = func() {
-				characterNav.PushHideNavBar(
+				characterNav.PushAndHideNavBar(
 					newCharacterAppBar("Communications", u.characterCommunications.Detail),
 				)
 			}
-			characterNav.Push(
+			characterNav.PushAndHideNavBar(
 				newCharacterAppBar(
 					"Communications",
 					u.characterCommunications.Notifications,
@@ -102,7 +102,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		theme.MailComposeIcon(),
 		func() {
 			u.characterMail.onSelected = func() {
-				characterNav.PushHideNavBar(
+				characterNav.Push(
 					newCharacterAppBar(
 						"Mail",
 						u.characterMail.Detail,
@@ -115,7 +115,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 					),
 				)
 			}
-			characterNav.Push(
+			characterNav.PushAndHideNavBar(
 				newCharacterAppBar(
 					"Mail",
 					u.characterMail.Headers,
@@ -128,7 +128,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		"Skills",
 		theme.NewThemedResource(icons.SchoolSvg),
 		func() {
-			characterNav.Push(
+			characterNav.PushAndHideNavBar(
 				newCharacterAppBar(
 					"Skills",
 					container.NewAppTabs(
@@ -143,7 +143,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		"Wallet",
 		theme.NewThemedResource(icons.AttachmoneySvg),
 		func() {
-			characterNav.Push(
+			characterNav.PushAndHideNavBar(
 				newCharacterAppBar(
 					"Wallet",
 					container.NewAppTabs(
@@ -226,28 +226,21 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 	characterPage := newCharacterAppBar("Character", characterList)
 	characterNav = iwidget.NewNavigatorWithAppBar(characterPage)
 
-	// characters cross destination
+	// home destination
 	var homeNav *iwidget.Navigator
 	var homeList *iwidget.List
-	navItemWealth := iwidget.NewListItemWithIcon(
-		"Wealth",
-		theme.NewThemedResource(icons.GoldSvg),
-		func() {
-			homeNav.Push(iwidget.NewAppBar("Wealth", u.wealth))
-		},
-	)
 	navItemColonies2 := iwidget.NewListItemWithIcon(
 		"Colonies",
 		theme.NewThemedResource(icons.EarthSvg),
 		func() {
-			homeNav.Push(iwidget.NewAppBar("Colonies", u.colonies))
+			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Colonies", u.colonies))
 		},
 	)
 	navItemIndustry := iwidget.NewListItemWithIcon(
 		"Industry",
 		theme.NewThemedResource(icons.FactorySvg),
 		func() {
-			homeNav.Push(iwidget.NewAppBar("Industry",
+			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Industry",
 				container.NewAppTabs(
 					container.NewTabItem("Jobs", u.industryJobs),
 					container.NewTabItem("Slots", container.NewAppTabs(
@@ -274,7 +267,14 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		"Contracts",
 		theme.NewThemedResource(icons.FileSignSvg),
 		func() {
-			homeNav.Push(iwidget.NewAppBar("Contracts", u.contracts))
+			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Contracts", u.contracts))
+		},
+	)
+	navItemWealth := iwidget.NewListItemWithIcon(
+		"Wealth",
+		theme.NewThemedResource(icons.GoldSvg),
+		func() {
+			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Wealth", u.wealth))
 		},
 	)
 	homeList = iwidget.NewNavList(
@@ -282,14 +282,14 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			"Characters",
 			theme.NewThemedResource(icons.PortraitSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Characters", u.characters))
+				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Characters", u.characters))
 			},
 		),
 		iwidget.NewListItemWithIcon(
 			"Assets",
 			theme.NewThemedResource(icons.Inventory2Svg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Assets", u.assets))
+				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Assets", u.assets))
 				u.assets.focus()
 			},
 		),
@@ -297,7 +297,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			"Clones",
 			theme.NewThemedResource(icons.HeadSnowflakeSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Clones", u.clones))
+				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Clones", u.clones))
 			},
 		),
 		navItemContracts,
@@ -307,19 +307,18 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			"Locations",
 			theme.NewThemedResource(icons.MapMarkerSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Locations", u.locations))
+				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Locations", u.locations))
 			},
 		),
 		iwidget.NewListItemWithIcon(
 			"Training",
 			theme.NewThemedResource(icons.SchoolSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Training", u.training))
+				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Training", u.training))
 			},
 		),
 		navItemWealth,
 	)
-	homeNav = iwidget.NewNavigatorWithAppBar(iwidget.NewAppBar("Home", homeList))
 	u.contracts.OnUpdate = func(count int) {
 		s := "Active"
 		if count > 0 {
@@ -347,6 +346,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			homeList.Refresh()
 		})
 	}
+	homeNav = iwidget.NewNavigatorWithAppBar(iwidget.NewAppBar("Home", homeList))
 
 	// info destination
 	searchNav := iwidget.NewNavigatorWithAppBar(
@@ -430,7 +430,9 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 	}
 
 	navBar = iwidget.NewNavBar(homeDest, characterDest, searchDest, moreDest)
+	homeNav.NavBar = navBar
 	characterNav.NavBar = navBar
+	searchNav.NavBar = navBar
 
 	u.onUpdateStatus = func() {
 		go func() {

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -74,9 +74,9 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		theme.NewThemedResource(icons.Inventory2Svg),
 		func() {
 			u.characterAsset.OnSelected = func() {
-				characterNav.Push(newCharacterAppBar("Assets", u.characterAsset.LocationAssets))
+				characterNav.PushAndHideNavBar(newCharacterAppBar("Assets", u.characterAsset.LocationAssets))
 			}
-			characterNav.PushAndHideNavBar(newCharacterAppBar("Assets", container.NewHScroll(u.characterAsset.Locations)))
+			characterNav.Push(newCharacterAppBar("Assets", container.NewHScroll(u.characterAsset.Locations)))
 		},
 	)
 	navItemCommunications := iwidget.NewListItemWithIcon(
@@ -88,7 +88,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 					newCharacterAppBar("Communications", u.characterCommunications.Detail),
 				)
 			}
-			characterNav.PushAndHideNavBar(
+			characterNav.Push(
 				newCharacterAppBar(
 					"Communications",
 					u.characterCommunications.Notifications,
@@ -102,7 +102,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		theme.MailComposeIcon(),
 		func() {
 			u.characterMail.onSelected = func() {
-				characterNav.Push(
+				characterNav.PushAndHideNavBar(
 					newCharacterAppBar(
 						"Mail",
 						u.characterMail.Detail,
@@ -115,7 +115,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 					),
 				)
 			}
-			characterNav.PushAndHideNavBar(
+			characterNav.Push(
 				newCharacterAppBar(
 					"Mail",
 					u.characterMail.Headers,
@@ -128,7 +128,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		"Skills",
 		theme.NewThemedResource(icons.SchoolSvg),
 		func() {
-			characterNav.PushAndHideNavBar(
+			characterNav.Push(
 				newCharacterAppBar(
 					"Skills",
 					container.NewAppTabs(
@@ -143,7 +143,7 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 		"Wallet",
 		theme.NewThemedResource(icons.AttachmoneySvg),
 		func() {
-			characterNav.PushAndHideNavBar(
+			characterNav.Push(
 				newCharacterAppBar(
 					"Wallet",
 					container.NewAppTabs(
@@ -226,132 +226,9 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 	characterPage := newCharacterAppBar("Character", characterList)
 	characterNav = iwidget.NewNavigatorWithAppBar(characterPage)
 
-	// home destination
-	var homeNav *iwidget.Navigator
-	var homeList *iwidget.List
-	navItemColonies2 := iwidget.NewListItemWithIcon(
-		"Colonies",
-		theme.NewThemedResource(icons.EarthSvg),
-		func() {
-			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Colonies", u.colonies))
-		},
-	)
-	navItemIndustry := iwidget.NewListItemWithIcon(
-		"Industry",
-		theme.NewThemedResource(icons.FactorySvg),
-		func() {
-			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Industry",
-				container.NewAppTabs(
-					container.NewTabItem("Jobs", u.industryJobs),
-					container.NewTabItem("Slots", container.NewAppTabs(
-						container.NewTabItem("Manufacturing", u.slotsManufacturing),
-						container.NewTabItem("Science", u.slotsResearch),
-						container.NewTabItem("Reactions", u.slotsReactions),
-					)),
-				),
-			))
-		},
-	)
-	u.industryJobs.OnUpdate = func(count int) {
-		var badge string
-		if count > 0 {
-			badge = fmt.Sprintf("%s jobs ready", ihumanize.Comma(count))
-		}
-		fyne.Do(func() {
-			navItemIndustry.Supporting = badge
-			homeList.Refresh()
-		})
-	}
+	homeNav := makeHomeNav(u)
 
-	navItemContracts := iwidget.NewListItemWithIcon(
-		"Contracts",
-		theme.NewThemedResource(icons.FileSignSvg),
-		func() {
-			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Contracts", u.contracts))
-		},
-	)
-	navItemWealth := iwidget.NewListItemWithIcon(
-		"Wealth",
-		theme.NewThemedResource(icons.GoldSvg),
-		func() {
-			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Wealth", u.wealth))
-		},
-	)
-	homeList = iwidget.NewNavList(
-		iwidget.NewListItemWithIcon(
-			"Characters",
-			theme.NewThemedResource(icons.PortraitSvg),
-			func() {
-				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Characters", u.characters))
-			},
-		),
-		iwidget.NewListItemWithIcon(
-			"Assets",
-			theme.NewThemedResource(icons.Inventory2Svg),
-			func() {
-				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Assets", u.assets))
-				u.assets.focus()
-			},
-		),
-		iwidget.NewListItemWithIcon(
-			"Clones",
-			theme.NewThemedResource(icons.HeadSnowflakeSvg),
-			func() {
-				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Clones", u.clones))
-			},
-		),
-		navItemContracts,
-		navItemColonies2,
-		navItemIndustry,
-		iwidget.NewListItemWithIcon(
-			"Locations",
-			theme.NewThemedResource(icons.MapMarkerSvg),
-			func() {
-				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Locations", u.locations))
-			},
-		),
-		iwidget.NewListItemWithIcon(
-			"Training",
-			theme.NewThemedResource(icons.SchoolSvg),
-			func() {
-				homeNav.PushAndHideNavBar(iwidget.NewAppBar("Training", u.training))
-			},
-		),
-		navItemWealth,
-	)
-	u.contracts.OnUpdate = func(count int) {
-		s := "Active"
-		if count > 0 {
-			s += fmt.Sprintf(" (%d)", count)
-		}
-		fyne.Do(func() {
-			navItemContracts.Supporting = s
-			homeList.Refresh()
-		})
-	}
-
-	u.colonies.OnUpdate = func(_, expired int) {
-		fyne.Do(func() {
-			navItemColonies2.Supporting = fmt.Sprintf("%d expired", expired)
-			homeList.Refresh()
-		})
-	}
-	u.wealth.OnUpdate = func(wallet, assets float64) {
-		fyne.Do(func() {
-			navItemWealth.Supporting = fmt.Sprintf(
-				"Wallet: %s • Assets: %s",
-				ihumanize.Number(wallet, 1),
-				ihumanize.Number(assets, 1),
-			)
-			homeList.Refresh()
-		})
-	}
-	homeNav = iwidget.NewNavigatorWithAppBar(iwidget.NewAppBar("Home", homeList))
-
-	// info destination
-	searchNav := iwidget.NewNavigatorWithAppBar(
-		newCharacterAppBar("Search", u.gameSearch),
-	)
+	searchNav := makeSearchNav(newCharacterAppBar, u)
 
 	// more destination
 	var moreNav *iwidget.Navigator
@@ -532,4 +409,135 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 
 	u.MainWindow().SetContent(navBar)
 	return u
+}
+
+func makeSearchNav(newCharacterAppBar func(title string, body fyne.CanvasObject, items ...*kxwidget.IconButton) *iwidget.AppBar, u *MobileUI) *iwidget.Navigator {
+	searchNav := iwidget.NewNavigatorWithAppBar(
+		newCharacterAppBar("Search", u.gameSearch),
+	)
+	return searchNav
+}
+
+func makeHomeNav(u *MobileUI) *iwidget.Navigator {
+	var homeNav *iwidget.Navigator
+	var homeList *iwidget.List
+	navItemColonies2 := iwidget.NewListItemWithIcon(
+		"Colonies",
+		theme.NewThemedResource(icons.EarthSvg),
+		func() {
+			homeNav.PushAndHideNavBar(iwidget.NewAppBar("Colonies", u.colonies))
+		},
+	)
+	navItemIndustry := iwidget.NewListItemWithIcon(
+		"Industry",
+		theme.NewThemedResource(icons.FactorySvg),
+		func() {
+			homeNav.Push(iwidget.NewAppBar("Industry",
+				container.NewAppTabs(
+					container.NewTabItem("Jobs", u.industryJobs),
+					container.NewTabItem("Slots", container.NewAppTabs(
+						container.NewTabItem("Manufacturing", u.slotsManufacturing),
+						container.NewTabItem("Science", u.slotsResearch),
+						container.NewTabItem("Reactions", u.slotsReactions),
+					)),
+				),
+			))
+		},
+	)
+	u.industryJobs.OnUpdate = func(count int) {
+		var badge string
+		if count > 0 {
+			badge = fmt.Sprintf("%s jobs ready", ihumanize.Comma(count))
+		}
+		fyne.Do(func() {
+			navItemIndustry.Supporting = badge
+			homeList.Refresh()
+		})
+	}
+
+	navItemContracts := iwidget.NewListItemWithIcon(
+		"Contracts",
+		theme.NewThemedResource(icons.FileSignSvg),
+		func() {
+			homeNav.Push(iwidget.NewAppBar("Contracts", u.contracts))
+		},
+	)
+	navItemWealth := iwidget.NewListItemWithIcon(
+		"Wealth",
+		theme.NewThemedResource(icons.GoldSvg),
+		func() {
+			homeNav.Push(iwidget.NewAppBar("Wealth", u.wealth))
+		},
+	)
+	homeList = iwidget.NewNavList(
+		iwidget.NewListItemWithIcon(
+			"Characters",
+			theme.NewThemedResource(icons.PortraitSvg),
+			func() {
+				homeNav.Push(iwidget.NewAppBar("Characters", u.characters))
+			},
+		),
+		iwidget.NewListItemWithIcon(
+			"Assets",
+			theme.NewThemedResource(icons.Inventory2Svg),
+			func() {
+				homeNav.Push(iwidget.NewAppBar("Assets", u.assets))
+				u.assets.focus()
+			},
+		),
+		iwidget.NewListItemWithIcon(
+			"Clones",
+			theme.NewThemedResource(icons.HeadSnowflakeSvg),
+			func() {
+				homeNav.Push(iwidget.NewAppBar("Clones", u.clones))
+			},
+		),
+		navItemContracts,
+		navItemColonies2,
+		navItemIndustry,
+		iwidget.NewListItemWithIcon(
+			"Locations",
+			theme.NewThemedResource(icons.MapMarkerSvg),
+			func() {
+				homeNav.Push(iwidget.NewAppBar("Locations", u.locations))
+			},
+		),
+		iwidget.NewListItemWithIcon(
+			"Training",
+			theme.NewThemedResource(icons.SchoolSvg),
+			func() {
+				homeNav.Push(iwidget.NewAppBar("Training", u.training))
+			},
+		),
+		navItemWealth,
+	)
+	u.contracts.OnUpdate = func(count int) {
+		s := "Active"
+		if count > 0 {
+			s += fmt.Sprintf(" (%d)", count)
+		}
+		fyne.Do(func() {
+			navItemContracts.Supporting = s
+			homeList.Refresh()
+		})
+	}
+
+	u.colonies.OnUpdate = func(_, expired int) {
+		fyne.Do(func() {
+			navItemColonies2.Supporting = fmt.Sprintf("%d expired", expired)
+			homeList.Refresh()
+		})
+	}
+	u.wealth.OnUpdate = func(wallet, assets float64) {
+		fyne.Do(func() {
+			navItemWealth.Supporting = fmt.Sprintf(
+				"Wallet: %s • Assets: %s",
+				ihumanize.Number(wallet, 1),
+				ihumanize.Number(assets, 1),
+			)
+			homeList.Refresh()
+		})
+	}
+	homeNav = iwidget.NewNavigatorWithAppBar(iwidget.NewAppBar("Home", homeList))
+	return homeNav
 }

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -131,7 +131,7 @@ func (s Set[E]) Delete(v E) bool {
 }
 
 // DeleteFunc deletes the elements in s for which del returns true.
-// It returns the numnber of deleted elements.
+// It returns the number of deleted elements.
 func (s *Set[E]) DeleteFunc(del func(E) bool) int {
 	if del == nil {
 		return 0
@@ -148,7 +148,7 @@ func (s *Set[E]) DeleteFunc(del func(E) bool) int {
 
 // DeleteSeq deletes the elements in seq from s.
 // Elements that are not present are ignored.
-// It returns the numnber of deleted elements.
+// It returns the number of deleted elements.
 func (s *Set[E]) DeleteSeq(seq iter.Seq[E]) int {
 	var c int
 	for v := range seq {
@@ -189,6 +189,7 @@ func (s Set[E]) String() string {
 	for v := range s.All() {
 		p = append(p, fmt.Sprint(v))
 	}
+	slices.Sort(p)
 	return "{" + strings.Join(p, " ") + "}"
 }
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,0 +1,52 @@
+// Package Stack provides a simple Stack container.
+package stack
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrEmpty = errors.New("empty")
+
+// Stack represents a simple generic Stack.
+// The zero value is an empty stack ready to use.
+// A Stack is not thread safe.
+type Stack[T any] struct {
+	s []T
+}
+
+func (s *Stack[T]) Clear() {
+	s.s = s.s[0:0]
+}
+
+func (s *Stack[T]) Push(v T) {
+	if s.s == nil {
+		s.s = make([]T, 0)
+	}
+	s.s = append(s.s, v)
+}
+
+func (s Stack[T]) Peek() (T, error) {
+	var x T
+	if len(s.s) == 0 {
+		return x, ErrEmpty
+	}
+	return s.s[len(s.s)-1], nil
+}
+
+func (s *Stack[T]) Pop() (T, error) {
+	v, err := s.Peek()
+	if err != nil {
+		return v, err
+	}
+	s.s = s.s[:(len(s.s) - 1)]
+	return v, nil
+}
+
+func (s Stack[T]) Size() int {
+	return len(s.s)
+}
+
+func (s Stack[T]) String() string {
+	return fmt.Sprint(s.s)
+}

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,0 +1,64 @@
+package stack_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/stack"
+)
+
+func TestStack(t *testing.T) {
+	t.Run("can push and pop", func(t *testing.T) {
+		var s stack.Stack[int]
+		s.Push(99)
+		s.Push(42)
+		v, err := s.Pop()
+		if assert.NoError(t, err) {
+			assert.Equal(t, 42, v)
+		}
+		v, err = s.Pop()
+		if assert.NoError(t, err) {
+			assert.Equal(t, 99, v)
+		}
+	})
+	t.Run("should return specific error when trying to pop from empty stack", func(t *testing.T) {
+		var s stack.Stack[int]
+		_, err := s.Pop()
+		assert.ErrorIs(t, stack.ErrEmpty, err)
+	})
+	t.Run("should return correct stack size", func(t *testing.T) {
+		var s stack.Stack[int]
+		s.Push(99)
+		s.Push(42)
+		v := s.Size()
+		assert.Equal(t, 2, v)
+	})
+	t.Run("can clear the stack", func(t *testing.T) {
+		var s stack.Stack[int]
+		s.Push(99)
+		s.Clear()
+		assert.Equal(t, 0, s.Size())
+	})
+	t.Run("can return the current value without popping", func(t *testing.T) {
+		var s stack.Stack[int]
+		s.Push(99)
+		v, err := s.Peek()
+		if assert.NoError(t, err) {
+			assert.Equal(t, 99, v)
+			assert.Equal(t, 1, s.Size())
+		}
+	})
+	t.Run("should return specific error when trying to peek at empty stack", func(t *testing.T) {
+		var s stack.Stack[int]
+		_, err := s.Peek()
+		assert.ErrorIs(t, stack.ErrEmpty, err)
+	})
+	t.Run("can print stack", func(t *testing.T) {
+		var s stack.Stack[int]
+		s.Push(99)
+		x := fmt.Sprint(s)
+		assert.Equal(t, "[99]", x)
+	})
+}

--- a/internal/widget/appbar.go
+++ b/internal/widget/appbar.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
+	"github.com/ErikKalkoken/evebuddy/internal/stack"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 )
 
@@ -21,17 +22,19 @@ type Navigator struct {
 
 	NavBar *NavBar // Current navbar. Required for hide feature.
 
-	stack *fyne.Container // stack of pages. First object is the root page.
+	pages      *fyne.Container // stack of pages. First object is the root page.
+	hideNavBar stack.Stack[bool]
 }
 
 // NewNavigatorWithAppBar return a new Navigator and defines the root page.
 func NewNavigatorWithAppBar(ab *AppBar) *Navigator {
 	n := &Navigator{
-		stack: container.NewStack(),
+		pages: container.NewStack(),
 	}
 	n.ExtendBaseWidget(n)
 	if ab != nil {
-		n.stack.Add(ab)
+		n.pages.Add(ab)
+		n.hideNavBar.Push(false)
 	}
 	return n
 }
@@ -47,17 +50,19 @@ func (n *Navigator) Push(ab *AppBar) {
 }
 
 func (n *Navigator) Set(ab *AppBar) {
-	n.stack.RemoveAll()
-	n.stack.Add(ab)
+	n.pages.RemoveAll()
+	n.pages.Add(ab)
+	n.hideNavBar.Clear()
+	n.hideNavBar.Push(false)
 	n.Refresh()
 }
 
 func (n *Navigator) IsEmpty() bool {
-	return len(n.stack.Objects) == 0
+	return len(n.pages.Objects) == 0
 }
 
-// PushHideNavBar adds a new page and shows it while hiding the navbar.
-func (n *Navigator) PushHideNavBar(ab *AppBar) {
+// PushAndHideNavBar adds a new page and shows it while hiding the navbar.
+func (n *Navigator) PushAndHideNavBar(ab *AppBar) {
 	n.push(ab, true)
 }
 
@@ -67,31 +72,39 @@ func (n *Navigator) push(ab *AppBar, hideNavBar bool) {
 		n.NavBar.HideBar()
 	}
 	previous := n.topPage()
-	n.stack.Add(ab)
+	n.pages.Add(ab)
+	n.hideNavBar.Push(hideNavBar)
 	previous.Hide()
 }
 
 // Pop removes the current page and shows the previous page.
 // Does nothing when the root page is shown.
 func (n *Navigator) Pop() {
-	if len(n.stack.Objects) < 2 {
+	if len(n.pages.Objects) < 2 {
 		return
 	}
-	n.stack.Remove(n.topPage())
+	n.pages.Remove(n.topPage())
+	n.hideNavBar.Pop()
 	n.topPage().Show()
 	if n.NavBar != nil {
-		n.NavBar.ShowBar()
+		v, err := n.hideNavBar.Peek()
+		if err != nil {
+			panic(err)
+		}
+		if !v {
+			n.NavBar.ShowBar()
+		}
 	}
 }
 
 // PopAll removes all additional pages and shows the root page.
 // Does nothing when the root page is shown.
 func (n *Navigator) PopAll() {
-	if len(n.stack.Objects) == 0 {
+	if len(n.pages.Objects) == 0 {
 		return
 	}
-	for len(n.stack.Objects) > 1 {
-		n.stack.Remove(n.topPage())
+	for len(n.pages.Objects) > 1 {
+		n.pages.Remove(n.topPage())
 	}
 	n.topPage().Show()
 	if n.NavBar != nil {
@@ -100,11 +113,11 @@ func (n *Navigator) PopAll() {
 }
 
 func (n *Navigator) topPage() fyne.CanvasObject {
-	return n.stack.Objects[len(n.stack.Objects)-1]
+	return n.pages.Objects[len(n.pages.Objects)-1]
 }
 
 func (n *Navigator) CreateRenderer() fyne.WidgetRenderer {
-	return widget.NewSimpleRenderer(n.stack)
+	return widget.NewSimpleRenderer(n.pages)
 }
 
 // An AppBar displays navigation, actions, and text at the top of a screen.

--- a/internal/widget/appbar.go
+++ b/internal/widget/appbar.go
@@ -86,15 +86,7 @@ func (n *Navigator) Pop() {
 	n.pages.Remove(n.topPage())
 	n.hideNavBar.Pop()
 	n.topPage().Show()
-	if n.NavBar != nil {
-		v, err := n.hideNavBar.Peek()
-		if err != nil {
-			panic(err)
-		}
-		if !v {
-			n.NavBar.ShowBar()
-		}
-	}
+	n.showNavBarWhenRequired()
 }
 
 // PopAll removes all additional pages and shows the root page.
@@ -105,11 +97,24 @@ func (n *Navigator) PopAll() {
 	}
 	for len(n.pages.Objects) > 1 {
 		n.pages.Remove(n.topPage())
+		n.hideNavBar.Pop()
 	}
 	n.topPage().Show()
-	if n.NavBar != nil {
+	n.showNavBarWhenRequired()
+}
+
+func (n *Navigator) showNavBarWhenRequired() {
+	if n.NavBar == nil {
+		return
+	}
+	v, err := n.hideNavBar.Peek()
+	if err != nil {
+		panic(err)
+	}
+	if !v {
 		n.NavBar.ShowBar()
 	}
+
 }
 
 func (n *Navigator) topPage() fyne.CanvasObject {

--- a/internal/widget/navbar.go
+++ b/internal/widget/navbar.go
@@ -246,7 +246,7 @@ func (w *NavBar) Disable(id int) {
 
 // HideBar hides the nav bar, while still showing the rest of the page.
 func (w *NavBar) HideBar() {
-	w.destinations.Hide()
+	w.bar.Hide()
 }
 
 // Select switches to a new destination.
@@ -265,7 +265,7 @@ func (w *NavBar) Select(id int) {
 
 // ShowBar shows the nav bar again.
 func (w *NavBar) ShowBar() {
-	w.destinations.Show()
+	w.bar.Show()
 }
 
 // SetBadge shows or hides the badge of a destination.

--- a/tools/genchars/builder.go
+++ b/tools/genchars/builder.go
@@ -14,18 +14,20 @@ import (
 const (
 	assetItemsPerLocation      = 100
 	assetTypes                 = 10
+	contracts                  = 1
+	contractItems              = 1
 	implants                   = 2
 	jumpClones                 = 2
 	locations                  = 5
 	mailEntities               = 50
-	mailMaxRecipients          = 3
-	mails                      = 1000
 	mailLabels                 = 10
 	mailLists                  = 10
+	mailMaxRecipients          = 3
+	mails                      = 1000
 	notifications              = 1000
+	skillGroups                = 2
 	skillqueue                 = 2
 	skills                     = 5
-	skillGroups                = 2
 	walletJournalEntries       = 1000
 	walletJournalEntryEntities = 25
 	walletTransactionClients   = 25
@@ -61,6 +63,7 @@ func (b *CharacterBuilder) Create() {
 	b.createAttributes()
 	b.createImplants()
 	b.createAssets()
+	b.createContracts()
 	b.createJumpClones()
 	b.createMail()
 	b.createNotifications()
@@ -121,6 +124,27 @@ func (b *CharacterBuilder) createCharacter() {
 	})
 	b.f.CreateCharacterToken(app.CharacterToken{CharacterID: c.ID})
 	fmt.Printf("Creating new character %s with factor %d\n", b.c.EveCharacter.Name, b.Factor)
+}
+
+func (b *CharacterBuilder) createContracts() {
+	makeTypeID := b.makeRandomTypes(assetTypes * b.Factor)
+	var count int
+	for range contracts * b.Factor {
+		o := b.f.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: b.c.ID,
+			Type:        app.ContractTypeItemExchange,
+			Price:       float64(rand.IntN(10_000_000*100)) / 100,
+		})
+		for range contractItems {
+			b.f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+				ContractID: o.ID,
+				TypeID:     makeTypeID(),
+				IsIncluded: true,
+			})
+		}
+		count++
+	}
+	printSummary("contracts", count)
 }
 
 func (b *CharacterBuilder) createImplants() {


### PR DESCRIPTION
- Re-design of the wallet lists for mobile (both wallet journal and wallet transactions) to make it easier to read, fit more entries on the screen and improve scroll performance
- Tapping an entry now opens a window with details for each entry. Works both for mobile and desktop.
- Adds context links for both journal entries and transactions. e.g. journal entries can link to a related contract or transaction, transaction can link to the related journal entry
- Technical: Navigator widget now supports hiding the navbar on nested pages