### PR TITLE
fix: some reactions not detected

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.32.2"
+  Version = "0.32.3"
   Build = 0
 
 [Release]

--- a/internal/app/characterservice/character_test.go
+++ b/internal/app/characterservice/character_test.go
@@ -1181,22 +1181,22 @@ func TestListAllCharactersIndustrySlots(t *testing.T) {
 		})
 		factory.CreateCharacterIndustryJob(storage.UpdateOrCreateCharacterIndustryJobParams{
 			CharacterID: character.ID,
-			ActivityID:  int32(app.Reactions),
+			ActivityID:  int32(app.Reactions1),
 			Status:      app.JobActive,
 		})
 		factory.CreateCharacterIndustryJob(storage.UpdateOrCreateCharacterIndustryJobParams{
 			CharacterID: character.ID,
-			ActivityID:  int32(app.Reactions),
+			ActivityID:  int32(app.Reactions2),
 			Status:      app.JobActive,
 		})
 		factory.CreateCharacterIndustryJob(storage.UpdateOrCreateCharacterIndustryJobParams{
 			CharacterID: character.ID,
-			ActivityID:  int32(app.Reactions),
+			ActivityID:  int32(app.Reactions2),
 			Status:      app.JobReady,
 		})
 		factory.CreateCharacterIndustryJob(storage.UpdateOrCreateCharacterIndustryJobParams{
 			CharacterID: character.ID,
-			ActivityID:  int32(app.Reactions),
+			ActivityID:  int32(app.Reactions2),
 			Status:      app.JobDelivered,
 		})
 		got, err := cs.ListAllCharactersIndustrySlots(ctx, app.ReactionJob)

