### PR TITLE
feat: show main instance

### DIFF
--- a/internal/remoteservice/remote.go
+++ b/internal/remoteservice/remote.go
@@ -1,0 +1,73 @@
+// Package remoteservice provides a service for communicating between instances remotely.
+package remoteservice
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/rpc"
+)
+
+// TODO: Add tests
+
+const (
+	remoteServicePort = 30124
+)
+
+type EmptyArgs struct{}
+
+// RemoteService is a RPC service allows to communicate between multiple instances of EVE Buddy.
+type RemoteService struct {
+	showInstance func() // callback that show an instance of the app
+}
+
+func newRemoteService(showInstance func()) *RemoteService {
+	if showInstance == nil {
+		panic("showInstance can not be nil")
+	}
+	s := &RemoteService{
+		showInstance: showInstance,
+	}
+	return s
+}
+
+// ShowInstance shows the instance that is running the service.
+func (sw RemoteService) ShowInstance(args *EmptyArgs, reply *EmptyArgs) error {
+	sw.showInstance()
+	slog.Info("Remote Service: ShowInstance completed")
+	return nil
+}
+
+// Start starts the remote service.
+func Start(showInstance func()) error {
+	rpc.Register(newRemoteService(showInstance))
+	rpc.HandleHTTP()
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", remoteServicePort))
+	if err != nil {
+		return fmt.Errorf("remote service: listen error: %w", err)
+	}
+	go func() {
+		slog.Info("Remote service running", "port", remoteServicePort)
+		err := http.Serve(l, nil)
+		if err != nil {
+			slog.Error("Remote service: terminated prematurely", "error", err)
+		}
+	}()
+	return nil
+}
+
+// ShowMainInstance sends a request the main instance to show it.
+// This function should be called by the client.
+func ShowMainInstance() error {
+	client, err := rpc.DialHTTP("tcp", fmt.Sprintf("localhost:%d", remoteServicePort))
+	if err != nil {
+		return fmt.Errorf("dial remote service: %w", err)
+	}
+	err = client.Call("RemoteService.ShowInstance", &EmptyArgs{}, &EmptyArgs{})
+	if err != nil {
+		return fmt.Errorf("call remote service: %w", err)
+	}
+	slog.Info("RemoteService.ShowInstance called")
+	return nil
+}

--- a/internal/remoteservice/remote.go
+++ b/internal/remoteservice/remote.go
@@ -2,6 +2,7 @@
 package remoteservice
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -50,7 +51,7 @@ func Start(showInstance func()) error {
 	go func() {
 		slog.Info("Remote service running", "port", remoteServicePort)
 		err := http.Serve(l, nil)
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("Remote service: terminated prematurely", "error", err)
 		}
 	}()

--- a/internal/remoteservice/remote_test.go
+++ b/internal/remoteservice/remote_test.go
@@ -1,0 +1,21 @@
+package remoteservice_test
+
+import (
+	"testing"
+
+	"github.com/ErikKalkoken/evebuddy/internal/remoteservice"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteService(t *testing.T) {
+	var isCalled bool
+	err := remoteservice.Start(func() {
+		isCalled = true
+	})
+	if assert.NoError(t, err) {
+		err := remoteservice.ShowMainInstance()
+		if assert.NoError(t, err) {
+			assert.True(t, isCalled)
+		}
+	}
+}


### PR DESCRIPTION
EVE Buddy can only have one instance running at a time (per user). It therefore detects during startup if another instance is already running and automatically terminates again.

This can lead to confusion for the user who may not realize that another instance is already running. For example if the window of that other instance is hidden behind other window or if it is minimized to the system tray. In addition on Windows the app can not produce an error message on the console to inform the user about this.

This PR solves this problem by automatically switching over to the main instance and opening it's window to the foreground, when a user tries to start a 2nd instance.

This is implemented with a tiny RPC service, which is started by the first instance. Any secondary instance is then able to poke the main instance via RPC.. 