### PR TITLE
feat: UI scaling for desktop

### DIFF
--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -62,7 +62,7 @@ const (
 	settingSysTrayEnabledDefault              = true
 	settingTabsMainID                         = "tabs-main-id"
 	settingTabsMainIDDefault                  = -1
-	settingFyneDisableDPIDetection            = "settingFyneDisableDPIDetection"
+	settingDisableDPIDetection                = "settingFyneDisableDPIDetection"
 	settingFyneScale                          = "settingFyneScale"
 	settingFyneScaleDefault                   = 1.0
 	settingWindowHeightDefault                = 600
@@ -461,16 +461,25 @@ func (s Settings) SetFyneScale(v float64) {
 	s.p.SetFloat(settingFyneScale, v)
 }
 
-func (s Settings) FyneDisableDPIDetection() bool {
-	return s.p.Bool(settingFyneDisableDPIDetection)
+func (s Settings) DisableDPIDetection() bool {
+	return s.p.Bool(settingDisableDPIDetection)
 }
 
-func (s Settings) ResetSetFyneDisableDPIDetection() {
-	s.SetFyneDisableDPIDetection(false)
+func (s Settings) ResetDisableDPIDetection() {
+	s.SetDisableDPIDetection(false)
 }
 
-func (s Settings) SetFyneDisableDPIDetection(v bool) {
-	s.p.SetBool(settingFyneDisableDPIDetection, v)
+func (s Settings) SetDisableDPIDetection(v bool) {
+	s.p.SetBool(settingDisableDPIDetection, v)
+}
+
+// ResetUI resets all UI related settings to default.
+func (s Settings) ResetUI() {
+	s.ResetTabsMainID()
+	s.ResetWindowSize()
+	s.ResetColorTheme()
+	s.ResetFyneScale()
+	s.ResetDisableDPIDetection()
 }
 
 // Keys returns all setting keys. Mostly to know what to delete.

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -56,15 +56,18 @@ const (
 	settingNotifyTrainingEarliest             = "settingNotifyTrainingEarliest"
 	settingNotifyTrainingEnabled              = "settingNotifyTrainingEnabled"
 	settingNotifyTrainingEnabledDefault       = false
+	settingPreferMarketTab                    = "settingPreferMarketTab"
 	settingRecentSearches                     = "settingRecentSearches"
 	settingSysTrayEnabled                     = "settingSysTrayEnabled"
 	settingSysTrayEnabledDefault              = true
 	settingTabsMainID                         = "tabs-main-id"
 	settingTabsMainIDDefault                  = -1
+	settingFyneDisableDPIDetection            = "settingFyneDisableDPIDetection"
+	settingFyneScale                          = "settingFyneScale"
+	settingFyneScaleDefault                   = 1.0
 	settingWindowHeightDefault                = 600
 	settingWindowsSize                        = "window-size"
 	settingWindowWidthDefault                 = 1000
-	settingPreferMarketTab                    = "settingPreferMarketTab"
 )
 
 // Settings represents the settings for the app and provides an API for reading and writing settings.
@@ -440,6 +443,34 @@ func (s Settings) ResetColorTheme() {
 
 func (s Settings) SetColorTheme(v ColorTheme) {
 	s.p.SetString(settingColorTheme, string(v))
+}
+
+func (s Settings) FyneScale() float64 {
+	return s.p.FloatWithFallback(settingFyneScale, settingFyneScaleDefault)
+}
+
+func (s Settings) FyneScaleDefault() float64 {
+	return settingFyneScaleDefault
+}
+
+func (s Settings) ResetFyneScale() {
+	s.SetFyneScale(settingFyneScaleDefault)
+}
+
+func (s Settings) SetFyneScale(v float64) {
+	s.p.SetFloat(settingFyneScale, v)
+}
+
+func (s Settings) FyneDisableDPIDetection() bool {
+	return s.p.Bool(settingFyneDisableDPIDetection)
+}
+
+func (s Settings) ResetSetFyneDisableDPIDetection() {
+	s.SetFyneDisableDPIDetection(false)
+}
+
+func (s Settings) SetFyneDisableDPIDetection(v bool) {
+	s.p.SetBool(settingFyneDisableDPIDetection, v)
 }
 
 // Keys returns all setting keys. Mostly to know what to delete.

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -20,12 +20,13 @@ const (
 	Dark  ColorTheme = "Dark"
 )
 
+// Keys, defaults and presets for settings.
+// Keys without default have the zero value as default.
 const (
 	notifyEarliestFallback                    = 24 * time.Hour
 	settingColorTheme                         = "color-theme"
 	settingColorThemeDefault                  = Auto
 	settingDeveloperMode                      = "developer-mode"
-	settingDeveloperModeDefault               = false
 	settingLastCharacterID                    = "settingLastCharacterID"
 	settingLastCorporationID                  = "settingLastCorporationID"
 	settingLogLevel                           = "logLevel"
@@ -82,11 +83,7 @@ func New(p fyne.Preferences) *Settings {
 }
 
 func (s Settings) DeveloperMode() bool {
-	return s.p.BoolWithFallback(settingDeveloperMode, settingDeveloperModeDefault)
-}
-
-func (s Settings) ResetDeveloperMode() {
-	s.SetDeveloperMode(settingDeveloperModeDefault)
+	return s.p.Bool(settingDeveloperMode)
 }
 
 func (s Settings) SetDeveloperMode(v bool) {
@@ -142,10 +139,6 @@ func (s Settings) MaxMailsPresets() (min int, max int, def int) {
 	return
 }
 
-func (s Settings) ResetMaxMails() {
-	s.SetMaxMails(settingMaxMailsDefault)
-}
-
 func (s Settings) SetMaxMails(v int) {
 	s.p.SetInt(settingMaxMails, v)
 }
@@ -153,8 +146,9 @@ func (s Settings) SetMaxMails(v int) {
 func (s Settings) SysTrayEnabled() bool {
 	return s.p.BoolWithFallback(settingSysTrayEnabled, settingSysTrayEnabledDefault)
 }
-func (s Settings) ResetSysTrayEnabled() {
-	s.SetSysTrayEnabled(settingSysTrayEnabledDefault)
+
+func (s Settings) SysTrayEnabledDefault() bool {
+	return settingSysTrayEnabledDefault
 }
 
 func (s Settings) SetSysTrayEnabled(v bool) {
@@ -349,8 +343,9 @@ func string2time(s string) (time.Time, bool) {
 func (s Settings) NotifyCommunicationsEnabled() bool {
 	return s.p.BoolWithFallback(settingNotifyCommunicationsEnabled, settingNotifyCommunicationsEnabledDefault)
 }
-func (s Settings) ResetNotifyCommunicationsEnabled() {
-	s.SetNotifyCommunicationsEnabled(settingNotifyCommunicationsEnabledDefault)
+
+func (s Settings) NotifyCommunicationsEnabledDefault() bool {
+	return settingNotifyCommunicationsEnabledDefault
 }
 
 func (s Settings) SetNotifyCommunicationsEnabled(v bool) {
@@ -360,8 +355,9 @@ func (s Settings) SetNotifyCommunicationsEnabled(v bool) {
 func (s Settings) NotifyContractsEnabled() bool {
 	return s.p.BoolWithFallback(settingNotifyContractsEnabled, settingNotifyContractsEnabledDefault)
 }
-func (s Settings) ResetNotifyContractsEnabled() {
-	s.SetNotifyContractsEnabled(settingNotifyContractsEnabledDefault)
+
+func (s Settings) NotifyContractsEnabledDefault() bool {
+	return settingNotifyContractsEnabledDefault
 }
 
 func (s Settings) SetNotifyContractsEnabled(v bool) {
@@ -371,8 +367,9 @@ func (s Settings) SetNotifyContractsEnabled(v bool) {
 func (s Settings) NotifyMailsEnabled() bool {
 	return s.p.BoolWithFallback(settingNotifyMailsEnabled, settingNotifyMailsEnabledDefault)
 }
-func (s Settings) ResetNotifyMailsEnabled() {
-	s.SetNotifyMailsEnabled(settingNotifyMailsEnabledDefault)
+
+func (s Settings) NotifyMailsEnabledDefault() bool {
+	return settingNotifyMailsEnabledDefault
 }
 
 func (s Settings) SetNotifyMailsEnabled(v bool) {
@@ -382,8 +379,9 @@ func (s Settings) SetNotifyMailsEnabled(v bool) {
 func (s Settings) NotifyPIEnabled() bool {
 	return s.p.BoolWithFallback(settingNotifyPIEnabled, settingNotifyPIEnabledDefault)
 }
-func (s Settings) ResetNotifyPIEnabled() {
-	s.SetNotifyPIEnabled(settingNotifyPIEnabledDefault)
+
+func (s Settings) NotifyPIEnabledDefault() bool {
+	return settingNotifyPIEnabledDefault
 }
 
 func (s Settings) SetNotifyPIEnabled(v bool) {
@@ -394,8 +392,8 @@ func (s Settings) NotifyTrainingEnabled() bool {
 	return s.p.BoolWithFallback(settingNotifyTrainingEnabled, settingNotifyTrainingEnabledDefault)
 }
 
-func (s Settings) ResetNotifyTrainingEnabled() {
-	s.SetNotifyTrainingEnabled(settingNotifyTrainingEnabledDefault)
+func (s Settings) NotifyTrainingEnabledDefault() bool {
+	return settingNotifyTrainingEnabledDefault
 }
 
 func (s Settings) SetNotifyTrainingEnabled(v bool) {

--- a/internal/app/storage/corporationwalletjournal_test.go
+++ b/internal/app/storage/corporationwalletjournal_test.go
@@ -62,16 +62,16 @@ func TestCorporationWalletJournalEntry(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		c := factory.CreateCorporation()
-		e1 := factory.CreateEveEntity()
-		e2 := factory.CreateEveEntity()
-		e3 := factory.CreateEveEntity()
+		firstParty := factory.CreateEveEntity()
+		secondParty := factory.CreateEveEntity()
+		taxReceiver := factory.CreateEveEntity()
 		date := time.Now()
 		arg := storage.CreateCorporationWalletJournalEntryParams{
 			Amount:        123.45,
 			Balance:       234.56,
 			ContextID:     42,
 			ContextIDType: "corporation",
-			FirstPartyID:  e1.ID,
+			FirstPartyID:  firstParty.ID,
 			Date:          date,
 			Description:   "bla bla",
 			DivisionID:    1,
@@ -79,9 +79,9 @@ func TestCorporationWalletJournalEntry(t *testing.T) {
 			CorporationID: c.ID,
 			Reason:        "my reason",
 			RefType:       "player_donation",
-			SecondPartyID: e2.ID,
+			SecondPartyID: secondParty.ID,
 			Tax:           0.12,
-			TaxReceiverID: e3.ID,
+			TaxReceiverID: taxReceiver.ID,
 		}
 		// when
 		err := st.CreateCorporationWalletJournalEntry(ctx, arg)
@@ -97,13 +97,13 @@ func TestCorporationWalletJournalEntry(t *testing.T) {
 				assert.Equal(t, 234.56, i.Balance)
 				assert.Equal(t, int64(42), i.ContextID)
 				assert.Equal(t, "corporation", i.ContextIDType)
-				assert.Equal(t, e1, i.FirstParty)
+				assert.Equal(t, firstParty, i.FirstParty)
 				assert.Equal(t, date.UTC(), i.Date.UTC())
 				assert.Equal(t, "bla bla", i.Description)
 				assert.Equal(t, "player_donation", i.RefType)
 				assert.Equal(t, "my reason", i.Reason)
-				assert.Equal(t, e2, i.SecondParty)
-				assert.Equal(t, e3, i.TaxReceiver)
+				assert.Equal(t, secondParty, i.SecondParty)
+				assert.Equal(t, taxReceiver, i.TaxReceiver)
 				assert.Equal(t, 0.12, i.Tax)
 			}
 		}

--- a/internal/app/ui/desktopui.go
+++ b/internal/app/ui/desktopui.go
@@ -517,12 +517,6 @@ func (u *DesktopUI) saveAppState() {
 	slog.Debug("Saved app state")
 }
 
-func (u *DesktopUI) ResetDesktopSettings() {
-	u.settings.ResetTabsMainID()
-	u.settings.ResetWindowSize()
-	u.settings.ResetSysTrayEnabled()
-}
-
 func (u *DesktopUI) showSendMailWindow(c *app.Character, mode app.SendMailMode, mail *app.CharacterMail) {
 	title := fmt.Sprintf("New message [%s]", c.EveCharacter.Name)
 	w := u.App().NewWindow(u.makeWindowTitle(title))

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 
 	// start fyne app
 	fyneApp := app.NewWithID(appID)
+	appSettings := settings.New(fyneApp.Preferences())
 	var isDesktop bool
 	if !*mobileFlag {
 		_, isDesktop = fyneApp.(desktop.App)
@@ -136,8 +137,8 @@ func main() {
 
 	// set log level from settings
 	if *logLevelFlag == "" {
-		s := settings.New(fyneApp.Preferences())
-		if l := s.LogLevelSlog(); l != logLevelDefault {
+
+		if l := appSettings.LogLevelSlog(); l != logLevelDefault {
 			slog.Info("Setting log level", "level", l)
 			slog.SetLogLoggerLevel(l)
 		}
@@ -307,6 +308,8 @@ func main() {
 	})
 
 	// Init UI
+	os.Setenv("FYNE_SCALE", fmt.Sprint(appSettings.FyneScale()))
+	os.Setenv("FYNE_DISABLE_DPI_DETECTION", fmt.Sprint(appSettings.FyneDisableDPIDetection()))
 	key := os.Getenv("JANICE_API_KEY")
 	if key == "" {
 		key = fyneApp.Metadata().Custom["janiceAPIKey"]

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ var (
 	mobileFlag         = flag.Bool("mobile", false, "Run the app in forced mobile mode")
 	offlineFlag        = flag.Bool("offline", false, "Start app in offline mode")
 	pprofFlag          = flag.Bool("pprof", false, "Enable pprof web server")
-	resetSettingsFlag  = flag.Bool("reset-settings", false, "Resets desktop settings")
+	resetUIFlag        = flag.Bool("reset-ui", false, "Resets UI settings to defaults")
 	versionFlag        = flag.Bool("v", false, "Show version")
 	ssoDemoFlag        = flag.Bool("sso-demo", false, "Start SSO serer in demo mode")
 )
@@ -122,18 +122,17 @@ func main() {
 
 	// start fyne app
 	fyneApp := app.NewWithID(appID)
-	appSettings := settings.New(fyneApp.Preferences())
-	var isDesktop bool
-	if !*mobileFlag {
-		_, isDesktop = fyneApp.(desktop.App)
-	}
-
 	if *versionFlag {
 		fmt.Println(fyneApp.Metadata().Version)
 		return
 	}
 
 	log.Printf("INFO EVE Buddy version=%s", fyneApp.Metadata().Version)
+
+	appSettings := settings.New(fyneApp.Preferences())
+	if *resetUIFlag {
+		appSettings.ResetUI()
+	}
 
 	// set log level from settings
 	if *logLevelFlag == "" {
@@ -144,9 +143,12 @@ func main() {
 		}
 	}
 
-	var dataDir string
-
 	// data dir
+	var dataDir string
+	var isDesktop bool
+	if !*mobileFlag {
+		_, isDesktop = fyneApp.(desktop.App)
+	}
 	if isDesktop || *developFlag {
 		ad := appdirs.New(appName)
 		dataDir = ad.UserData()
@@ -309,7 +311,7 @@ func main() {
 
 	// Init UI
 	os.Setenv("FYNE_SCALE", fmt.Sprint(appSettings.FyneScale()))
-	os.Setenv("FYNE_DISABLE_DPI_DETECTION", fmt.Sprint(appSettings.FyneDisableDPIDetection()))
+	os.Setenv("FYNE_DISABLE_DPI_DETECTION", fmt.Sprint(appSettings.DisableDPIDetection()))
 	key := os.Getenv("JANICE_API_KEY")
 	if key == "" {
 		key = fyneApp.Metadata().Custom["janiceAPIKey"]
@@ -340,9 +342,6 @@ func main() {
 	})
 	if isDesktop {
 		u := ui.NewDesktopUI(bu)
-		if *resetSettingsFlag {
-			u.ResetDesktopSettings()
-		}
 		if err := remoteservice.Start(func() {
 			fyne.Do(func() {
 				u.MainWindow().Show()


### PR DESCRIPTION
Adds the new feature "UI scaling".

This feature helps when the build-on auto-scaling does not work correctly or the user prefers a different size of the app.

In detail this adds:
- A setting for a custom UI scale (50% - 200%) can be defined, which will scale all UI elements
- A setting for disabling "DPI detection"
- A new CLI parameter to reset UI scaling (as a fallback option)

This feature is available for desktop only.

This should solve these issues:
#24 
#209 