--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -1,3 +1,4 @@
+// Package corporationservice contains the corporation service.
 package corporationservice
 
 import (
@@ -46,7 +47,7 @@ type Params struct {
 	StatusCacheService *statuscacheservice.StatusCacheService
 	Storage            *storage.Storage
 	// optional
-	HttpClient *http.Client
+	HTTPClient *http.Client
 	EsiClient  *goesi.APIClient
 }
 
@@ -60,10 +61,10 @@ func New(args Params) *CorporationService {
 		st:  args.Storage,
 		sfg: new(singleflight.Group),
 	}
-	if args.HttpClient == nil {
+	if args.HTTPClient == nil {
 		s.httpClient = http.DefaultClient
 	} else {
-		s.httpClient = args.HttpClient
+		s.httpClient = args.HTTPClient
 	}
 	if args.EsiClient == nil {
 		s.esiClient = goesi.NewAPIClient(s.httpClient, "")

--- a/internal/app/industry.go
+++ b/internal/app/industry.go
@@ -24,7 +24,7 @@ const (
 var industryJobType2Activity = map[IndustryJobType]set.Set[IndustryActivity]{
 	ManufacturingJob: set.Of(Manufacturing),
 	ScienceJob:       set.Of(TimeEfficiencyResearch, MaterialEfficiencyResearch, Copying, Invention),
-	ReactionJob:      set.Of(Reactions),
+	ReactionJob:      set.Of(Reactions1, Reactions2),
 }
 
 // Activities returns the industry activities that belong to a job type.
@@ -68,7 +68,8 @@ const (
 	MaterialEfficiencyResearch IndustryActivity = 4
 	Copying                    IndustryActivity = 5
 	Invention                  IndustryActivity = 8
-	Reactions                  IndustryActivity = 11
+	Reactions1                 IndustryActivity = 9
+	Reactions2                 IndustryActivity = 11
 )
 
 func (a IndustryActivity) String() string {
@@ -79,7 +80,8 @@ func (a IndustryActivity) String() string {
 		MaterialEfficiencyResearch: "material efficiency research",
 		Copying:                    "copying",
 		Invention:                  "invention",
-		Reactions:                  "reactions",
+		Reactions1:                 "reactions",
+		Reactions2:                 "reactions",
 	}
 	s, ok := m[a]
 	if !ok {

--- a/internal/app/storage/characterindustryjob_test.go
+++ b/internal/app/storage/characterindustryjob_test.go
@@ -321,7 +321,7 @@ func TestCharacterIndustryJob(t *testing.T) {
 		})
 		factory.CreateCharacterIndustryJob(storage.UpdateOrCreateCharacterIndustryJobParams{
 			CharacterID: character1.ID,
-			ActivityID:  int32(app.Reactions),
+			ActivityID:  int32(app.Reactions2),
 			Status:      app.JobActive,
 		})
 		character2 := factory.CreateCharacterFull()
@@ -342,7 +342,7 @@ func TestCharacterIndustryJob(t *testing.T) {
 			want := []app.IndustryJobActivityCount{
 				{InstallerID: character1.ID, Activity: app.Manufacturing, Status: app.JobActive, Count: 3},
 				{InstallerID: character1.ID, Activity: app.Manufacturing, Status: app.JobReady, Count: 1},
-				{InstallerID: character1.ID, Activity: app.Reactions, Status: app.JobActive, Count: 1},
+				{InstallerID: character1.ID, Activity: app.Reactions2, Status: app.JobActive, Count: 1},
 				{InstallerID: character2.ID, Activity: app.Manufacturing, Status: app.JobActive, Count: 1},
 			}
 			assert.ElementsMatch(t, want, got)

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -422,7 +422,7 @@ func (f Factory) CreateCharacterIndustryJob(args ...storage.UpdateOrCreateCharac
 			app.MaterialEfficiencyResearch,
 			app.Copying,
 			app.Invention,
-			app.Reactions,
+			app.Reactions2,
 		}
 		arg.ActivityID = int32(activities[rand.IntN(len(activities))])
 	}
@@ -1069,7 +1069,7 @@ func (f Factory) CreateCorporationIndustryJob(args ...storage.UpdateOrCreateCorp
 			app.MaterialEfficiencyResearch,
 			app.Copying,
 			app.Invention,
-			app.Reactions,
+			app.Reactions2,
 		}
 		arg.ActivityID = int32(activities[rand.IntN(len(activities))])
 	}

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -277,7 +277,7 @@ func (a *industryJobs) filterRows(sortCol int) {
 			case industryActivityMaterialResearch:
 				return r.activity == app.MaterialEfficiencyResearch
 			case industryActivityReaction:
-				return r.activity == app.Reactions
+				return r.activity == app.Reactions1 || r.activity == app.Reactions2
 			case industryActivityTimeResearch:
 				return r.activity == app.TimeEfficiencyResearch
 			}
@@ -359,7 +359,7 @@ func (a *industryJobs) makeDataList() *iwidget.StripedList {
 		app.TimeEfficiencyResearch:     theme.NewThemedResource(icons.IndytimeresearchSvg),
 		app.Copying:                    theme.NewThemedResource(icons.IndycopyingSvg),
 		app.Invention:                  theme.NewThemedResource(icons.IndyinventionSvg),
-		app.Reactions:                  theme.NewThemedResource(icons.IndyreactionsSvg),
+		app.Reactions2:                 theme.NewThemedResource(icons.IndyreactionsSvg),
 	}
 	var l *iwidget.StripedList
 	l = iwidget.NewStripedList(

--- a/main.go
+++ b/main.go
@@ -276,7 +276,7 @@ func main() {
 		CharacterService:   cs,
 		EsiClient:          esiClient,
 		EveUniverseService: eus,
-		HttpClient:         rhc.StandardClient(),
+		HTTPClient:         rhc.StandardClient(),
 		StatusCacheService: scs,
 		Storage:            st,
 	})


### PR DESCRIPTION
This fixes a bug where some reactions where not detected correctly, i.e. not showing up in the slots calculation and their activity label shown as "?".

Relates to this known quirk in ESI: [Industry jobs activity id changed to enum](https://github.com/esi/esi-issues/issues/894)