### PR TITLE
feat: improve detail windows & fixes

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,7 +4,7 @@ Website = "https://github.com/ErikKalkoken/evebuddy"
   Icon = "icon.png"
   Name = "EVE Buddy"
   ID = "io.github.erikkalkoken.evebuddy"
-  Version = "0.36.3"
+  Version = "0.37.0"
   Build = 0
 
 [Release]

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/maniartech/signals v1.2.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/maniartech/signals v1.2.0 h1:Z2syAD1hqvum9C4QOV9y8pFOS31Du3tRmVaQA5EG7FM=
+github.com/maniartech/signals v1.2.0/go.mod h1:AbE8Yy9ZjKCWNU/VhQ+0Ea9KOaTWHp6aOfdLBe5m1iM=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -243,11 +243,11 @@ func (s *CharacterService) UpdateOrCreateCharacterFromSSO(ctx context.Context, s
 	if err := s.scs.UpdateCharacters(ctx); err != nil {
 		return 0, err
 	}
+	setInfo("Fetching corporation from game server. Please wait...")
+	if _, err := s.eus.GetOrCreateCorporationESI(ctx, character.Corporation.ID); err != nil {
+		return 0, err
+	}
 	if x := character.Corporation.IsNPC(); !x.IsEmpty() && !x.ValueOrZero() {
-		setInfo("Fetching corporation from game server. Please wait...")
-		if _, err := s.eus.GetOrCreateCorporationESI(ctx, character.Corporation.ID); err != nil {
-			return 0, err
-		}
 		if _, err = s.st.GetOrCreateCorporation(ctx, character.Corporation.ID); err != nil {
 			return 0, err
 		}

--- a/internal/app/ui/assets.go
+++ b/internal/app/ui/assets.go
@@ -499,7 +499,7 @@ func (a *assets) characterCount() int {
 
 // showAssetDetailWindow shows the details for a character assets in a new window.
 func showAssetDetailWindow(u *baseUI, r assetRow) {
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", r.characterID, r.itemID), "Asset: Information", r.characterName)
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("asset-%d-%d", r.characterID, r.itemID), "Asset: Information", r.characterName)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/assets.go
+++ b/internal/app/ui/assets.go
@@ -540,6 +540,11 @@ func showAssetDetailWindow(u *baseUI, r assetRow) {
 	f := widget.NewForm(fi...)
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Asset #%d", r.itemID)
-	setDetailWindowWithSize(subTitle, fyne.NewSize(500, 450), f, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		minSize: fyne.NewSize(500, 450),
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/assets.go
+++ b/internal/app/ui/assets.go
@@ -54,6 +54,7 @@ type assetRow struct {
 	typeID          int32
 	typeName        string
 	typeNameDisplay string
+	variant         app.EveTypeVariant
 }
 
 func newAssetRow(ca *app.CharacterAsset, assetCollection assetcollection.AssetCollection, characterName func(int32) string) assetRow {
@@ -68,6 +69,7 @@ func newAssetRow(ca *app.CharacterAsset, assetCollection assetcollection.AssetCo
 		typeID:          ca.Type.ID,
 		typeName:        ca.Type.Name,
 		typeNameDisplay: ca.DisplayName2(),
+		variant:         ca.Variant(),
 	}
 	if ca.IsSingleton {
 		r.quantityDisplay = "1*"
@@ -541,9 +543,24 @@ func showAssetDetailWindow(u *baseUI, r assetRow) {
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Asset #%d", r.itemID)
 	setDetailWindow(detailWindowParams{
-		title:   subTitle,
-		minSize: fyne.NewSize(500, 450),
 		content: f,
+		imageAction: func() {
+			u.ShowTypeInfoWindow(r.typeID)
+		},
+		imageLoader: func() (fyne.Resource, error) {
+			switch r.variant {
+			case app.VariantSKIN:
+				return u.eis.InventoryTypeSKIN(r.typeID, app.IconPixelSize)
+			case app.VariantBPO:
+				return u.eis.InventoryTypeBPO(r.typeID, app.IconPixelSize)
+			case app.VariantBPC:
+				return u.eis.InventoryTypeBPC(r.typeID, app.IconPixelSize)
+			default:
+				return u.eis.InventoryTypeIcon(r.typeID, app.IconPixelSize)
+			}
+		},
+		minSize: fyne.NewSize(500, 450),
+		title:   subTitle,
 		window:  w,
 	})
 	w.Show()

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -270,12 +270,12 @@ func (a *characterJumpClones) startUpdateTicker() {
 	ticker := time.NewTicker(time.Second * 15)
 	go func() {
 		for {
+			<-ticker.C
 			var c int
 			fyne.DoAndWait(func() {
 				c = cloneCount(a.tree.Nodes())
 			})
 			a.refreshTop(c)
-			<-ticker.C
 		}
 	}()
 }

--- a/internal/app/ui/characterlocations.go
+++ b/internal/app/ui/characterlocations.go
@@ -335,10 +335,16 @@ func showCharacterLocationWindow(u *baseUI, r characterLocationRow) {
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Location of %s", r.characterName)
 	setDetailWindow(detailWindowParams{
-		title:   subTitle,
-		minSize: fyne.NewSize(500, 250),
 		content: f,
-		window:  w,
+		minSize: fyne.NewSize(500, 250),
+		imageAction: func() {
+			u.ShowInfoWindow(app.EveEntityCharacter, r.characterID)
+		},
+		imageLoader: func() (fyne.Resource, error) {
+			return u.eis.CharacterPortrait(r.characterID, 512)
+		},
+		title:  subTitle,
+		window: w,
 	})
 	w.Show()
 }

--- a/internal/app/ui/characterlocations.go
+++ b/internal/app/ui/characterlocations.go
@@ -334,6 +334,11 @@ func showCharacterLocationWindow(u *baseUI, r characterLocationRow) {
 	f := widget.NewForm(fi...)
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Location of %s", r.characterName)
-	setDetailWindowWithSize(subTitle, fyne.NewSize(500, 250), f, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		minSize: fyne.NewSize(500, 250),
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/characterlocations_internal_test.go
+++ b/internal/app/ui/characterlocations_internal_test.go
@@ -35,11 +35,11 @@ func TestLocations_CanRenderWithData(t *testing.T) {
 	})
 	test.ApplyTheme(t, test.Theme())
 	ui := NewFakeBaseUI(st, test.NewTempApp(t), true)
-	w := test.NewWindow(ui.locations)
+	w := test.NewWindow(ui.characterLocations)
 	defer w.Close()
 	w.Resize(fyne.NewSize(1700, 300))
 
-	ui.locations.update()
+	ui.characterLocations.update()
 
 	test.AssertImageMatches(t, "locations/full.png", w.Canvas().Capture())
 }
@@ -55,11 +55,11 @@ func TestLocations_CanRenderWithoutData(t *testing.T) {
 	})
 	test.ApplyTheme(t, test.Theme())
 	ui := NewFakeBaseUI(st, test.NewTempApp(t), true)
-	w := test.NewWindow(ui.locations)
+	w := test.NewWindow(ui.characterLocations)
 	defer w.Close()
 	w.Resize(fyne.NewSize(1700, 300))
 
-	ui.locations.update()
+	ui.characterLocations.update()
 
 	test.AssertImageMatches(t, "locations/minimal.png", w.Canvas().Capture())
 }

--- a/internal/app/ui/characteroverview.go
+++ b/internal/app/ui/characteroverview.go
@@ -384,6 +384,11 @@ func showCharacterOverviewDetailWindow(u *baseUI, r characterOverviewRow) {
 	f := widget.NewForm(fi...)
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Overview of %s", r.characterName)
-	setDetailWindowWithSize(subTitle, fyne.NewSize(500, 450), f, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		minSize: fyne.NewSize(500, 450),
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/characteroverview.go
+++ b/internal/app/ui/characteroverview.go
@@ -385,9 +385,15 @@ func showCharacterOverviewDetailWindow(u *baseUI, r characterOverviewRow) {
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("Overview of %s", r.characterName)
 	setDetailWindow(detailWindowParams{
-		title:   subTitle,
-		minSize: fyne.NewSize(500, 450),
 		content: f,
+		imageLoader: func() (fyne.Resource, error) {
+			return u.eis.CharacterPortrait(r.characterID, 256)
+		},
+		imageAction: func() {
+			u.ShowInfoWindow(app.EveEntityCharacter, r.characterID)
+		},
+		minSize: fyne.NewSize(500, 450),
+		title:   subTitle,
 		window:  w,
 	})
 	w.Show()

--- a/internal/app/ui/characteroverview_internal_test.go
+++ b/internal/app/ui/characteroverview_internal_test.go
@@ -62,11 +62,11 @@ func TestCharacters_CanRenderWithData(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := NewFakeBaseUI(st, test.NewTempApp(t), tc.isDesktop)
-			w := test.NewWindow(ui.characters)
+			w := test.NewWindow(ui.characterOverview)
 			defer w.Close()
 			w.Resize(tc.size)
 
-			ui.characters.update()
+			ui.characterOverview.update()
 
 			test.AssertImageMatches(t, "characters/"+tc.filename+".png", w.Canvas().Capture())
 		})
@@ -103,11 +103,11 @@ func TestCharacters_CanRenderWitoutData(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := NewFakeBaseUI(st, test.NewTempApp(t), tc.isDesktop)
-			w := test.NewWindow(ui.characters)
+			w := test.NewWindow(ui.characterOverview)
 			defer w.Close()
 			w.Resize(tc.size)
 
-			ui.characters.update()
+			ui.characterOverview.update()
 
 			test.AssertImageMatches(t, "characters/"+tc.filename+".png", w.Canvas().Capture())
 		})

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -233,7 +233,12 @@ func showSkillInTrainingWindow(u *baseUI, q *app.CharacterSkillqueueItem) {
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
 	subTitle := fmt.Sprintf("%s by %s", app.SkillDisplayName(q.SkillName, q.FinishedLevel), characterName)
-	setDetailWindowWithSize(subTitle, fyne.NewSize(500, 450), f, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		minSize: fyne.NewSize(500, 450),
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }
 

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -198,7 +198,7 @@ func (a *characterSkillQueue) makeTopText(total optional.Optional[time.Duration]
 
 func showSkillInTrainingWindow(u *baseUI, q *app.CharacterSkillqueueItem) {
 	characterName := u.scs.CharacterName(q.CharacterID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", q.CharacterID, q.SkillID), "Skill: Information", characterName)
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("skill-%d-%d", q.CharacterID, q.SkillID), "Skill: Information", characterName)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -8,13 +8,12 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
-	"github.com/dustin/go-humanize"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/dustin/go-humanize"
 )
 
 type characterSkillQueue struct {
@@ -22,17 +21,31 @@ type characterSkillQueue struct {
 
 	OnUpdate func(statusShort, statusLong string)
 
-	list *widget.List
-	sq   *app.CharacterSkillqueue
-	top  *widget.Label
-	u    *baseUI
+	character          *app.Character
+	done               chan bool
+	isCharacterUpdated bool
+	list               *widget.List
+	signalKey          string
+	sq                 *app.CharacterSkillqueue
+	top                *widget.Label
+	u                  *baseUI
+	updatedKey         string
 }
 
+// newCharacterSkillQueue returns a new characterSkillQueue object with dynamic character.
 func newCharacterSkillQueue(u *baseUI) *characterSkillQueue {
+	return newCharacterSkillQueueWithCharacter(u, nil)
+}
+
+// newCharacterSkillQueue returns a new characterSkillQueue object with static character.
+func newCharacterSkillQueueWithCharacter(u *baseUI, c *app.Character) *characterSkillQueue {
 	a := &characterSkillQueue{
-		top: makeTopLabel(),
-		sq:  app.NewCharacterSkillqueue(),
-		u:   u,
+		character:          c,
+		done:               make(chan bool),
+		isCharacterUpdated: c == nil,
+		sq:                 app.NewCharacterSkillqueue(),
+		top:                makeTopLabel(),
+		u:                  u,
 	}
 	a.ExtendBaseWidget(a)
 	a.list = a.makeSkillQueue()
@@ -88,67 +101,56 @@ func (a *characterSkillQueue) makeSkillQueue() *widget.List {
 			list.UnselectAll()
 			return
 		}
-		var isActive string
-		if q.IsActive() {
-			isActive = "yes"
-		} else {
-			isActive = "no"
-		}
-		var data = []struct {
-			label string
-			value string
-			wrap  bool
-		}{
-			{"Name", app.SkillDisplayName(q.SkillName, q.FinishedLevel), false},
-			{"Group", q.GroupName, false},
-			{"Description", q.SkillDescription, true},
-			{"Start date", timeFormattedOrFallback(q.StartDate, app.DateTimeFormat, "?"), false},
-			{"Finish date", timeFormattedOrFallback(q.FinishDate, app.DateTimeFormat, "?"), false},
-			{"Duration", ihumanize.Optional(q.Duration(), "?"), false},
-			{"Remaining", ihumanize.Optional(q.Remaining(), "?"), false},
-			{"Completed", fmt.Sprintf("%.0f%%", q.CompletionP()*100), false},
-			{"SP at start", humanize.Comma(int64(q.TrainingStartSP - q.LevelStartSP)), false},
-			{"Total SP", humanize.Comma(int64(q.LevelEndSP - q.LevelStartSP)), false},
-			{"Active?", isActive, false},
-		}
-		form := widget.NewForm()
-		if !a.u.isDesktop {
-			form.Orientation = widget.Vertical
-		}
-		for _, row := range data {
-			c := widget.NewLabel(row.value)
-			if row.wrap {
-				c.Wrapping = fyne.TextWrapWord
-			}
-			form.Append(row.label, c)
-
-		}
-		s := container.NewScroll(form)
-		s.SetMinSize(fyne.NewSize(500, 300))
-		d := dialog.NewCustom("Skill Details", "OK", s, a.u.MainWindow())
-		a.u.ModifyShortcutsForDialog(d, a.u.MainWindow())
-		d.SetOnClosed(func() {
-			list.UnselectAll()
-		})
-		d.Show()
+		showSkillInTrainingWindow(a.u, q)
 	}
 	return list
 }
 
-func (a *characterSkillQueue) startUpdateTicker() {
+func (a *characterSkillQueue) start() {
+	a.signalKey = generateUniqueID()
+	if a.isCharacterUpdated {
+		a.u.characterChanged.AddListener(
+			func(_ context.Context, c *app.Character) {
+				a.character = c
+				a.update()
+			},
+			a.signalKey,
+		)
+	}
+	a.u.characterSectionUpdated.AddListener(
+		func(_ context.Context, arg app.CharacterUpdateSectionParams) {
+			if arg.Section == app.SectionCharacterSkillqueue && characterIDOrZero(a.character) == a.character.ID {
+				a.update()
+			}
+		},
+		a.signalKey,
+	)
 	ticker := time.NewTicker(time.Second * 60)
 	go func() {
 		for {
-			<-ticker.C
-			a.update()
+			select {
+			case <-ticker.C:
+				a.update()
+			case <-a.done:
+				return
+			}
 		}
 	}()
+	ticker.Stop()
+}
+
+func (a *characterSkillQueue) stop() {
+	if a.isCharacterUpdated {
+		a.u.characterChanged.RemoveListener(a.signalKey)
+	}
+	a.u.characterSectionUpdated.RemoveListener(a.signalKey)
+	a.done <- true
 }
 
 func (a *characterSkillQueue) update() {
 	var t string
 	var i widget.Importance
-	err := a.sq.Update(context.Background(), a.u.cs, a.u.currentCharacterID())
+	err := a.sq.Update(context.Background(), a.u.cs, characterIDOrZero(a.character))
 	if err != nil {
 		slog.Error("Failed to refresh skill queue UI", "err", err)
 		t = "ERROR"
@@ -183,7 +185,7 @@ func (a *characterSkillQueue) update() {
 }
 
 func (a *characterSkillQueue) makeTopText(total optional.Optional[time.Duration]) (string, widget.Importance) {
-	hasData := a.u.scs.HasCharacterSection(a.u.currentCharacterID(), app.SectionCharacterSkillqueue)
+	hasData := a.u.scs.HasCharacterSection(characterIDOrZero(a.character), app.SectionCharacterSkillqueue)
 	if !hasData {
 		return "Waiting for character data to be loaded...", widget.WarningImportance
 	}
@@ -194,11 +196,45 @@ func (a *characterSkillQueue) makeTopText(total optional.Optional[time.Duration]
 	return t, widget.MediumImportance
 }
 
-func timeFormattedOrFallback(t time.Time, layout, fallback string) string {
-	if t.IsZero() {
-		return fallback
+func showSkillInTrainingWindow(u *baseUI, q *app.CharacterSkillqueueItem) {
+	characterName := u.scs.CharacterName(q.CharacterID)
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", q.CharacterID, q.SkillID), "Skill: Information", characterName)
+	if !ok {
+		w.Show()
+		return
 	}
-	return t.Format(layout)
+	description := widget.NewLabel(q.SkillDescription)
+	description.Wrapping = fyne.TextWrapWord
+	var isActive *widget.Label
+	if q.IsActive() {
+		isActive = widget.NewLabel("active")
+		isActive.Importance = widget.SuccessImportance
+	} else {
+		isActive = widget.NewLabel("inactive")
+		isActive.Importance = widget.DangerImportance
+	}
+	items := []*widget.FormItem{
+		widget.NewFormItem(
+			"Owner",
+			makeOwnerActionLabel(q.CharacterID, characterName, u.ShowEveEntityInfoWindow),
+		),
+		widget.NewFormItem("Skill", widget.NewLabel(app.SkillDisplayName(q.SkillName, q.FinishedLevel))),
+		widget.NewFormItem("Group", widget.NewLabel(q.GroupName)),
+		widget.NewFormItem("Description", description),
+		widget.NewFormItem("Active?", isActive),
+		widget.NewFormItem("Completed", widget.NewLabel(fmt.Sprintf("%.0f%%", q.CompletionP()*100))),
+		widget.NewFormItem("Remaining", widget.NewLabel(ihumanize.Optional(q.Remaining(), "?"))),
+		widget.NewFormItem("Duration", widget.NewLabel(ihumanize.Optional(q.Duration(), "?"))),
+		widget.NewFormItem("Start date", widget.NewLabel(timeFormattedOrFallback(q.StartDate, app.DateTimeFormat, "?"))),
+		widget.NewFormItem("End date", widget.NewLabel(timeFormattedOrFallback(q.FinishDate, app.DateTimeFormat, "?"))),
+		widget.NewFormItem("SP at start", widget.NewLabel(humanize.Comma(int64(q.TrainingStartSP-q.LevelStartSP)))),
+		widget.NewFormItem("Total SP", widget.NewLabel(humanize.Comma(int64(q.LevelEndSP-q.LevelStartSP)))),
+	}
+	f := widget.NewForm(items...)
+	f.Orientation = widget.Adaptive
+	subTitle := fmt.Sprintf("%s by %s", app.SkillDisplayName(q.SkillName, q.FinishedLevel), characterName)
+	setDetailWindowWithSize(subTitle, fyne.NewSize(500, 450), f, w)
+	w.Show()
 }
 
 type skillQueueItem struct {

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -135,6 +135,16 @@ func (a *characterSkillQueue) makeSkillQueue() *widget.List {
 	return list
 }
 
+func (a *characterSkillQueue) startUpdateTicker() {
+	ticker := time.NewTicker(time.Second * 60)
+	go func() {
+		for {
+			<-ticker.C
+			a.update()
+		}
+	}()
+}
+
 func (a *characterSkillQueue) update() {
 	var t string
 	var i widget.Importance

--- a/internal/app/ui/clones.go
+++ b/internal/app/ui/clones.go
@@ -578,7 +578,11 @@ func (a *clones) showRouteWindow(r cloneRow) {
 		nil,
 		list,
 	)
-	setDetailWindow(title, c, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: c,
+		window:  w,
+	})
 	w.Show()
 }
 
@@ -673,6 +677,10 @@ func (a *clones) showCloneWindow(jc *app.CharacterJumpClone2) {
 		nil,
 		list,
 	)
-	setDetailWindow(title, c, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: c,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/clones.go
+++ b/internal/app/ui/clones.go
@@ -495,7 +495,7 @@ func (a *clones) showRouteWindow(r cloneRow) {
 		return
 	}
 	title := fmt.Sprintf("Route: %s -> %s", a.origin.Name, r.jc.Location.SolarSystemName())
-	w, ok := a.u.getOrCreateWindow(r.id(), title, r.jc.Character.Name)
+	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("route-%s", r.id()), title, r.jc.Character.Name)
 	if !ok {
 		w.Show()
 		return
@@ -587,7 +587,7 @@ func (a *clones) showCloneWindow(jc *app.CharacterJumpClone2) {
 		return
 	}
 	title := fmt.Sprintf("Clone #%d", jc.CloneID)
-	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("%d-%d", jc.Character.ID, jc.ID), title, jc.Character.Name)
+	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("clone-%d-%d", jc.Character.ID, jc.ID), title, jc.Character.Name)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/colonies.go
+++ b/internal/app/ui/colonies.go
@@ -357,7 +357,7 @@ func (a *colonies) fetchRows(s services) ([]colonyRow, int, error) {
 // showColonyWindow shows the details of a colony in a window.
 func (a *colonies) showColonyWindow(r colonyRow) {
 	title := fmt.Sprintf("Colony %s", r.planetName)
-	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("%d-%d", r.characterID, r.planetID), title, r.ownerName)
+	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("colony-%d-%d", r.characterID, r.planetID), title, r.ownerName)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/colonies.go
+++ b/internal/app/ui/colonies.go
@@ -438,7 +438,10 @@ func (a *colonies) showColonyWindow(r colonyRow) {
 		top.Add(container.NewVBox(container.NewPadded(image)))
 	}
 	c := container.NewVBox(top, processes)
-
-	setDetailWindow(title, c, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: c,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/colonies.go
+++ b/internal/app/ui/colonies.go
@@ -10,7 +10,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 
@@ -431,16 +430,12 @@ func (a *colonies) showColonyWindow(r colonyRow) {
 	)
 	processes.Orientation = widget.Adaptive
 
-	top := container.NewHBox(infos, layout.NewSpacer())
-	if a.u.isDesktop {
-		res, _ := cp.EvePlanet.Type.Icon()
-		image := iwidget.NewImageFromResource(res, fyne.NewSquareSize(100))
-		top.Add(container.NewVBox(container.NewPadded(image)))
-	}
-	c := container.NewVBox(top, processes)
+	c := container.NewVBox(infos, processes)
+	res, _ := cp.EvePlanet.Type.Icon()
 	setDetailWindow(detailWindowParams{
-		title:   title,
 		content: c,
+		title:   title,
+		image:   res,
 		window:  w,
 	})
 	w.Show()

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -569,6 +569,10 @@ func showContractWindow(u *baseUI, characterID, contractID int32) {
 		}
 		main.Add(x)
 	}
-	setDetailWindow(subTitle, main, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		content: main,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -394,7 +394,7 @@ func (a *contracts) fetchRows(s services) ([]contractRow, int, error) {
 // showContractWindow shows the details of a contract in a window.
 func showContractWindow(u *baseUI, characterID, contractID int32) {
 	title := fmt.Sprintf("Contract #%d", contractID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", characterID, contractID), title, u.scs.CharacterName(characterID))
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("contract-%d-%d", characterID, contractID), title, u.scs.CharacterName(characterID))
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/corporationsheet.go
+++ b/internal/app/ui/corporationsheet.go
@@ -136,8 +136,17 @@ func (a *corporationSheet) update() {
 	}
 	if corporation == nil {
 		fyne.Do(func() {
-			a.name.SetText("No corporation...")
+			a.alliance.SetText("")
+			a.ceo.SetText("")
+			a.faction.SetText("")
+			a.home.SetText("")
+			a.logo.SetResource(icons.BlankSvg)
+			a.members.SetText("")
 			a.name.OnTapped = nil
+			a.name.SetText("No corporation...")
+			a.roles.SetText("")
+			a.taxRate.SetText("")
+			a.ticker.SetText("")
 		})
 		return
 	}

--- a/internal/app/ui/desktopui.go
+++ b/internal/app/ui/desktopui.go
@@ -200,9 +200,9 @@ func NewDesktopUI(bu *baseUI) *DesktopUI {
 		overviewColonies,
 		industry,
 		iwidget.NewNavPage(
-			"Locations",
+			"Character Locations",
 			theme.NewThemedResource(icons.MapMarkerSvg),
-			makePageWithTitle("Locations", u.locations),
+			makePageWithTitle("Character Locations", u.characterLocations),
 		),
 		iwidget.NewNavPage(
 			"Training",

--- a/internal/app/ui/desktopui.go
+++ b/internal/app/ui/desktopui.go
@@ -126,10 +126,11 @@ func NewDesktopUI(bu *baseUI) *DesktopUI {
 		})
 	}
 
+	const assetsTitle = "Character Assets"
 	allAssets := iwidget.NewNavPage(
-		"Assets",
+		assetsTitle,
 		theme.NewThemedResource(icons.Inventory2Svg),
-		makePageWithTitle("Assets", u.assets),
+		makePageWithTitle(assetsTitle, u.assets),
 	)
 	u.assets.onUpdate = func(total string) {
 		fyne.Do(func() {

--- a/internal/app/ui/desktopui.go
+++ b/internal/app/ui/desktopui.go
@@ -111,7 +111,7 @@ func NewDesktopUI(bu *baseUI) *DesktopUI {
 	overview := iwidget.NewNavPage(
 		"Character Overview",
 		theme.NewThemedResource(icons.PortraitSvg),
-		makePageWithTitle("Character Overview", u.characters),
+		makePageWithTitle("Character Overview", u.characterOverview),
 	)
 
 	wealth := iwidget.NewNavPage(

--- a/internal/app/ui/detailwindow.go
+++ b/internal/app/ui/detailwindow.go
@@ -5,10 +5,12 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
 )
 
 type detailWindowParams struct {
 	content fyne.CanvasObject
+	image   fyne.Resource
 	minSize fyne.Size
 	title   string
 	window  fyne.Window
@@ -29,11 +31,16 @@ func setDetailWindow(arg detailWindowParams) {
 	top := container.NewVBox(t, widget.NewSeparator())
 	vs := container.NewVScroll(arg.content)
 	vs.SetMinSize(arg.minSize)
+	var image fyne.CanvasObject
+	if arg.image != nil && !fyne.CurrentDevice().IsMobile() {
+		x := iwidget.NewImageFromResource(arg.image, fyne.NewSquareSize(100))
+		image = container.NewVBox(container.NewPadded(x))
+	}
 	c := container.NewBorder(
 		top,
 		nil,
 		nil,
-		nil,
+		image,
 		vs,
 	)
 	c.Refresh()

--- a/internal/app/ui/detailwindow.go
+++ b/internal/app/ui/detailwindow.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+type detailWindowParams struct {
+	content fyne.CanvasObject
+	minSize fyne.Size
+	title   string
+	window  fyne.Window
+}
+
+// setDetailWindow sets the content of a window to create a "detail window".
+// Detail windows are used to show more information about objects in data lists.
+func setDetailWindow(arg detailWindowParams) {
+	if arg.window == nil {
+		panic("must define window for detailWindow")
+	}
+	if arg.minSize.IsZero() {
+		arg.minSize = fyne.NewSize(600, 500)
+	}
+	t := widget.NewLabel(arg.title)
+	t.SizeName = theme.SizeNameSubHeadingText
+	t.Truncation = fyne.TextTruncateEllipsis
+	top := container.NewVBox(t, widget.NewSeparator())
+	vs := container.NewVScroll(arg.content)
+	vs.SetMinSize(arg.minSize)
+	c := container.NewBorder(
+		top,
+		nil,
+		nil,
+		nil,
+		vs,
+	)
+	c.Refresh()
+	arg.window.SetContent(container.NewPadded(c))
+}

--- a/internal/app/ui/gamesearch.go
+++ b/internal/app/ui/gamesearch.go
@@ -26,7 +26,7 @@ const (
 	maxSearchResults = 500 // max results returned from the server
 )
 
-type hameSearch struct {
+type gameSearch struct {
 	widget.BaseWidget
 
 	categories          *kxwidget.FilterChipGroup
@@ -47,8 +47,8 @@ type hameSearch struct {
 	w                   fyne.Window
 }
 
-func newGameSearch(u *baseUI) *hameSearch {
-	a := &hameSearch{
+func newGameSearch(u *baseUI) *gameSearch {
+	a := &gameSearch{
 		defaultCategories:   makeOptions(),
 		entry:               widget.NewEntry(),
 		indicator:           widget.NewProgressBarInfinite(),
@@ -127,7 +127,7 @@ func newGameSearch(u *baseUI) *hameSearch {
 	return a
 }
 
-func (a *hameSearch) init() {
+func (a *gameSearch) init() {
 	ids := a.u.settings.RecentSearches()
 	if len(ids) == 0 {
 		return
@@ -143,13 +143,13 @@ func (a *hameSearch) init() {
 	})
 }
 
-func (a *hameSearch) resetOptions() {
+func (a *gameSearch) resetOptions() {
 	a.categories.SetSelected(a.defaultCategories)
 	a.strict.SetOn(false)
 	a.updateSearchOptionsTitle()
 }
 
-func (a *hameSearch) updateSearchOptionsTitle() {
+func (a *gameSearch) updateSearchOptionsTitle() {
 	isDefault := func() bool {
 		if a.strict.On {
 			return false
@@ -167,12 +167,12 @@ func (a *hameSearch) updateSearchOptionsTitle() {
 	a.searchOptions.Refresh()
 }
 
-func (a *hameSearch) doSearch(s string) {
+func (a *gameSearch) doSearch(s string) {
 	a.entry.SetText(s)
 	go a.doSearch2(s)
 }
 
-func (a *hameSearch) toogleOptions(enabled bool) {
+func (a *gameSearch) toogleOptions(enabled bool) {
 	if enabled {
 		a.searchOptions.Open(0)
 	} else {
@@ -181,21 +181,21 @@ func (a *hameSearch) toogleOptions(enabled bool) {
 	a.searchOptions.Refresh()
 }
 
-func (a *hameSearch) setRecentItems(ee []*app.EveEntity) {
+func (a *gameSearch) setRecentItems(ee []*app.EveEntity) {
 	a.mu.Lock()
 	a.recentItems = ee
 	a.mu.Unlock()
 	a.recent.Refresh()
 }
 
-func (a *hameSearch) storeRecentItems() {
+func (a *gameSearch) storeRecentItems() {
 	ids := xslices.Map(a.recentItems, func(x *app.EveEntity) int32 {
 		return x.ID
 	})
 	a.u.settings.SetRecentSearches(ids)
 }
 
-func (a *hameSearch) CreateRenderer() fyne.WidgetRenderer {
+func (a *gameSearch) CreateRenderer() fyne.WidgetRenderer {
 	c := container.NewBorder(
 		container.NewVBox(
 			a.entry,
@@ -210,20 +210,20 @@ func (a *hameSearch) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(c)
 }
 
-func (a *hameSearch) focus() {
+func (a *gameSearch) focus() {
 	a.w.Canvas().Focus(a.entry)
 }
 
-func (a *hameSearch) reset() {
+func (a *gameSearch) reset() {
 	a.entry.SetText("")
 	a.clearResults()
 }
 
-func (a *hameSearch) setWindow(w fyne.Window) {
+func (a *gameSearch) setWindow(w fyne.Window) {
 	a.w = w
 }
 
-func (a *hameSearch) makeResults() *iwidget.Tree[resultNode] {
+func (a *gameSearch) makeResults() *iwidget.Tree[resultNode] {
 	t := iwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			if isBranch {
@@ -258,14 +258,14 @@ func (a *hameSearch) makeResults() *iwidget.Tree[resultNode] {
 	return t
 }
 
-func (a *hameSearch) showSupportedResult(o *app.EveEntity) {
+func (a *gameSearch) showSupportedResult(o *app.EveEntity) {
 	if !a.supportedCategories.Contains(o.Category) {
 		return
 	}
 	a.u.ShowEveEntityInfoWindow(o)
 }
 
-func (a *hameSearch) makeRecentSelected() *widget.List {
+func (a *gameSearch) makeRecentSelected() *widget.List {
 	l := widget.NewList(
 		func() int {
 			a.mu.RLock()
@@ -299,7 +299,7 @@ func (a *hameSearch) makeRecentSelected() *widget.List {
 	return l
 }
 
-func (a *hameSearch) clearResults() {
+func (a *gameSearch) clearResults() {
 	fyne.Do(func() {
 		a.results.Clear()
 		a.resultCount.Hide()
@@ -307,12 +307,12 @@ func (a *hameSearch) clearResults() {
 	})
 }
 
-func (a *hameSearch) showRecent() {
+func (a *gameSearch) showRecent() {
 	a.resultsPage.Hide()
 	a.recentPage.Show()
 }
 
-func (a *hameSearch) doSearch2(search string) {
+func (a *gameSearch) doSearch2(search string) {
 	if a.u.IsOffline() {
 		fyne.Do(func() {
 			a.u.ShowInformationDialog(

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -10,7 +10,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
-	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	"github.com/ErikKalkoken/evebuddy/internal/app"
@@ -111,30 +110,6 @@ func makeLocationLabel(o *app.EveLocationShort, show func(int64)) fyne.CanvasObj
 	})
 	x.Wrapping = fyne.TextWrapWord
 	return x
-}
-
-// setDetailWindow sets the content of a window to create a "detail window".
-// Detail windows are used to show more information about objects in data lists.
-func setDetailWindow(title string, content fyne.CanvasObject, window fyne.Window) {
-	setDetailWindowWithSize(title, fyne.NewSize(600, 500), content, window)
-}
-
-func setDetailWindowWithSize(title string, minSize fyne.Size, content fyne.CanvasObject, w fyne.Window) {
-	t := widget.NewLabel(title)
-	t.SizeName = theme.SizeNameSubHeadingText
-	t.Truncation = fyne.TextTruncateEllipsis
-	top := container.NewVBox(t, widget.NewSeparator())
-	vs := container.NewVScroll(content)
-	vs.SetMinSize(minSize)
-	c := container.NewBorder(
-		top,
-		nil,
-		nil,
-		nil,
-		vs,
-	)
-	c.Refresh()
-	w.SetContent(container.NewPadded(c))
 }
 
 func newSpacer(s fyne.Size) fyne.CanvasObject {

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -1,9 +1,12 @@
 package ui
 
 import (
+	"crypto/rand"
 	"fmt"
 	"image/color"
 	"math"
+	"math/big"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -119,6 +122,7 @@ func setDetailWindow(title string, content fyne.CanvasObject, window fyne.Window
 func setDetailWindowWithSize(title string, minSize fyne.Size, content fyne.CanvasObject, w fyne.Window) {
 	t := widget.NewLabel(title)
 	t.SizeName = theme.SizeNameSubHeadingText
+	t.Truncation = fyne.TextTruncateEllipsis
 	top := container.NewVBox(t, widget.NewSeparator())
 	vs := container.NewVScroll(content)
 	vs.SetMinSize(minSize)
@@ -141,4 +145,26 @@ func newSpacer(s fyne.Size) fyne.CanvasObject {
 
 func newStandardSpacer() fyne.CanvasObject {
 	return newSpacer(fyne.NewSquareSize(theme.Padding()))
+}
+
+// characterIDOrZero returns the ID of a character or 0 if the c does not exist.
+func characterIDOrZero(c *app.Character) int32 {
+	if c == nil {
+		return 0
+	}
+	return c.ID
+}
+
+// generateUniqueID returns a unique ID.
+func generateUniqueID() string {
+	currentTime := time.Now().UnixNano()
+	randomNumber, _ := rand.Int(rand.Reader, big.NewInt(1000000))
+	return fmt.Sprintf("%d-%d", currentTime, randomNumber)
+}
+
+func timeFormattedOrFallback(t time.Time, layout, fallback string) string {
+	if t.IsZero() {
+		return fallback
+	}
+	return t.Format(layout)
 }

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -670,9 +670,15 @@ func (a *industryJobs) showIndustryJobWindow(r industryJobRow) {
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
 	setDetailWindow(detailWindowParams{
-		title:   title,
 		content: f,
-		window:  w,
+		imageAction: func() {
+			a.u.ShowTypeInfoWindow(r.blueprintType.ID)
+		},
+		imageLoader: func() (fyne.Resource, error) {
+			return a.u.eis.InventoryTypeBPO(r.blueprintType.ID, 256)
+		},
+		title:  title,
+		window: w,
 	})
 	w.Show()
 }

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -588,7 +588,7 @@ func (a *industryJobs) update() {
 // showIndustryJobWindow shows the details of a industry job in a window.
 func (a *industryJobs) showIndustryJobWindow(r industryJobRow) {
 	title := fmt.Sprintf("Industry Job #%d", r.jobID)
-	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("%d-%d", r.owner.ID, r.jobID), title, r.owner.Name)
+	w, ok := a.u.getOrCreateWindow(fmt.Sprintf("industryjob-%d-%d", r.owner.ID, r.jobID), title, r.owner.Name)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -669,6 +669,10 @@ func (a *industryJobs) showIndustryJobWindow(r industryJobRow) {
 	}
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
-	setDetailWindow(title, f, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -607,7 +607,7 @@ func makeHomeNav(u *MobileUI) *iwidget.Navigator {
 			"Character Overview",
 			theme.NewThemedResource(icons.PortraitSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Character Overview", u.characters))
+				homeNav.Push(iwidget.NewAppBar("Character Overview", u.characterOverview))
 			},
 		),
 		navItemAssets,

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -70,15 +70,15 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 			),
 		)
 	}
-
+	const assetsTitle = "Character Assets"
 	navItemAssets := iwidget.NewListItemWithIcon(
-		"Assets",
+		assetsTitle,
 		theme.NewThemedResource(icons.Inventory2Svg),
 		func() {
 			u.characterAsset.OnSelected = func() {
-				characterNav.PushAndHideNavBar(newCharacterAppBar("Assets", u.characterAsset.LocationAssets))
+				characterNav.PushAndHideNavBar(newCharacterAppBar(assetsTitle, u.characterAsset.LocationAssets))
 			}
-			characterNav.Push(newCharacterAppBar("Assets", container.NewHScroll(u.characterAsset.Locations)))
+			characterNav.Push(newCharacterAppBar(assetsTitle, container.NewHScroll(u.characterAsset.Locations)))
 		},
 	)
 	navItemCommunications := iwidget.NewListItemWithIcon(

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -249,12 +249,12 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 	}
 	corpWalletList := iwidget.NewNavList(corpWalletItems...)
 	corpWalletNav := iwidget.NewListItemWithIcon(
-		"Wallet",
+		"Wallets",
 		theme.NewThemedResource(icons.CashSvg),
 		func() {
 			corpNav.Push(
 				newCorpAppBar(
-					"Wallet",
+					"Wallets",
 					corpWalletList,
 				))
 		},

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -622,10 +622,10 @@ func makeHomeNav(u *MobileUI) *iwidget.Navigator {
 		navItemColonies2,
 		navItemIndustry,
 		iwidget.NewListItemWithIcon(
-			"Locations",
+			"Character Locations",
 			theme.NewThemedResource(icons.MapMarkerSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Locations", u.locations))
+				homeNav.Push(iwidget.NewAppBar("Character Locations", u.characterLocations))
 			},
 		),
 		iwidget.NewListItemWithIcon(

--- a/internal/app/ui/training.go
+++ b/internal/app/ui/training.go
@@ -448,7 +448,7 @@ func (a *training) startUpdateTicker() {
 }
 
 func (a *training) showTrainingQueueWindow(r trainingRow) {
-	w, ok, onClosed := a.u.getOrCreateWindowWithOnClosed(fmt.Sprintf("%d-skillqueue", r.characterID), "Skill Queue", r.characterName)
+	w, ok, onClosed := a.u.getOrCreateWindowWithOnClosed(fmt.Sprintf("skillqueue-%d", r.characterID), "Skill Queue", r.characterName)
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/training.go
+++ b/internal/app/ui/training.go
@@ -468,6 +468,11 @@ func (a *training) showTrainingQueueWindow(r trainingRow) {
 		sq.stop()
 	})
 	subTitle := fmt.Sprintf("Skill Queue for %s", r.characterName)
-	setDetailWindowWithSize(subTitle, fyne.NewSize(800, 450), sq, w)
+	setDetailWindow(detailWindowParams{
+		title:   subTitle,
+		minSize: fyne.NewSize(800, 450),
+		content: sq,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -1586,9 +1586,9 @@ func (u *baseUI) getOrCreateWindow(id string, titles ...string) (window fyne.Win
 	return w, ok
 }
 
-// getOrCreateWindowWithOnClosed is like makeOrFindWindow,
+// getOrCreateWindowWithOnClosed is like getOrCreateWindow,
 // but returns an additional onClosed function which must be called when the window is closed.
-// This variant allows constructing a custom onClosed callback for the window.
+// This allows constructing a custom onClosed callback for the window.
 func (u *baseUI) getOrCreateWindowWithOnClosed(id string, titles ...string) (window fyne.Window, created bool, onClosed func()) {
 	w, ok := u.windows[id]
 	if ok {

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -268,6 +268,7 @@ func NewBaseUI(args BaseUIParams) *baseUI {
 			u.isStartupCompleted.Store(true)
 			u.training.startUpdateTicker()
 			u.characterJumpClones.startUpdateTicker()
+			u.characterSkillQueue.startUpdateTicker()
 			if !u.isOffline && !u.isUpdateDisabled {
 				time.Sleep(5 * time.Second) // Workaround to prevent concurrent updates from happening at startup.
 				u.startUpdateTickerGeneralSections()
@@ -1159,12 +1160,12 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 		}
 
 	case app.SectionCharacterSkillqueue:
-		if isShown {
-			u.characterSkillQueue.update() // TODO: Move into widget
-		}
 		if needsRefresh {
 			u.training.update()
 			u.notifyExpiredTrainingIfNeeded(ctx, characterID)
+			if isShown {
+				u.characterSkillQueue.update()
+			}
 		}
 		if u.settings.NotifyTrainingEnabled() {
 			err := u.cs.EnableTrainingWatcher(ctx, characterID)

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -109,7 +109,7 @@ type baseUI struct {
 	characterJumpClones     *characterJumpClones
 	characterLocations      *characterLocations
 	characterMail           *characterMails
-	characters              *characters
+	characterOverview       *characterOverview
 	characterSheet          *characterSheet
 	characterShips          *characterFlyableShips
 	characterSkillCatalogue *characterSkillCatalogue
@@ -121,7 +121,7 @@ type baseUI struct {
 	corporationMember       *corporationMember
 	corporationSheet        *corporationSheet
 	corporationWallets      map[app.Division]*corporationWallet
-	gameSearch              *hameSearch
+	gameSearch              *gameSearch
 	industryJobs            *industryJobs
 	slotsManufacturing      *industrySlots
 	slotsReactions          *industrySlots
@@ -245,7 +245,7 @@ func NewBaseUI(args BaseUIParams) *baseUI {
 	u.slotsReactions = newIndustrySlots(u, app.ReactionJob)
 	u.slotsResearch = newIndustrySlots(u, app.ScienceJob)
 	u.assets = newAssets(u)
-	u.characters = newOverviewCharacters(u)
+	u.characterOverview = newCharacterOverview(u)
 	u.clones = newClones(u)
 	u.colonies = newColonies(u)
 	u.characterLocations = newCharacterLocations(u)
@@ -676,7 +676,7 @@ func (u *baseUI) defineHomeUpdates() map[string]func() {
 		"slotsReactions":     u.slotsReactions.update,
 		"slotsResearch":      u.slotsResearch.update,
 		"locations":          u.characterLocations.update,
-		"overview":           u.characters.update,
+		"overview":           u.characterOverview.update,
 		"training":           u.training.update,
 		"wealth":             u.wealth.update,
 	}
@@ -907,14 +907,14 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 		u.characterSkillCatalogue.update()
 	case app.SectionEveCharacters:
 		u.reloadCurrentCharacter()
-		u.characters.update()
+		u.characterOverview.update()
 	case app.SectionEveCorporations:
 		// TODO: Only update when shown entity changed
 		u.characterCorporation.update()
 		u.corporationSheet.update()
 	case app.SectionEveMarketPrices:
 		u.characterAsset.update()
-		u.characters.update()
+		u.characterOverview.update()
 		u.assets.update()
 		u.reloadCurrentCharacter()
 	default:
@@ -1083,7 +1083,7 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 		}
 	case app.SectionCharacterJumpClones:
 		if needsRefresh {
-			u.characters.update()
+			u.characterOverview.update()
 			u.clones.update()
 			if isShown {
 				u.reloadCurrentCharacter()
@@ -1106,14 +1106,14 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 		}
 	case app.SectionCharacterMailLabels, app.SectionCharacterMailLists:
 		if needsRefresh {
-			u.characters.update()
+			u.characterOverview.update()
 			if isShown {
 				u.characterMail.update()
 			}
 		}
 	case app.SectionCharacterMails:
 		if needsRefresh {
-			go u.characters.update()
+			go u.characterOverview.update()
 			go u.updateMailIndicator()
 			if isShown {
 				u.characterMail.update()
@@ -1194,7 +1194,7 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 		}
 	case app.SectionCharacterWalletBalance:
 		if needsRefresh {
-			u.characters.update()
+			u.characterOverview.update()
 			u.wealth.update()
 			if isShown {
 				u.reloadCurrentCharacter()

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -120,7 +120,7 @@ type baseUI struct {
 	corporationWallets      map[app.Division]*corporationWallet
 	gameSearch              *hameSearch
 	industryJobs            *industryJobs
-	locations               *locations
+	characterLocations      *characterLocations
 	slotsManufacturing      *industrySlots
 	slotsReactions          *industrySlots
 	slotsResearch           *industrySlots
@@ -242,7 +242,7 @@ func NewBaseUI(args BaseUIParams) *baseUI {
 	u.characters = newOverviewCharacters(u)
 	u.clones = newClones(u)
 	u.colonies = newColonies(u)
-	u.locations = newLocations(u)
+	u.characterLocations = newCharacterLocations(u)
 	u.training = newTraining(u)
 	u.wealth = newWealth(u)
 	u.snackbar = iwidget.NewSnackbar(u.window)
@@ -669,7 +669,7 @@ func (u *baseUI) defineHomeUpdates() map[string]func() {
 		"slotsManufacturing": u.slotsManufacturing.update,
 		"slotsReactions":     u.slotsReactions.update,
 		"slotsResearch":      u.slotsResearch.update,
-		"locations":          u.locations.update,
+		"locations":          u.characterLocations.update,
 		"overview":           u.characters.update,
 		"training":           u.training.update,
 		"wealth":             u.wealth.update,
@@ -1093,7 +1093,7 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 		}
 	case app.SectionCharacterLocation, app.SectionCharacterOnline, app.SectionCharacterShip:
 		if needsRefresh {
-			u.locations.update()
+			u.characterLocations.update()
 			if isShown {
 				u.reloadCurrentCharacter()
 			}

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -79,6 +79,7 @@ type services struct {
 
 // baseUI represents the core UI logic and is used by both the desktop and mobile UI.
 type baseUI struct {
+	// Callbacks
 	clearCache                      func() // clear all caches
 	disableMenuShortcuts            func()
 	enableMenuShortcuts             func()
@@ -97,6 +98,7 @@ type baseUI struct {
 	showMailIndicator               func()
 	showManageCharacters            func()
 
+	// UI elements
 	assets                  *assets
 	characterAsset          *characterAssets
 	characterAttributes     *characterAttributes
@@ -105,6 +107,7 @@ type baseUI struct {
 	characterCommunications *characterCommunications
 	characterCorporation    *corporationSheet
 	characterJumpClones     *characterJumpClones
+	characterLocations      *characterLocations
 	characterMail           *characterMails
 	characters              *characters
 	characterSheet          *characterSheet
@@ -120,35 +123,38 @@ type baseUI struct {
 	corporationWallets      map[app.Division]*corporationWallet
 	gameSearch              *hameSearch
 	industryJobs            *industryJobs
-	characterLocations      *characterLocations
 	slotsManufacturing      *industrySlots
 	slotsReactions          *industrySlots
 	slotsResearch           *industrySlots
+	snackbar                *iwidget.Snackbar
 	training                *training
 	wealth                  *wealth
 
+	// Signals
 	characterSectionUpdated signals.Signal[app.CharacterUpdateSectionParams]
 	characterChanged        signals.Signal[*app.Character]
 
+	// Services
+	cs       *characterservice.CharacterService
+	eis      *eveimageservice.EveImageService
+	ess      *esistatusservice.ESIStatusService
+	eus      *eveuniverseservice.EveUniverseService
+	js       *janiceservice.JaniceService
+	memcache *memcache.Cache
+	rs       *corporationservice.CorporationService
+	scs      *statuscacheservice.StatusCacheService
+	settings *settings.Settings
+
+	// UI state
 	app                fyne.App
 	character          atomic.Pointer[app.Character]
 	corporation        atomic.Pointer[app.Corporation]
-	cs                 *characterservice.CharacterService
-	dataPaths          map[string]string // Paths to user data
-	eis                *eveimageservice.EveImageService
-	ess                *esistatusservice.ESIStatusService
-	eus                *eveuniverseservice.EveUniverseService
-	isDesktop          bool        // whether the app runs on a desktop. If false we assume it's on mobile.
-	isForeground       atomic.Bool // whether the app is currently shown in the foreground
-	isOffline          bool        // Run the app in offline mode
-	isStartupCompleted atomic.Bool // whether the app has completed startup (for testing)
-	isUpdateDisabled   bool        // Whether to disable update tickers (useful for debugging)
-	js                 *janiceservice.JaniceService
-	memcache           *memcache.Cache
-	rs                 *corporationservice.CorporationService
-	scs                *statuscacheservice.StatusCacheService
-	settings           *settings.Settings
-	snackbar           *iwidget.Snackbar
+	dataPaths          map[string]string      // Paths to user data
+	isDesktop          bool                   // whether the app runs on a desktop. If false we assume it's on mobile.
+	isForeground       atomic.Bool            // whether the app is currently shown in the foreground
+	isOffline          bool                   // Run the app in offline mode
+	isStartupCompleted atomic.Bool            // whether the app has completed startup (for testing)
+	isUpdateDisabled   bool                   // Whether to disable update tickers (useful for debugging)
 	wasStarted         atomic.Bool            // whether the app has already been started at least once
 	window             fyne.Window            // main window
 	windows            map[string]fyne.Window // child windows

--- a/internal/app/ui/walletjournal.go
+++ b/internal/app/ui/walletjournal.go
@@ -393,7 +393,7 @@ func (*walletJournal) fetchCorporationRows(corporationID int32, division app.Div
 // showCharacterWalletJournalEntryWindow shows a wallet journal entry for a character in a new window.
 func showCharacterWalletJournalEntryWindow(u *baseUI, characterID int32, refID int64) {
 	title := fmt.Sprintf("Character Wallet Transaction #%d", refID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", characterID, refID), title, u.scs.CharacterName(characterID))
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("walletjournalentry-%d-%d", characterID, refID), title, u.scs.CharacterName(characterID))
 	if !ok {
 		w.Show()
 		return
@@ -517,7 +517,7 @@ func showCharacterWalletJournalEntryWindow(u *baseUI, characterID int32, refID i
 // showCorporationWalletJournalEntryWindow shows a wallet journal entry for a corporation in a new window.
 func showCorporationWalletJournalEntryWindow(u *baseUI, corporationID int32, division app.Division, refID int64) {
 	title := fmt.Sprintf("Corporation Wallet Transaction #%d", refID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", corporationID, refID), title, u.scs.CorporationName(corporationID))
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("walletjournalentry-%d-%d", corporationID, refID), title, u.scs.CorporationName(corporationID))
 	if !ok {
 		w.Show()
 		return

--- a/internal/app/ui/walletjournal.go
+++ b/internal/app/ui/walletjournal.go
@@ -510,7 +510,11 @@ func showCharacterWalletJournalEntryWindow(u *baseUI, characterID int32, refID i
 	for _, it := range items {
 		f.AppendItem(it)
 	}
-	setDetailWindow(title, f, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }
 
@@ -634,6 +638,10 @@ func showCorporationWalletJournalEntryWindow(u *baseUI, corporationID int32, div
 	for _, it := range items {
 		f.AppendItem(it)
 	}
-	setDetailWindow(title, f, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/wallettransaction.go
+++ b/internal/app/ui/wallettransaction.go
@@ -569,7 +569,11 @@ func showCharacterWalletTransactionWindow(u *baseUI, characterID int32, transact
 	}
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
-	setDetailWindow(title, f, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }
 
@@ -617,6 +621,10 @@ func showCorporationWalletTransactionWindow(u *baseUI, corporationID int32, divi
 	}
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
-	setDetailWindow(title, f, w)
+	setDetailWindow(detailWindowParams{
+		title:   title,
+		content: f,
+		window:  w,
+	})
 	w.Show()
 }

--- a/internal/app/ui/wallettransaction.go
+++ b/internal/app/ui/wallettransaction.go
@@ -570,9 +570,15 @@ func showCharacterWalletTransactionWindow(u *baseUI, characterID int32, transact
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
 	setDetailWindow(detailWindowParams{
-		title:   title,
 		content: f,
-		window:  w,
+		imageAction: func() {
+			u.ShowTypeInfoWindow(o.Type.ID)
+		},
+		imageLoader: func() (fyne.Resource, error) {
+			return u.eis.InventoryTypeIcon(o.Type.ID, 256)
+		},
+		title:  title,
+		window: w,
 	})
 	w.Show()
 }
@@ -622,9 +628,15 @@ func showCorporationWalletTransactionWindow(u *baseUI, corporationID int32, divi
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
 	setDetailWindow(detailWindowParams{
-		title:   title,
 		content: f,
-		window:  w,
+		imageAction: func() {
+			u.ShowTypeInfoWindow(o.Type.ID)
+		},
+		imageLoader: func() (fyne.Resource, error) {
+			return u.eis.InventoryTypeIcon(o.Type.ID, 256)
+		},
+		title:  title,
+		window: w,
 	})
 	w.Show()
 }

--- a/internal/app/ui/wallettransaction.go
+++ b/internal/app/ui/wallettransaction.go
@@ -519,7 +519,7 @@ func (a *walletTransactions) fetchCorporationRows(corporationID int32, division 
 // showCharacterWalletTransactionWindow shows the detail of a character wallet transaction in a window.
 func showCharacterWalletTransactionWindow(u *baseUI, characterID int32, transactionID int64) {
 	title := fmt.Sprintf("Character Market Transaction #%d", transactionID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", characterID, transactionID), title, u.scs.CharacterName(characterID))
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("wallettransaction-%d-%d", characterID, transactionID), title, u.scs.CharacterName(characterID))
 	if !ok {
 		w.Show()
 		return
@@ -576,7 +576,7 @@ func showCharacterWalletTransactionWindow(u *baseUI, characterID int32, transact
 // showCorporationWalletTransactionWindow shows the detail of a corporation wallet transaction in a window.
 func showCorporationWalletTransactionWindow(u *baseUI, corporationID int32, division app.Division, transactionID int64) {
 	title := fmt.Sprintf("Corporation Market Transaction #%d", transactionID)
-	w, ok := u.getOrCreateWindow(fmt.Sprintf("%d-%d", corporationID, transactionID), title, u.scs.CorporationName(corporationID))
+	w, ok := u.getOrCreateWindow(fmt.Sprintf("wallettransaction-%d-%d", corporationID, transactionID), title, u.scs.CorporationName(corporationID))
 	if !ok {
 		w.Show()
 		return

--- a/internal/humanize/humanize.go
+++ b/internal/humanize/humanize.go
@@ -58,7 +58,7 @@ func Number(value float64, decimals int) string {
 // Rounds to full minutes.
 // Negative durations are returned as "0 m"
 func Duration(duration time.Duration) string {
-	if duration < 0 {
+	if duration <= 0 {
 		return "0m"
 	}
 	mRaw := duration.Abs().Minutes()


### PR DESCRIPTION
## Added

- Detail window now shows a context image, e.g. character portrait for character location detail

## Changed

- Clicking on a row in Home / Training now shows the training queue for that character (#201)
- Clicking on a row in Home / Location now shows a detail window
- Clicking on a row in Home / Character Overview now shows a detail window
- Clarified names of menu options in Home list

## Fixed

- Potential duplicate window IDs may result in weird behavior when opening a detail window
- Corp was not loaded when adding character with NPC corp

Fixes #201