### PR TITLE
feat: Add theme switcher

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.30.2"
+  Version = "0.31.0"
   Build = 0
 
 [Release]

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -11,8 +11,18 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
+type ColorTheme string
+
+const (
+	Auto  ColorTheme = "Auto"
+	Light ColorTheme = "Light"
+	Dark  ColorTheme = "Dark"
+)
+
 const (
 	notifyEarliestFallback                    = 24 * time.Hour
+	settingColorTheme                         = "color-theme"
+	settingColorThemeDefault                  = Auto
 	settingDeveloperMode                      = "developer-mode"
 	settingDeveloperModeDefault               = false
 	settingLastCharacterID                    = "settingLastCharacterID"
@@ -399,6 +409,23 @@ func (s Settings) ResetPreferMarketTab() {
 
 func (s Settings) SetPreferMarketTab(v bool) {
 	s.p.SetBool(settingPreferMarketTab, v)
+}
+
+func (s Settings) ColorTheme() ColorTheme {
+	x := s.p.StringWithFallback(settingColorTheme, string(settingColorThemeDefault))
+	return ColorTheme(x)
+}
+
+func (s Settings) ColorThemeDefault() ColorTheme {
+	return settingColorThemeDefault
+}
+
+func (s Settings) ResetColorTheme() {
+	s.SetColorTheme(settingColorThemeDefault)
+}
+
+func (s Settings) SetColorTheme(v ColorTheme) {
+	s.p.SetString(settingColorTheme, string(v))
 }
 
 // Keys returns all setting keys. Mostly to know what to delete.

--- a/internal/app/settings/settings_test.go
+++ b/internal/app/settings/settings_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAppSettings(t *testing.T) {
+func TestSettings(t *testing.T) {
 	t.Run("Window size", func(t *testing.T) {
 		p := settings.NewMyPref()
 		s := settings.New(p)
@@ -41,14 +41,18 @@ func TestAppSettings(t *testing.T) {
 		want := s.NotificationTypesEnabled()
 		assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
 	})
-	t.Run("Color theme", func(t *testing.T) {
+}
+
+func TestColorTheme(t *testing.T) {
+	t.Run("Default theme", func(t *testing.T) {
 		s := settings.New(settings.NewMyPref())
-
 		x1 := s.ColorTheme()
-		assert.Equal(t, "", x1)
-
-		s.SetColorTheme("alpha")
-		x2 := s.ColorTheme()
-		assert.Equal(t, "alpha", x2)
+		assert.Equal(t, settings.Auto, x1)
+	})
+	t.Run("Can set and get theme", func(t *testing.T) {
+		s := settings.New(settings.NewMyPref())
+		s.SetColorTheme(settings.Dark)
+		x1 := s.ColorTheme()
+		assert.Equal(t, settings.Dark, x1)
 	})
 }

--- a/internal/app/settings/settings_test.go
+++ b/internal/app/settings/settings_test.go
@@ -41,4 +41,14 @@ func TestAppSettings(t *testing.T) {
 		want := s.NotificationTypesEnabled()
 		assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
 	})
+	t.Run("Color theme", func(t *testing.T) {
+		s := settings.New(settings.NewMyPref())
+
+		x1 := s.ColorTheme()
+		assert.Equal(t, "", x1)
+
+		s.SetColorTheme("alpha")
+		x2 := s.ColorTheme()
+		assert.Equal(t, "alpha", x2)
+	})
 }

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -23,6 +23,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 	kxdialog "github.com/ErikKalkoken/fyne-kx/dialog"
 	kxmodal "github.com/ErikKalkoken/fyne-kx/modal"
+	kxtheme "github.com/ErikKalkoken/fyne-kx/theme"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
@@ -249,6 +250,7 @@ func NewBaseUI(args BaseUIParams) *baseUI {
 		} else {
 			slog.Info("App started")
 		}
+		u.setColorTheme(u.settings.ColorTheme())
 		u.isForeground.Store(true)
 		u.snackbar.Start()
 		go func() {
@@ -575,6 +577,17 @@ func (u *baseUI) updateAvatar(id int32, setIcon func(fyne.Resource)) {
 		r2 = icons.Characterplaceholder64Jpeg
 	}
 	setIcon(r2)
+}
+
+func (u *baseUI) setColorTheme(s settings.ColorTheme) {
+	switch s {
+	case settings.Light:
+		u.app.Settings().SetTheme(kxtheme.DefaultWithFixedVariant(theme.VariantLight))
+	case settings.Dark:
+		u.app.Settings().SetTheme(kxtheme.DefaultWithFixedVariant(theme.VariantDark))
+	default:
+		u.app.Settings().SetTheme(theme.DefaultTheme())
+	}
 }
 
 func (u *baseUI) updateMailIndicator() {

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/evenotification"
 	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
+	"github.com/ErikKalkoken/evebuddy/internal/app/settings"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
@@ -118,6 +119,7 @@ func (a *userSettings) makeGeneralSettingsPage() (fyne.CanvasObject, *kxwidget.I
 		},
 		a.w,
 	)
+
 	vMin, vMax, vDef := a.u.settings.MaxMailsPresets()
 	maxMail := NewSettingItemSlider(
 		"Maximum mails",
@@ -133,6 +135,7 @@ func (a *userSettings) makeGeneralSettingsPage() (fyne.CanvasObject, *kxwidget.I
 		},
 		a.w,
 	)
+
 	vMin, vMax, vDef = a.u.settings.MaxWalletTransactionsPresets()
 	maxWallet := NewSettingItemSlider(
 		"Maximum wallet transaction",
@@ -148,6 +151,7 @@ func (a *userSettings) makeGeneralSettingsPage() (fyne.CanvasObject, *kxwidget.I
 		},
 		a.w,
 	)
+
 	preferMarketTab := NewSettingItemSwitch(
 		"Prefer market tab",
 		"Show market tab for tradeable items",
@@ -158,6 +162,23 @@ func (a *userSettings) makeGeneralSettingsPage() (fyne.CanvasObject, *kxwidget.I
 			a.u.settings.SetPreferMarketTab(v)
 		},
 	)
+
+	colorTheme := NewSettingItemOptions(
+		"Appearance",
+		"Choose the color scheme. 'Auto' uses the current OS theme.",
+		[]string{string(settings.Auto), string(settings.Light), string(settings.Dark)},
+		string(a.u.settings.ColorThemeDefault()),
+		func() string {
+			return string(a.u.settings.ColorTheme())
+		},
+		func(v string) {
+			s := a.u.settings
+			s.SetColorTheme(settings.ColorTheme(v))
+			a.u.setColorTheme(settings.ColorTheme(v))
+		},
+		a.w,
+	)
+
 	developerMode := NewSettingItemSwitch(
 		"Developer Mode",
 		"App shows additional technical information like Character IDs",
@@ -172,6 +193,7 @@ func (a *userSettings) makeGeneralSettingsPage() (fyne.CanvasObject, *kxwidget.I
 	items := []SettingItem{
 		NewSettingItemHeading("Application"),
 		logLevel,
+		colorTheme,
 		preferMarketTab,
 		developerMode,
 		NewSettingItemSeparator(),


### PR DESCRIPTION
Adds a color theme switcher with the options:
- Auto (= current OS theme)
- Light
- Dark
