### PR TITLE
fix: skill progress bar shown in inactive skills

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.32.0"
+  Version = "0.32.1"
   Build = 0
 
 [Release]

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -194,6 +194,8 @@ func timeFormattedOrFallback(t time.Time, layout, fallback string) string {
 type skillQueueItem struct {
 	widget.BaseWidget
 
+	Placeholder string
+
 	duration *widget.Label
 	isMobile bool
 	name     *widget.Label
@@ -201,16 +203,16 @@ type skillQueueItem struct {
 }
 
 func newSkillQueueItem() *skillQueueItem {
-	name := widget.NewLabel("N/A")
-	name.Truncation = fyne.TextTruncateEllipsis
 	pb := widget.NewProgressBar()
 	w := &skillQueueItem{
-		duration: widget.NewLabel(""),
-		name:     name,
-		progress: pb,
-		isMobile: fyne.CurrentDevice().IsMobile(),
+		Placeholder: "N/A",
+		duration:    widget.NewLabel(""),
+		progress:    pb,
+		isMobile:    fyne.CurrentDevice().IsMobile(),
 	}
 	w.ExtendBaseWidget(w)
+	w.name = widget.NewLabel(w.Placeholder)
+	w.name.Truncation = fyne.TextTruncateEllipsis
 	pb.Hide()
 	if w.isMobile {
 		pb.TextFormatter = func() string {
@@ -229,7 +231,7 @@ func (w *skillQueueItem) Set(qi *app.CharacterSkillqueueItem) {
 		name        string
 	)
 	if qi == nil {
-		return
+		name = w.Placeholder
 	} else {
 		isActive = qi.IsActive()
 		completionP = qi.CompletionP()

--- a/internal/app/ui/locations.go
+++ b/internal/app/ui/locations.go
@@ -127,13 +127,14 @@ func (a *locations) makeDataList() *iwidget.StripedList {
 			return len(a.rowsFiltered)
 		},
 		func() fyne.CanvasObject {
-			title := widget.NewLabelWithStyle("Template", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
-			title.Wrapping = fyne.TextWrapWord
+			character := widget.NewLabel("Template")
+			character.Wrapping = fyne.TextWrapWord
+			character.SizeName = theme.SizeNameSubHeadingText
 			location := iwidget.NewRichTextWithText("Template")
 			location.Wrapping = fyne.TextWrapWord
 			ship := widget.NewLabel("Template")
 			return container.New(layout.NewCustomPaddedVBoxLayout(-p),
-				title,
+				character,
 				location,
 				ship,
 			)


### PR DESCRIPTION
# Fixed
- Training mobile: Progress bar of active entry can appear inside entry of inactive entry