### PR TITLE
fix: remaining queue time not always correct (#182)

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.32.3"
+  Version = "0.32.4"
   Build = 0
 
 [Release]

--- a/internal/app/storage/characterskillqueueitem.go
+++ b/internal/app/storage/characterskillqueueitem.go
@@ -96,6 +96,7 @@ func (st *Storage) GetCharacterSkillqueueItem(ctx context.Context, characterID i
 	}), err
 }
 
+// ListCharacterSkillqueueItems returns the skillqueue for a character. Items are ordered by queue position.
 func (st *Storage) ListCharacterSkillqueueItems(ctx context.Context, characterID int32) ([]*app.CharacterSkillqueueItem, error) {
 	if characterID == 0 {
 		return nil, fmt.Errorf("ListCharacterSkillqueueItems: %w", app.ErrInvalid)

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -151,7 +151,7 @@ func (a *characterSkillQueue) update() {
 			s2 = "training paused"
 		} else if c := a.sq.CompletionP(); c.ValueOrZero() < 1 {
 			s1 = fmt.Sprintf("%.0f%%", c.ValueOrZero()*100)
-			s2 = fmt.Sprintf("%s (%s)", a.sq.Current(), s1)
+			s2 = fmt.Sprintf("%s (%s)", a.sq.Active(), s1)
 		}
 		if a.OnUpdate != nil {
 			a.OnUpdate(s1, s2)

--- a/internal/app/ui/training.go
+++ b/internal/app/ui/training.go
@@ -397,7 +397,7 @@ func (*training) fetchRows(s services) ([]trainingRow, error) {
 		if err := queue.Update(ctx, s.cs, c.ID); err != nil {
 			return nil, err
 		}
-		r.skill = queue.Current()
+		r.skill = queue.Active()
 		if r.skill != nil {
 			r.isActive = true
 			r.statusText = "Active"
@@ -418,7 +418,7 @@ func (*training) fetchRows(s services) ([]trainingRow, error) {
 				},
 			)
 		}
-		r.totalFinishDate = queue.FinishDateEstimate()
+		r.totalFinishDate = queue.FinishDate()
 		r.totalRemainingCount = queue.RemainingCount()
 		r.totalRemainingCountDisplay = r.totalRemainingCount.StringFunc("N/A", func(v int) string {
 			return ihumanize.Comma(v)


### PR DESCRIPTION
The calculation of the queue time is simplified and directly taking from the ESI response. This should fix #182 .