### PR TITLE
feat: Remove stale corporations & filter limited corporations

### DIFF
--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 type SSOService interface {
@@ -191,6 +192,17 @@ func (s *CharacterService) getCharacterName(ctx context.Context, characterID int
 
 func (s *CharacterService) ListCharacters(ctx context.Context) ([]*app.Character, error) {
 	return s.st.ListCharacters(ctx)
+}
+
+func (s *CharacterService) ListCharacterIDs(ctx context.Context) (set.Set[int32], error) {
+	cc, err := s.st.ListCharactersShort(ctx)
+	if err != nil {
+		return set.Set[int32]{}, err
+	}
+	ids := set.Collect(xiter.MapSlice(cc, func(x *app.EntityShort[int32]) int32 {
+		return x.ID
+	}))
+	return ids, nil
 }
 
 func (s *CharacterService) ListCharactersShort(ctx context.Context) ([]*app.EntityShort[int32], error) {

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -197,6 +197,10 @@ func (s *CharacterService) ListCharactersShort(ctx context.Context) ([]*app.Enti
 	return s.st.ListCharactersShort(ctx)
 }
 
+func (s *CharacterService) ListCharacterCorporations(ctx context.Context) ([]*app.EntityShort[int32], error) {
+	return s.st.ListCharacterCorporations(ctx)
+}
+
 // HasCharacter reports whether a character exists.
 func (s *CharacterService) HasCharacter(ctx context.Context, id int32) (bool, error) {
 	_, err := s.GetCharacter(ctx, id)

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -197,6 +197,10 @@ func (s *CharacterService) ListCharactersShort(ctx context.Context) ([]*app.Enti
 	return s.st.ListCharactersShort(ctx)
 }
 
+func (s *CharacterService) ListCharacterCorporationIDs(ctx context.Context) (set.Set[int32], error) {
+	return s.st.ListCharacterCorporationIDs(ctx)
+}
+
 // HasCharacter reports whether a character exists.
 func (s *CharacterService) HasCharacter(ctx context.Context, id int32) (bool, error) {
 	_, err := s.GetCharacter(ctx, id)

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -197,10 +197,6 @@ func (s *CharacterService) ListCharactersShort(ctx context.Context) ([]*app.Enti
 	return s.st.ListCharactersShort(ctx)
 }
 
-func (s *CharacterService) ListCharacterCorporationIDs(ctx context.Context) (set.Set[int32], error) {
-	return s.st.ListCharacterCorporationIDs(ctx)
-}
-
 // HasCharacter reports whether a character exists.
 func (s *CharacterService) HasCharacter(ctx context.Context, id int32) (bool, error) {
 	_, err := s.GetCharacter(ctx, id)

--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/statuscacheservice"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 type CharacterService interface {
@@ -133,10 +134,13 @@ func (s *CorporationService) RemoveStaleCorporations(ctx context.Context) (bool,
 	if all.Size() == 0 {
 		return false, nil
 	}
-	current, err := s.st.ListCharacterCorporationIDs(ctx)
+	cc, err := s.st.ListCharacterCorporations(ctx)
 	if err != nil {
 		return false, wrapErr(err)
 	}
+	current := set.Collect(xiter.MapSlice(cc, func(x *app.EntityShort[int32]) int32 {
+		return x.ID
+	}))
 	stale := set.Difference(all, current)
 	if stale.Size() == 0 {
 		return false, nil

--- a/internal/app/corporationservice/corporation_internal_test.go
+++ b/internal/app/corporationservice/corporation_internal_test.go
@@ -18,12 +18,17 @@ import (
 )
 
 type CharacterServiceFake struct {
-	Token *app.CharacterToken
-	Error error
+	Token          *app.CharacterToken
+	CorporationIDs set.Set[int32]
+	Error          error
 }
 
-func (s CharacterServiceFake) ValidCharacterTokenForCorporation(ctx context.Context, corporationID int32, roles set.Set[app.Role], scopes set.Set[string]) (*app.CharacterToken, error) {
+func (s *CharacterServiceFake) ValidCharacterTokenForCorporation(ctx context.Context, corporationID int32, roles set.Set[app.Role], scopes set.Set[string]) (*app.CharacterToken, error) {
 	return s.Token, s.Error
+}
+
+func (s *CharacterServiceFake) ListCharacterCorporationIDs(ctx context.Context) (set.Set[int32], error) {
+	return s.CorporationIDs, s.Error
 }
 
 func NewFake(st *storage.Storage, args ...Params) *CorporationService {
@@ -54,7 +59,9 @@ func TestUpdateDivisionsESI(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)
 		httpmock.Reset()
-		s := NewFake(st, Params{CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+		s := NewFake(st, Params{CharacterService: &CharacterServiceFake{
+			Token: &app.CharacterToken{AccessToken: "accessToken"},
+		}})
 		c := factory.CreateCorporation()
 		data := map[string]any{
 			"hangar": []map[string]any{

--- a/internal/app/corporationservice/corporation_internal_test.go
+++ b/internal/app/corporationservice/corporation_internal_test.go
@@ -27,10 +27,6 @@ func (s *CharacterServiceFake) ValidCharacterTokenForCorporation(ctx context.Con
 	return s.Token, s.Error
 }
 
-func (s *CharacterServiceFake) ListCharacterCorporationIDs(ctx context.Context) (set.Set[int32], error) {
-	return s.CorporationIDs, s.Error
-}
-
 func NewFake(st *storage.Storage, args ...Params) *CorporationService {
 	scs := statuscacheservice.New(memcache.New(), st)
 	eus := eveuniverseservice.New(eveuniverseservice.Params{

--- a/internal/app/corporationservice/corporation_test.go
+++ b/internal/app/corporationservice/corporation_test.go
@@ -1,1 +1,68 @@
 package corporationservice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/corporationservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCorporation(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	t.Run("can delete corporations with no member character", func(t *testing.T) {
+		testutil.TruncateTables(db)
+		corp := factory.CreateCorporation()
+		factory.CreateCorporation()
+		s := corporationservice.NewFake(st, corporationservice.Params{
+			CharacterService: &corporationservice.CharacterServiceFake{
+				CorporationIDs: set.Of(corp.ID),
+			}})
+		changed, err := s.RemoveStaleCorporations(ctx)
+		if assert.NoError(t, err) {
+			assert.True(t, changed)
+			want := set.Of(corp.ID)
+			got, err := s.ListCorporationIDs(ctx)
+			if assert.NoError(t, err) {
+				assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
+			}
+		}
+	})
+	t.Run("report false when nothing deleted", func(t *testing.T) {
+		testutil.TruncateTables(db)
+		corp := factory.CreateCorporation()
+		s := corporationservice.NewFake(st, corporationservice.Params{
+			CharacterService: &corporationservice.CharacterServiceFake{
+				CorporationIDs: set.Of(corp.ID),
+			}})
+		changed, err := s.RemoveStaleCorporations(ctx)
+		if assert.NoError(t, err) {
+			assert.False(t, changed)
+			want := set.Of(corp.ID)
+			got, err := s.ListCorporationIDs(ctx)
+			if assert.NoError(t, err) {
+				assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
+			}
+		}
+	})
+	t.Run("report false when no corporations", func(t *testing.T) {
+		testutil.TruncateTables(db)
+		s := corporationservice.NewFake(st, corporationservice.Params{
+			CharacterService: &corporationservice.CharacterServiceFake{
+				CorporationIDs: set.Of[int32](),
+			}})
+		changed, err := s.RemoveStaleCorporations(ctx)
+		if assert.NoError(t, err) {
+			assert.False(t, changed)
+			want := set.Of[int32]()
+			got, err := s.ListCorporationIDs(ctx)
+			if assert.NoError(t, err) {
+				assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
+			}
+		}
+	})
+}

--- a/internal/app/evetype.go
+++ b/internal/app/evetype.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"math"
+
 	"fyne.io/fyne/v2"
 	"github.com/ErikKalkoken/evebuddy/internal/evehtml"
 	"github.com/ErikKalkoken/evebuddy/internal/eveicon"
@@ -354,4 +356,11 @@ type EveMarketPrice struct {
 	TypeID        int32
 	AdjustedPrice float64
 	AveragePrice  float64
+}
+
+// Equal reports whether two objects are equal.
+func (x EveMarketPrice) Equal(other EveMarketPrice) bool {
+	return x.TypeID == other.TypeID &&
+		math.Abs(float64(x.AdjustedPrice-other.AdjustedPrice)) < 0.001 &&
+		math.Abs(float64(x.AveragePrice-other.AveragePrice)) < 0.001
 }

--- a/internal/app/eveuniverse.go
+++ b/internal/app/eveuniverse.go
@@ -138,6 +138,20 @@ func (ec EveCorporation) AllianceID() int32 {
 	return ec.Alliance.ID
 }
 
+func (ec EveCorporation) CeoID() int32 {
+	if ec.Ceo == nil {
+		return 0
+	}
+	return ec.Ceo.ID
+}
+
+func (ec EveCorporation) CreatorID() int32 {
+	if ec.Creator == nil {
+		return 0
+	}
+	return ec.Creator.ID
+}
+
 func (ec EveCorporation) FactionID() int32 {
 	if !ec.HasFaction() {
 		return 0
@@ -172,8 +186,8 @@ func (ec EveCorporation) ToEveEntity() *EveEntity {
 func (ec EveCorporation) Equal(other EveCorporation) bool {
 	return ec.ID == other.ID &&
 		ec.AllianceID() == other.AllianceID() &&
-		ec.Ceo.ID == other.Ceo.ID &&
-		ec.Creator.ID == other.Creator.ID &&
+		ec.CeoID() == other.CeoID() &&
+		ec.CreatorID() == other.CreatorID() &&
 		ec.DateFounded.ValueOrZero().Equal(other.DateFounded.ValueOrZero()) &&
 		ec.Description == other.Description &&
 		ec.FactionID() == other.FactionID() &&

--- a/internal/app/eveuniverse.go
+++ b/internal/app/eveuniverse.go
@@ -97,10 +97,7 @@ func (ec EveCharacter) ToEveEntity() *EveEntity {
 
 // IsIdentical reports whether two characters are identical.
 // Two characters must have the same values in all fields to be identical.
-func (ec EveCharacter) IsIdentical(other *EveCharacter) bool {
-	if other == nil {
-		return false
-	}
+func (ec EveCharacter) IsIdentical(other EveCharacter) bool {
 	return ec.ID == other.ID &&
 		ec.AllianceID() == other.AllianceID() &&
 		ec.Birthday.Equal(other.Birthday) &&
@@ -134,6 +131,20 @@ type EveCorporation struct {
 	Timestamp   time.Time
 }
 
+func (ec EveCorporation) AllianceID() int32 {
+	if !ec.HasAlliance() {
+		return 0
+	}
+	return ec.Alliance.ID
+}
+
+func (ec EveCorporation) FactionID() int32 {
+	if !ec.HasFaction() {
+		return 0
+	}
+	return ec.Faction.ID
+}
+
 func (ec EveCorporation) HasAlliance() bool {
 	return ec.Alliance != nil
 }
@@ -142,12 +153,35 @@ func (ec EveCorporation) HasFaction() bool {
 	return ec.Faction != nil
 }
 
+func (ec EveCorporation) HomeStationID() int32 {
+	if ec.HomeStation == nil {
+		return 0
+	}
+	return ec.HomeStation.ID
+}
 func (ec EveCorporation) DescriptionPlain() string {
 	return evehtml.ToPlain(ec.Description)
 }
 
 func (ec EveCorporation) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCorporation}
+}
+
+// IsIdentical reports whether two characters are identical.
+// Two characters must have the same values in all fields to be identical.
+func (ec EveCorporation) IsIdentical(other EveCorporation) bool {
+	return ec.ID == other.ID &&
+		ec.AllianceID() == other.AllianceID() &&
+		ec.Ceo.ID == other.Ceo.ID &&
+		ec.Creator.ID == other.Creator.ID &&
+		ec.DateFounded.ValueOrZero().Equal(other.DateFounded.ValueOrZero()) &&
+		ec.Description == other.Description &&
+		ec.FactionID() == other.FactionID() &&
+		ec.HomeStationID() == other.HomeStationID() &&
+		ec.MemberCount == other.MemberCount &&
+		ec.Name == other.Name &&
+		ec.Shares == other.Shares &&
+		math.Abs(float64(ec.TaxRate-other.TaxRate)) < 0.01
 }
 
 // TODO: Add race alliance

--- a/internal/app/eveuniverse.go
+++ b/internal/app/eveuniverse.go
@@ -95,9 +95,9 @@ func (ec EveCharacter) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCharacter}
 }
 
-// IsIdentical reports whether two characters are identical.
-// Two characters must have the same values in all fields to be identical.
-func (ec EveCharacter) IsIdentical(other EveCharacter) bool {
+// Equal reports whether two characters are equal.
+// Two characters must have the same values in all fields to be equal.
+func (ec EveCharacter) Equal(other EveCharacter) bool {
 	return ec.ID == other.ID &&
 		ec.AllianceID() == other.AllianceID() &&
 		ec.Birthday.Equal(other.Birthday) &&
@@ -167,9 +167,9 @@ func (ec EveCorporation) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCorporation}
 }
 
-// IsIdentical reports whether two characters are identical.
-// Two characters must have the same values in all fields to be identical.
-func (ec EveCorporation) IsIdentical(other EveCorporation) bool {
+// Equal reports whether two characters are equal.
+// Two characters must have the same values in all fields to be equal.
+func (ec EveCorporation) Equal(other EveCorporation) bool {
 	return ec.ID == other.ID &&
 		ec.AllianceID() == other.AllianceID() &&
 		ec.Ceo.ID == other.Ceo.ID &&

--- a/internal/app/eveuniverse.go
+++ b/internal/app/eveuniverse.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"math"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -41,11 +42,25 @@ type EveCharacter struct {
 	Title          string
 }
 
+func (ec EveCharacter) AllianceID() int32 {
+	if !ec.HasAlliance() {
+		return 0
+	}
+	return ec.Alliance.ID
+}
+
 func (ec EveCharacter) AllianceName() string {
 	if !ec.HasAlliance() {
 		return ""
 	}
 	return ec.Alliance.Name
+}
+
+func (ec EveCharacter) FactionID() int32 {
+	if !ec.HasFaction() {
+		return 0
+	}
+	return ec.Faction.ID
 }
 
 func (ec EveCharacter) FactionName() string {
@@ -78,6 +93,25 @@ func (ec EveCharacter) RaceDescription() string {
 
 func (ec EveCharacter) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCharacter}
+}
+
+// IsIdentical reports whether two characters are identical.
+// Two characters must have the same values in all fields to be identical.
+func (ec EveCharacter) IsIdentical(other *EveCharacter) bool {
+	if other == nil {
+		return false
+	}
+	return ec.ID == other.ID &&
+		ec.AllianceID() == other.AllianceID() &&
+		ec.Birthday.Equal(other.Birthday) &&
+		ec.Corporation.ID == other.Corporation.ID &&
+		ec.Description == other.Description &&
+		ec.FactionID() == other.FactionID() &&
+		ec.Gender == other.Gender &&
+		ec.Name == other.Name &&
+		ec.Race.ID == other.Race.ID &&
+		math.Abs(ec.SecurityStatus-other.SecurityStatus) < 0.01 &&
+		ec.Title == other.Title
 }
 
 // EveCorporation is a corporation in Eve Online.

--- a/internal/app/eveuniverse_test.go
+++ b/internal/app/eveuniverse_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestEveAlliance(t *testing.T) {
 	assert.EqualValues(t, app.EveEntityAlliance, ee.Category)
 }
 
-func TestEveCharacterAlliance(t *testing.T) {
+func TestEveCharacter_Alliance(t *testing.T) {
 	x1 := &app.EveCharacter{
 		Alliance: &app.EveEntity{
 			Name: "alliance",
@@ -32,12 +33,12 @@ func TestEveCharacterAlliance(t *testing.T) {
 	assert.False(t, x2.HasAlliance())
 }
 
-func TestEveCharacterDescription(t *testing.T) {
+func TestEveCharacter_Description(t *testing.T) {
 	x := &app.EveCharacter{Description: "alpha<br>bravo"}
 	assert.Equal(t, "alpha\nbravo", x.DescriptionPlain())
 }
 
-func TestEveCharacterFaction(t *testing.T) {
+func TestEveCharacter_Faction(t *testing.T) {
 	x1 := &app.EveCharacter{
 		Faction: &app.EveEntity{
 			Name: "faction",
@@ -51,7 +52,7 @@ func TestEveCharacterFaction(t *testing.T) {
 	assert.False(t, x2.HasFaction())
 }
 
-func TestEveCharacterRace(t *testing.T) {
+func TestEveCharacter_Race(t *testing.T) {
 	x1 := &app.EveCharacter{Race: &app.EveRace{Description: "description"}}
 	assert.Equal(t, "description", x1.RaceDescription())
 
@@ -59,7 +60,7 @@ func TestEveCharacterRace(t *testing.T) {
 	assert.Equal(t, "", x2.RaceDescription())
 }
 
-func TestEveCharacterEveEntity(t *testing.T) {
+func TestEveCharacter_EveEntity(t *testing.T) {
 	x1 := &app.EveCharacter{ID: 42, Name: "name"}
 	x2 := x1.ToEveEntity()
 	assert.EqualValues(t, 42, x2.ID)
@@ -67,7 +68,46 @@ func TestEveCharacterEveEntity(t *testing.T) {
 	assert.EqualValues(t, app.EveEntityCharacter, x2.Category)
 }
 
-func TestEveCorporationAlliance(t *testing.T) {
+func TestEveCharacter_IsSame(t *testing.T) {
+	t.Run("should report when same", func(t *testing.T) {
+		x1 := app.EveCharacter{
+			Alliance:       &app.EveEntity{ID: 1},
+			Birthday:       time.Now(),
+			Corporation:    &app.EveEntity{ID: 2},
+			Description:    "abc",
+			Faction:        &app.EveEntity{ID: 3},
+			Gender:         "male",
+			ID:             4,
+			Name:           "Bruce Wayne",
+			Race:           &app.EveRace{ID: 4},
+			SecurityStatus: -4.5,
+			Title:          "def",
+		}
+		x2 := x1
+		assert.True(t, x1.IsIdentical(&x2))
+	})
+	t.Run("should report when not same", func(t *testing.T) {
+		x1 := app.EveCharacter{
+			Alliance:       &app.EveEntity{ID: 1},
+			Birthday:       time.Now(),
+			Corporation:    &app.EveEntity{ID: 2},
+			Description:    "abc",
+			Faction:        &app.EveEntity{ID: 3},
+			Gender:         "male",
+			ID:             4,
+			Name:           "Bruce Wayne",
+			Race:           &app.EveRace{ID: 4},
+			SecurityStatus: -4.5,
+			Title:          "def",
+		}
+		x2 := app.EveCharacter{
+			ID: 4,
+		}
+		assert.False(t, x1.IsIdentical(&x2))
+	})
+}
+
+func TestEveCorporation_Alliance(t *testing.T) {
 	x1 := &app.EveCorporation{Alliance: &app.EveEntity{}}
 	assert.True(t, x1.HasAlliance())
 
@@ -75,7 +115,7 @@ func TestEveCorporationAlliance(t *testing.T) {
 	assert.False(t, x2.HasAlliance())
 }
 
-func TestEveCorporationFaction(t *testing.T) {
+func TestEveCorporation_Faction(t *testing.T) {
 	x1 := &app.EveCorporation{Faction: &app.EveEntity{}}
 	assert.True(t, x1.HasFaction())
 
@@ -83,7 +123,7 @@ func TestEveCorporationFaction(t *testing.T) {
 	assert.False(t, x2.HasFaction())
 }
 
-func TestEveCorporationEveEntity(t *testing.T) {
+func TestEveCorporation_EveEntity(t *testing.T) {
 	x1 := &app.EveCorporation{ID: 42, Name: "name"}
 	x2 := x1.ToEveEntity()
 	assert.EqualValues(t, 42, x2.ID)

--- a/internal/app/eveuniverse_test.go
+++ b/internal/app/eveuniverse_test.go
@@ -85,7 +85,7 @@ func TestEveCharacter_IsIdentical(t *testing.T) {
 			Title:          "def",
 		}
 		x2 := x1
-		assert.True(t, x1.IsIdentical(x2))
+		assert.True(t, x1.Equal(x2))
 	})
 	t.Run("should report when not same", func(t *testing.T) {
 		x1 := app.EveCharacter{
@@ -104,7 +104,7 @@ func TestEveCharacter_IsIdentical(t *testing.T) {
 		x2 := app.EveCharacter{
 			ID: 4,
 		}
-		assert.False(t, x1.IsIdentical(x2))
+		assert.False(t, x1.Equal(x2))
 	})
 }
 
@@ -153,7 +153,7 @@ func TestEveCorporation_IsIdentical(t *testing.T) {
 			Timestamp:   time.Now(),
 		}
 		x2 := x1
-		assert.True(t, x1.IsIdentical(x2))
+		assert.True(t, x1.Equal(x2))
 	})
 	t.Run("should report when not same", func(t *testing.T) {
 		x1 := app.EveCorporation{
@@ -177,7 +177,7 @@ func TestEveCorporation_IsIdentical(t *testing.T) {
 		x2 := app.EveCorporation{
 			ID: 4,
 		}
-		assert.False(t, x1.IsIdentical(x2))
+		assert.False(t, x1.Equal(x2))
 	})
 }
 

--- a/internal/app/eveuniverse_test.go
+++ b/internal/app/eveuniverse_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,7 +69,7 @@ func TestEveCharacter_EveEntity(t *testing.T) {
 	assert.EqualValues(t, app.EveEntityCharacter, x2.Category)
 }
 
-func TestEveCharacter_IsSame(t *testing.T) {
+func TestEveCharacter_IsIdentical(t *testing.T) {
 	t.Run("should report when same", func(t *testing.T) {
 		x1 := app.EveCharacter{
 			Alliance:       &app.EveEntity{ID: 1},
@@ -84,7 +85,7 @@ func TestEveCharacter_IsSame(t *testing.T) {
 			Title:          "def",
 		}
 		x2 := x1
-		assert.True(t, x1.IsIdentical(&x2))
+		assert.True(t, x1.IsIdentical(x2))
 	})
 	t.Run("should report when not same", func(t *testing.T) {
 		x1 := app.EveCharacter{
@@ -103,7 +104,7 @@ func TestEveCharacter_IsSame(t *testing.T) {
 		x2 := app.EveCharacter{
 			ID: 4,
 		}
-		assert.False(t, x1.IsIdentical(&x2))
+		assert.False(t, x1.IsIdentical(x2))
 	})
 }
 
@@ -129,6 +130,55 @@ func TestEveCorporation_EveEntity(t *testing.T) {
 	assert.EqualValues(t, 42, x2.ID)
 	assert.EqualValues(t, "name", x2.Name)
 	assert.EqualValues(t, app.EveEntityCorporation, x2.Category)
+}
+
+func TestEveCorporation_IsIdentical(t *testing.T) {
+	t.Run("should report when same", func(t *testing.T) {
+		x1 := app.EveCorporation{
+			Alliance:    &app.EveEntity{ID: 1},
+			Ceo:         &app.EveEntity{ID: 2},
+			Creator:     &app.EveEntity{ID: 3},
+			DateFounded: optional.New(time.Now().Add(-3 * time.Hour)),
+			Description: "abc",
+			Faction:     &app.EveEntity{ID: 4},
+			HomeStation: &app.EveEntity{ID: 5},
+			ID:          6,
+			MemberCount: 7,
+			Name:        "def",
+			Shares:      optional.New(8),
+			TaxRate:     9.1,
+			Ticker:      "ghi",
+			URL:         "jkl",
+			WarEligible: true,
+			Timestamp:   time.Now(),
+		}
+		x2 := x1
+		assert.True(t, x1.IsIdentical(x2))
+	})
+	t.Run("should report when not same", func(t *testing.T) {
+		x1 := app.EveCorporation{
+			Alliance:    &app.EveEntity{ID: 1},
+			Ceo:         &app.EveEntity{ID: 2},
+			Creator:     &app.EveEntity{ID: 3},
+			DateFounded: optional.New(time.Now().Add(-3 * time.Hour)),
+			Description: "abc",
+			Faction:     &app.EveEntity{ID: 4},
+			HomeStation: &app.EveEntity{ID: 5},
+			ID:          6,
+			MemberCount: 7,
+			Name:        "def",
+			Shares:      optional.New(8),
+			TaxRate:     9.1,
+			Ticker:      "ghi",
+			URL:         "jkl",
+			WarEligible: true,
+			Timestamp:   time.Now(),
+		}
+		x2 := app.EveCorporation{
+			ID: 4,
+		}
+		assert.False(t, x1.IsIdentical(x2))
+	})
 }
 
 func TestEveSchematic(t *testing.T) {

--- a/internal/app/eveuniverseservice/character.go
+++ b/internal/app/eveuniverseservice/character.go
@@ -122,7 +122,7 @@ func (s *EveUniverseService) UpdateAllCharactersESI(ctx context.Context) (set.Se
 			changed.Add(id)
 		}
 	}
-	slog.Info("Finished updating eve characters", "count", ids.Size())
+	slog.Info("Finished updating eve characters", "count", ids.Size(), "changed", changed)
 	return changed, nil
 }
 
@@ -185,7 +185,7 @@ func (s *EveUniverseService) updateCharacterESI(ctx context.Context, characterID
 		}); err != nil {
 			return false, err
 		}
-		hasChanged := !old.IsIdentical(c)
+		hasChanged := !old.IsIdentical(*c)
 		slog.Info("Updated eve character from ESI", "characterID", c.ID, "changed", hasChanged)
 		return hasChanged, nil
 	})

--- a/internal/app/eveuniverseservice/character.go
+++ b/internal/app/eveuniverseservice/character.go
@@ -185,7 +185,7 @@ func (s *EveUniverseService) updateCharacterESI(ctx context.Context, characterID
 		}); err != nil {
 			return false, err
 		}
-		hasChanged := !old.IsIdentical(*c)
+		hasChanged := !old.Equal(*c)
 		slog.Info("Updated eve character from ESI", "characterID", c.ID, "changed", hasChanged)
 		return hasChanged, nil
 	})

--- a/internal/app/eveuniverseservice/character_internal_test.go
+++ b/internal/app/eveuniverseservice/character_internal_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
 )
 
@@ -24,7 +26,7 @@ func TestUpdateEveCharacterESI(t *testing.T) {
 		testutil.TruncateTables(db)
 		o1 := factory.CreateEveCharacter()
 		factory.CreateEveEntityCharacter(app.EveEntity{ID: o1.ID})
-		alliance := factory.CreateEveEntityCorporation(app.EveEntity{ID: 434243723})
+		alliance := factory.CreateEveEntityAlliance(app.EveEntity{ID: 434243723})
 		corporation := factory.CreateEveEntityCorporation(app.EveEntity{ID: 109299958})
 		faction := factory.CreateEveEntity(app.EveEntity{ID: 500004, Category: app.EveEntityFaction})
 		httpmock.Reset()
@@ -54,9 +56,10 @@ func TestUpdateEveCharacterESI(t *testing.T) {
 				}}),
 		)
 		// when
-		err := s.updateCharacterESI(ctx, o1.ID)
+		changed, err := s.updateCharacterESI(ctx, o1.ID)
 		// then
 		if assert.NoError(t, err) {
+			assert.True(t, changed)
 			o2, err := st.GetEveCharacter(ctx, o1.ID)
 			if assert.NoError(t, err) {
 				assert.Equal(t, alliance, o2.Alliance)
@@ -67,6 +70,59 @@ func TestUpdateEveCharacterESI(t *testing.T) {
 				assert.Equal(t, "All round pretty awesome guy", o2.Title)
 				assert.InDelta(t, -9.9, o2.SecurityStatus, 0.01)
 			}
+		}
+	})
+	t.Run("should report when not changed", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		alliance := factory.CreateEveEntityAlliance(app.EveEntity{ID: 434243723})
+		corporation := factory.CreateEveEntityCorporation(app.EveEntity{ID: 109299958})
+		faction := factory.CreateEveEntity(app.EveEntity{ID: 500004, Category: app.EveEntityFaction})
+		race := factory.CreateEveRace(app.EveRace{ID: 2})
+		o1 := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+			AllianceID:     alliance.ID,
+			Birthday:       time.Date(2015, 3, 24, 11, 37, 0, 0, time.UTC),
+			CorporationID:  corporation.ID,
+			Description:    "bla bla",
+			FactionID:      faction.ID,
+			Gender:         "male",
+			Name:           "CCP Bartender",
+			RaceID:         race.ID,
+			SecurityStatus: -9.9,
+			Title:          "All round pretty awesome guy",
+		})
+		factory.CreateEveEntityCharacter(app.EveEntity{ID: o1.ID})
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi\.evetech\.net/v\d+/characters/\d+/`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"birthday":        "2015-03-24T11:37:00Z",
+				"bloodline_id":    3,
+				"corporation_id":  109299958,
+				"description":     "bla bla",
+				"gender":          "male",
+				"name":            "CCP Bartender",
+				"race_id":         2,
+				"security_status": -9.9,
+				"title":           "All round pretty awesome guy",
+			}))
+		httpmock.RegisterResponder(
+			"POST",
+			`=~^https://esi\.evetech\.net/v\d+/characters/affiliation/`,
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{
+					"alliance_id":    alliance.ID,
+					"character_id":   o1.ID,
+					"corporation_id": corporation.ID,
+					"faction_id":     faction.ID,
+				}}),
+		)
+		// when
+		changed, err := s.updateCharacterESI(ctx, o1.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.False(t, changed)
 		}
 	})
 	t.Run("should remove affiliations", func(t *testing.T) {
@@ -100,9 +156,10 @@ func TestUpdateEveCharacterESI(t *testing.T) {
 				}}),
 		)
 		// when
-		err := s.updateCharacterESI(ctx, o1.ID)
+		changed, err := s.updateCharacterESI(ctx, o1.ID)
 		// then
 		if assert.NoError(t, err) {
+			assert.True(t, changed)
 			o2, err := st.GetEveCharacter(ctx, o1.ID)
 			if assert.NoError(t, err) {
 				assert.Nil(t, o2.Alliance)
@@ -135,9 +192,10 @@ func TestUpdateEveCharacterESI(t *testing.T) {
 				}}),
 		)
 		// when
-		err := s.updateCharacterESI(ctx, o1.ID)
+		changed, err := s.updateCharacterESI(ctx, o1.ID)
 		// then
 		if assert.NoError(t, err) {
+			assert.True(t, changed)
 			_, err := st.GetEveCharacter(ctx, o1.ID)
 			assert.ErrorIs(t, err, app.ErrNotFound)
 		}

--- a/internal/app/eveuniverseservice/character_test.go
+++ b/internal/app/eveuniverseservice/character_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/set"
 )
 
 func TestGetOrCreateEveCharacterESI(t *testing.T) {
@@ -172,9 +173,11 @@ func TestUpdateAllEveCharactersESI(t *testing.T) {
 				}}),
 		)
 		// when
-		err := s.UpdateAllCharactersESI(ctx)
+		got, err := s.UpdateAllCharactersESI(ctx)
 		// then
 		if assert.NoError(t, err) {
+			want := set.Of[int32](characterID)
+			assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
 			ec, err := st.GetEveCharacter(ctx, characterID)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "CCP Bartender", ec.Name)

--- a/internal/app/eveuniverseservice/organization.go
+++ b/internal/app/eveuniverseservice/organization.go
@@ -177,7 +177,7 @@ func (s *EveUniverseService) UpdateAllCorporationsESI(ctx context.Context) (set.
 				Category: app.EveEntityCorporation,
 				Name:     c2.Name,
 			})
-			hasChanged[i] = !c1.IsIdentical(*c2)
+			hasChanged[i] = !c1.Equal(*c2)
 			return err
 		})
 	}

--- a/internal/app/eveuniverseservice/organization.go
+++ b/internal/app/eveuniverseservice/organization.go
@@ -150,34 +150,47 @@ func (s *EveUniverseService) UpdateOrCreateCorporationFromESI(ctx context.Contex
 }
 
 // UpdateAllCorporationsESI updates all known corporations from ESI.
-func (s *EveUniverseService) UpdateAllCorporationsESI(ctx context.Context) error {
+func (s *EveUniverseService) UpdateAllCorporationsESI(ctx context.Context) (set.Set[int32], error) {
+	var changed set.Set[int32]
 	ids, err := s.st.ListEveCorporationIDs(ctx)
 	if err != nil {
-		return err
+		return changed, err
 	}
 	if ids.Size() == 0 {
-		return nil
+		return changed, nil
 	}
+	ids2 := ids.Slice()
+	hasChanged := make([]bool, len(ids2))
 	g := new(errgroup.Group)
-	for id := range ids.All() {
+	for i, id := range ids2 {
 		g.Go(func() error {
-			c, err := s.UpdateOrCreateCorporationFromESI(ctx, id)
+			c1, err := s.GetEveCorporation(ctx, id)
+			if err != nil {
+				return err
+			}
+			c2, err := s.UpdateOrCreateCorporationFromESI(ctx, id)
 			if err != nil {
 				return err
 			}
 			_, err = s.st.UpdateOrCreateEveEntity(ctx, storage.CreateEveEntityParams{
 				ID:       id,
 				Category: app.EveEntityCorporation,
-				Name:     c.Name,
+				Name:     c2.Name,
 			})
+			hasChanged[i] = !c1.IsIdentical(*c2)
 			return err
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return err
+		return changed, err
 	}
-	slog.Info("Finished updating eve corporations", "count", ids.Size())
-	return nil
+	for i, id := range ids2 {
+		if hasChanged[i] {
+			changed.Add(id)
+		}
+	}
+	slog.Info("Finished updating eve corporations", "count", ids.Size(), "changed", changed)
+	return changed, nil
 }
 
 // RandomizeAllCorporationNames randomizes the names of all characters.

--- a/internal/app/eveuniverseservice/section.go
+++ b/internal/app/eveuniverseservice/section.go
@@ -45,10 +45,7 @@ func (s *EveUniverseService) UpdateSection(ctx context.Context, section app.Gene
 	case app.SectionEveCharacters:
 		f = s.UpdateAllCharactersESI
 	case app.SectionEveCorporations:
-		f = func(ctx context.Context) (set.Set[int32], error) {
-			err := s.UpdateAllCorporationsESI(ctx)
-			return set.Of[int32](0), err // FIXME: Fake change
-		}
+		f = s.UpdateAllCorporationsESI
 	case app.SectionEveMarketPrices:
 		f = func(ctx context.Context) (set.Set[int32], error) {
 			err := s.updateMarketPricesESI(ctx)

--- a/internal/app/eveuniverseservice/section.go
+++ b/internal/app/eveuniverseservice/section.go
@@ -44,15 +44,9 @@ func (s *EveUniverseService) UpdateSection(ctx context.Context, section app.Gene
 	case app.SectionEveCorporations:
 		f = s.UpdateAllCorporationsESI
 	case app.SectionEveMarketPrices:
-		f = func(ctx context.Context) (set.Set[int32], error) {
-			err := s.updateMarketPricesESI(ctx)
-			return set.Of[int32](0), err // FIXME: Fake change
-		}
+		f = s.updateMarketPricesESI
 	case app.SectionEveEntities:
-		f = func(ctx context.Context) (set.Set[int32], error) {
-			err := s.UpdateAllEntitiesESI(ctx)
-			return set.Of[int32](0), err // FIXME: Fake change
-		}
+		f = s.UpdateAllEntitiesESI
 	default:
 		slog.Warn("encountered unknown section", "section", section)
 	}

--- a/internal/app/eveuniverseservice/section.go
+++ b/internal/app/eveuniverseservice/section.go
@@ -38,10 +38,7 @@ func (s *EveUniverseService) UpdateSection(ctx context.Context, section app.Gene
 	var f func(context.Context) (set.Set[int32], error)
 	switch section {
 	case app.SectionEveTypes:
-		f = func(ctx context.Context) (set.Set[int32], error) {
-			err := s.updateCategories(ctx)
-			return set.Of[int32](0), err // FIXME: Fake change
-		}
+		f = s.updateTypes
 	case app.SectionEveCharacters:
 		f = s.UpdateAllCharactersESI
 	case app.SectionEveCorporations:

--- a/internal/app/eveuniverseservice/type.go
+++ b/internal/app/eveuniverseservice/type.go
@@ -457,7 +457,7 @@ func (s *EveUniverseService) updateMarketPricesESI(ctx context.Context) (set.Set
 			if err != nil {
 				return changed, err
 			}
-			if o1 != nil && !o2.Equal(*o1) {
+			if o1 == nil || !o2.Equal(*o1) {
 				changed.Add(o2.TypeID)
 			}
 		}

--- a/internal/app/eveuniverseservice/type.go
+++ b/internal/app/eveuniverseservice/type.go
@@ -189,6 +189,10 @@ func (s *EveUniverseService) GetOrCreateTypeESI(ctx context.Context, id int32) (
 	return x.(*app.EveType), nil
 }
 
+func (s *EveUniverseService) ListEveTypeIDs(ctx context.Context) (set.Set[int32], error) {
+	return s.st.ListEveTypeIDs(ctx)
+}
+
 // AddMissingTypes fetches missing typeIDs from ESI.
 // Invalid IDs (e.g. 0) will be ignored
 func (s *EveUniverseService) AddMissingTypes(ctx context.Context, ids set.Set[int32]) error {

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -69,6 +69,8 @@ const (
 	settingWindowHeightDefault                = 600
 	settingWindowsSize                        = "window-size"
 	settingWindowWidthDefault                 = 1000
+	settingHideLimitedCorporations            = "settingHideLimitedCorporations"
+	settingHideLimitedCorporationsDefault     = false
 )
 
 // Settings represents the settings for the app and provides an API for reading and writing settings.
@@ -424,6 +426,17 @@ func (s Settings) ResetPreferMarketTab() {
 
 func (s Settings) SetPreferMarketTab(v bool) {
 	s.p.SetBool(settingPreferMarketTab, v)
+}
+
+func (s Settings) HideLimitedCorporations() bool {
+	return s.p.Bool(settingHideLimitedCorporations)
+}
+func (s Settings) HideLimitedCorporationsDefault() bool {
+	return settingHideLimitedCorporationsDefault
+}
+
+func (s Settings) SetHideLimitedCorporations(v bool) {
+	s.p.SetBool(settingHideLimitedCorporations, v)
 }
 
 func (s Settings) ColorTheme() ColorTheme {

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -181,13 +181,16 @@ func (st *Storage) ListCharactersShort(ctx context.Context) ([]*app.EntityShort[
 	return cc, nil
 }
 
-func (st *Storage) ListCharacterCorporationIDs(ctx context.Context) (set.Set[int32], error) {
-	ids, err := st.qRO.ListCharacterCorporationIDs(ctx)
+func (st *Storage) ListCharacterCorporations(ctx context.Context) ([]*app.EntityShort[int32], error) {
+	rows, err := st.qRO.ListCharacterCorporations(ctx)
 	if err != nil {
-		return set.Set[int32]{}, fmt.Errorf("ListCharacterCorporationIDs: %w", err)
+		return nil, fmt.Errorf("ListCharacterCorporations: %w", err)
 	}
-	ids2 := set.Of(convertNumericSlice[int32](ids)...)
-	return ids2, nil
+	cc := make([]*app.EntityShort[int32], len(rows))
+	for i, row := range rows {
+		cc[i] = &app.EntityShort[int32]{ID: int32(row.ID), Name: row.Name}
+	}
+	return cc, nil
 }
 
 func (st *Storage) ListCharacterIDs(ctx context.Context) (set.Set[int32], error) {

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/ErikKalkoken/evebuddy/internal/set"
 )
 
 func TestCharacter(t *testing.T) {
@@ -230,6 +231,32 @@ func TestListCharacters(t *testing.T) {
 				assert.Equal(t, c1.EveCharacter.Alliance, c2.EveCharacter.Alliance)
 				assert.Equal(t, c1.EveCharacter.Faction, c2.EveCharacter.Faction)
 			}
+		}
+	})
+	t.Run("can list character IDs", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		c1 := factory.CreateCharacter()
+		c2 := factory.CreateCharacter()
+		// when
+		got, err := r.ListCharacterIDs(ctx)
+		// then
+		if assert.NoError(t, err) {
+			want := set.Of(c1.ID, c2.ID)
+			assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
+		}
+	})
+	t.Run("can list character's corporation IDs", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		c1 := factory.CreateCharacter()
+		c2 := factory.CreateCharacter()
+		// when
+		got, err := r.ListCharacterCorporationIDs(ctx)
+		// then
+		if assert.NoError(t, err) {
+			want := set.Of(c1.EveCharacter.Corporation.ID, c2.EveCharacter.Corporation.ID)
+			assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
 		}
 	})
 }

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 func TestCharacter(t *testing.T) {
@@ -252,9 +253,12 @@ func TestListCharacters(t *testing.T) {
 		c1 := factory.CreateCharacter()
 		c2 := factory.CreateCharacter()
 		// when
-		got, err := r.ListCharacterCorporationIDs(ctx)
+		cc, err := r.ListCharacterCorporations(ctx)
 		// then
 		if assert.NoError(t, err) {
+			got := set.Collect(xiter.MapSlice(cc, func(x *app.EntityShort[int32]) int32 {
+				return x.ID
+			}))
 			want := set.Of(c1.EveCharacter.Corporation.ID, c2.EveCharacter.Corporation.ID)
 			assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
 		}

--- a/internal/app/storage/characterrole.go
+++ b/internal/app/storage/characterrole.go
@@ -88,9 +88,7 @@ func (st *Storage) ListCharacterRoles(ctx context.Context, characterID int32) (s
 }
 
 func (st *Storage) UpdateCharacterRoles(ctx context.Context, characterID int32, roles set.Set[app.Role]) error {
-	incoming := set.Collect(xiter.Map(roles.All(), func(r app.Role) string {
-		return role2String[r]
-	}))
+	incoming := roles2names(roles)
 	s, err := st.qRO.ListCharacterRoles(ctx, int64(characterID))
 	if err != nil {
 		return err
@@ -117,4 +115,10 @@ func (st *Storage) UpdateCharacterRoles(ctx context.Context, characterID int32, 
 		}
 	}
 	return nil
+}
+
+func roles2names(roles set.Set[app.Role]) set.Set[string] {
+	return set.Collect(xiter.Map(roles.All(), func(r app.Role) string {
+		return role2String[r]
+	}))
 }

--- a/internal/app/storage/charactertoken.go
+++ b/internal/app/storage/charactertoken.go
@@ -128,10 +128,6 @@ func (st *Storage) ListCharacterTokenForCorporation(ctx context.Context, corpora
 	if corporationID == 0 {
 		return nil, wrapErr(app.ErrInvalid)
 	}
-	roleNames := make([]string, 0)
-	for r := range roles.All() {
-		roleNames = append(roleNames, role2String[r])
-	}
 	var rows []queries.CharacterToken
 	var err error
 	if roles.Size() == 0 {
@@ -142,7 +138,7 @@ func (st *Storage) ListCharacterTokenForCorporation(ctx context.Context, corpora
 	} else {
 		arg := queries.ListCharacterTokenForCorporationWithRolesParams{
 			CorporationID: int64(corporationID),
-			Roles:         roleNames,
+			Roles:         roles2names(roles).Slice(),
 		}
 		rows, err = st.qRO.ListCharacterTokenForCorporationWithRoles(ctx, arg)
 		if err != nil {

--- a/internal/app/storage/corporation.go
+++ b/internal/app/storage/corporation.go
@@ -185,8 +185,8 @@ func (st *Storage) ListCorporationsShort(ctx context.Context) ([]*app.EntityShor
 	return cc, nil
 }
 
-// ListPrivilegedCorporationsShort returns a list of corporations where characters exist
-// which have at least one role in requiredRoles.
+// ListPrivilegedCorporationsShort returns a list of corporations
+// where a user has at least one character exist with a role from requiredRoles.
 func (st *Storage) ListPrivilegedCorporationsShort(ctx context.Context, requiredRoles set.Set[app.Role]) ([]*app.EntityShort[int32], error) {
 	rows, err := st.qRO.ListPrivilegedCorporationsShort(ctx, roles2names(requiredRoles).Slice())
 	if err != nil {

--- a/internal/app/storage/corporation.go
+++ b/internal/app/storage/corporation.go
@@ -184,3 +184,18 @@ func (st *Storage) ListCorporationsShort(ctx context.Context) ([]*app.EntityShor
 	}
 	return cc, nil
 }
+
+// ListPrivilegedCorporationsShort returns a list of corporations where characters exist
+// which have at least one role in requiredRoles.
+func (st *Storage) ListPrivilegedCorporationsShort(ctx context.Context, requiredRoles set.Set[app.Role]) ([]*app.EntityShort[int32], error) {
+	rows, err := st.qRO.ListPrivilegedCorporationsShort(ctx, roles2names(requiredRoles).Slice())
+	if err != nil {
+		return nil, fmt.Errorf("ListPrivilegedCorporationsShort: %w", err)
+
+	}
+	cc := make([]*app.EntityShort[int32], 0)
+	for _, r := range rows {
+		cc = append(cc, &app.EntityShort[int32]{ID: int32(r.ID), Name: r.Name})
+	}
+	return cc, nil
+}

--- a/internal/app/storage/evemarketprice_test.go
+++ b/internal/app/storage/evemarketprice_test.go
@@ -23,15 +23,12 @@ func TestEveMarketPrice(t *testing.T) {
 			AveragePrice:  4.56,
 		}
 		// when
-		err := r.UpdateOrCreateEveMarketPrice(ctx, arg)
+		x, err := r.UpdateOrCreateEveMarketPrice(ctx, arg)
 		// then
 		if assert.NoError(t, err) {
-			o, err := r.GetEveMarketPrice(ctx, 42)
-			if assert.NoError(t, err) {
-				assert.Equal(t, int32(42), o.TypeID)
-				assert.Equal(t, 1.23, o.AdjustedPrice)
-				assert.Equal(t, 4.56, o.AveragePrice)
-			}
+			assert.Equal(t, int32(42), x.TypeID)
+			assert.Equal(t, 1.23, x.AdjustedPrice)
+			assert.Equal(t, 4.56, x.AveragePrice)
 		}
 	})
 	t.Run("can update existing", func(t *testing.T) {
@@ -48,15 +45,12 @@ func TestEveMarketPrice(t *testing.T) {
 			AveragePrice:  4.56,
 		}
 		// when
-		err := r.UpdateOrCreateEveMarketPrice(ctx, arg)
+		x, err := r.UpdateOrCreateEveMarketPrice(ctx, arg)
 		// then
 		if assert.NoError(t, err) {
-			o, err := r.GetEveMarketPrice(ctx, 42)
-			if assert.NoError(t, err) {
-				assert.Equal(t, int32(42), o.TypeID)
-				assert.Equal(t, 1.23, o.AdjustedPrice)
-				assert.Equal(t, 4.56, o.AveragePrice)
-			}
+			assert.Equal(t, int32(42), x.TypeID)
+			assert.Equal(t, 1.23, x.AdjustedPrice)
+			assert.Equal(t, 4.56, x.AveragePrice)
 		}
 	})
 }

--- a/internal/app/storage/evetype.go
+++ b/internal/app/storage/evetype.go
@@ -124,6 +124,15 @@ func (st *Storage) GetOrCreateEveType(ctx context.Context, arg CreateEveTypePara
 	return o, nil
 }
 
+func (st *Storage) ListEveTypeIDs(ctx context.Context) (set.Set[int32], error) {
+	ids, err := st.qRO.ListEveTypeIDs(ctx)
+	if err != nil {
+		return set.Set[int32]{}, fmt.Errorf("ListEveTypeIDs: %w", err)
+	}
+	ids2 := set.Of(convertNumericSlice[int32](ids)...)
+	return ids2, nil
+}
+
 func (st *Storage) MissingEveTypes(ctx context.Context, ids set.Set[int32]) (set.Set[int32], error) {
 	currentIDs, err := st.qRO.ListEveTypeIDs(ctx)
 	if err != nil {

--- a/internal/app/storage/evetype_test.go
+++ b/internal/app/storage/evetype_test.go
@@ -111,6 +111,19 @@ func TestEveType(t *testing.T) {
 			}
 		}
 	})
+	t.Run("can list IDs", func(t *testing.T) {
+		// given
+		testutil.TruncateTables(db)
+		x1 := factory.CreateEveType()
+		x2 := factory.CreateEveType()
+		// when
+		got, err := st.ListEveTypeIDs(ctx)
+		// then
+		if assert.NoError(t, err) {
+			want := set.Of(x1.ID, x2.ID)
+			assert.True(t, got.Equal(want), "got %q, wanted %q", got, want)
+		}
+	})
 	t.Run("can identify missing", func(t *testing.T) {
 		// given
 		testutil.TruncateTables(db)

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -96,12 +96,14 @@ SELECT
 FROM
     characters;
 
--- name: ListCharacterCorporationIDs :many
+-- name: ListCharacterCorporations :many
 SELECT
-    corporation_id
+    ee.id,
+    ee.name
 FROM
-    characters c
-    JOIN eve_characters ec ON ec.id = c.id;
+    characters ch
+    JOIN eve_characters ec ON ec.id = ch.id
+    JOIN eve_entities ee ON ee.id = ec.corporation_id;
 
 -- name: UpdateCharacterLastCloneJump :exec
 UPDATE characters

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -17,14 +17,12 @@ VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: DeleteCharacter :exec
-DELETE FROM
-    characters
+DELETE FROM characters
 WHERE
     id = ?;
 
 -- name: DisableAllTrainingWatchers :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     is_training_watched = FALSE;
 
@@ -60,8 +58,8 @@ WHERE
     id = ?;
 
 -- name: ListCharacters :many
-SELECT
-    DISTINCT sqlc.embed(cc),
+SELECT DISTINCT
+    sqlc.embed(cc),
     sqlc.embed(ec),
     sqlc.embed(eec),
     sqlc.embed(er),
@@ -83,14 +81,14 @@ ORDER BY
     ec.name;
 
 -- name: ListCharactersShort :many
-SELECT
-    DISTINCT eve_characters.id,
-    eve_characters.name
+SELECT DISTINCT
+    ec.id,
+    ec.name
 FROM
-    characters
-    JOIN eve_characters ON eve_characters.id = characters.id
+    characters c
+    JOIN eve_characters ec ON ec.id = c.id
 ORDER BY
-    eve_characters.name;
+    ec.name;
 
 -- name: ListCharacterIDs :many
 SELECT
@@ -98,57 +96,57 @@ SELECT
 FROM
     characters;
 
+-- name: ListCharacterCorporationIDs :many
+SELECT
+    corporation_id
+FROM
+    characters c
+    JOIN eve_characters ec ON ec.id = c.id;
+
 -- name: UpdateCharacterLastCloneJump :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     last_clone_jump_at = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterHomeId :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     home_id = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterIsTrainingWatched :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     is_training_watched = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterLastLoginAt :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     last_login_at = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterLocationID :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     location_id = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterShipID :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     ship_id = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterSP :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     total_sp = ?,
     unallocated_sp = ?
@@ -156,16 +154,14 @@ WHERE
     id = ?;
 
 -- name: UpdateCharacterWalletBalance :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     wallet_balance = ?
 WHERE
     id = ?;
 
 -- name: UpdateCharacterAssetValue :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     asset_value = ?
 WHERE

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -61,8 +61,7 @@ func (q *Queries) CreateCharacter(ctx context.Context, arg CreateCharacterParams
 }
 
 const deleteCharacter = `-- name: DeleteCharacter :exec
-DELETE FROM
-    characters
+DELETE FROM characters
 WHERE
     id = ?
 `
@@ -73,8 +72,7 @@ func (q *Queries) DeleteCharacter(ctx context.Context, id int64) error {
 }
 
 const disableAllTrainingWatchers = `-- name: DisableAllTrainingWatchers :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     is_training_watched = FALSE
 `
@@ -181,6 +179,37 @@ func (q *Queries) GetCharacterAssetValue(ctx context.Context, id int64) (sql.Nul
 	return asset_value, err
 }
 
+const listCharacterCorporationIDs = `-- name: ListCharacterCorporationIDs :many
+SELECT
+    corporation_id
+FROM
+    characters c
+    JOIN eve_characters ec ON ec.id = c.id
+`
+
+func (q *Queries) ListCharacterCorporationIDs(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, listCharacterCorporationIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var corporation_id int64
+		if err := rows.Scan(&corporation_id); err != nil {
+			return nil, err
+		}
+		items = append(items, corporation_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCharacterIDs = `-- name: ListCharacterIDs :many
 SELECT
     id
@@ -212,8 +241,8 @@ func (q *Queries) ListCharacterIDs(ctx context.Context) ([]int64, error) {
 }
 
 const listCharacters = `-- name: ListCharacters :many
-SELECT
-    DISTINCT cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at,
+SELECT DISTINCT
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -309,14 +338,14 @@ func (q *Queries) ListCharacters(ctx context.Context) ([]ListCharactersRow, erro
 }
 
 const listCharactersShort = `-- name: ListCharactersShort :many
-SELECT
-    DISTINCT eve_characters.id,
-    eve_characters.name
+SELECT DISTINCT
+    ec.id,
+    ec.name
 FROM
-    characters
-    JOIN eve_characters ON eve_characters.id = characters.id
+    characters c
+    JOIN eve_characters ec ON ec.id = c.id
 ORDER BY
-    eve_characters.name
+    ec.name
 `
 
 type ListCharactersShortRow struct {
@@ -348,8 +377,7 @@ func (q *Queries) ListCharactersShort(ctx context.Context) ([]ListCharactersShor
 }
 
 const updateCharacterAssetValue = `-- name: UpdateCharacterAssetValue :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     asset_value = ?
 WHERE
@@ -367,8 +395,7 @@ func (q *Queries) UpdateCharacterAssetValue(ctx context.Context, arg UpdateChara
 }
 
 const updateCharacterHomeId = `-- name: UpdateCharacterHomeId :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     home_id = ?
 WHERE
@@ -386,8 +413,7 @@ func (q *Queries) UpdateCharacterHomeId(ctx context.Context, arg UpdateCharacter
 }
 
 const updateCharacterIsTrainingWatched = `-- name: UpdateCharacterIsTrainingWatched :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     is_training_watched = ?
 WHERE
@@ -405,8 +431,7 @@ func (q *Queries) UpdateCharacterIsTrainingWatched(ctx context.Context, arg Upda
 }
 
 const updateCharacterLastCloneJump = `-- name: UpdateCharacterLastCloneJump :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     last_clone_jump_at = ?
 WHERE
@@ -424,8 +449,7 @@ func (q *Queries) UpdateCharacterLastCloneJump(ctx context.Context, arg UpdateCh
 }
 
 const updateCharacterLastLoginAt = `-- name: UpdateCharacterLastLoginAt :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     last_login_at = ?
 WHERE
@@ -443,8 +467,7 @@ func (q *Queries) UpdateCharacterLastLoginAt(ctx context.Context, arg UpdateChar
 }
 
 const updateCharacterLocationID = `-- name: UpdateCharacterLocationID :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     location_id = ?
 WHERE
@@ -462,8 +485,7 @@ func (q *Queries) UpdateCharacterLocationID(ctx context.Context, arg UpdateChara
 }
 
 const updateCharacterSP = `-- name: UpdateCharacterSP :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     total_sp = ?,
     unallocated_sp = ?
@@ -483,8 +505,7 @@ func (q *Queries) UpdateCharacterSP(ctx context.Context, arg UpdateCharacterSPPa
 }
 
 const updateCharacterShipID = `-- name: UpdateCharacterShipID :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     ship_id = ?
 WHERE
@@ -502,8 +523,7 @@ func (q *Queries) UpdateCharacterShipID(ctx context.Context, arg UpdateCharacter
 }
 
 const updateCharacterWalletBalance = `-- name: UpdateCharacterWalletBalance :exec
-UPDATE
-    characters
+UPDATE characters
 SET
     wallet_balance = ?
 WHERE

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -179,27 +179,34 @@ func (q *Queries) GetCharacterAssetValue(ctx context.Context, id int64) (sql.Nul
 	return asset_value, err
 }
 
-const listCharacterCorporationIDs = `-- name: ListCharacterCorporationIDs :many
+const listCharacterCorporations = `-- name: ListCharacterCorporations :many
 SELECT
-    corporation_id
+    ee.id,
+    ee.name
 FROM
-    characters c
-    JOIN eve_characters ec ON ec.id = c.id
+    characters ch
+    JOIN eve_characters ec ON ec.id = ch.id
+    JOIN eve_entities ee ON ee.id = ec.corporation_id
 `
 
-func (q *Queries) ListCharacterCorporationIDs(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, listCharacterCorporationIDs)
+type ListCharacterCorporationsRow struct {
+	ID   int64
+	Name string
+}
+
+func (q *Queries) ListCharacterCorporations(ctx context.Context) ([]ListCharacterCorporationsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listCharacterCorporations)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []int64
+	var items []ListCharacterCorporationsRow
 	for rows.Next() {
-		var corporation_id int64
-		if err := rows.Scan(&corporation_id); err != nil {
+		var i ListCharacterCorporationsRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
 			return nil, err
 		}
-		items = append(items, corporation_id)
+		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/app/storage/queries/corporations.sql
+++ b/internal/app/storage/queries/corporations.sql
@@ -55,10 +55,31 @@ FROM
 
 -- name: ListCorporationsShort :many
 SELECT
-    co.id,
+    cp.id,
     ec.name
 FROM
-    corporations co
-    JOIN eve_corporations ec ON ec.id = co.id
+    corporations cp
+    JOIN eve_corporations ec ON ec.id = cp.id
+ORDER BY
+    ec.name;
+
+-- name: ListPrivilegedCorporationsShort :many
+SELECT
+    cp.id,
+    ec.name
+FROM
+    corporations cp
+    JOIN eve_corporations ec ON ec.id = cp.id
+WHERE
+    cp.id IN (
+        SELECT DISTINCT
+            cp.id
+        FROM
+            corporations cp
+            JOIN eve_characters ec ON ec.corporation_id == cp.id
+            JOIN character_roles cr ON cr.character_id = ec.id
+        WHERE
+            cr.name IN (sqlc.slice('required_roles'))
+    )
 ORDER BY
     ec.name;

--- a/internal/app/storage/queries/eve_market_prices.sql
+++ b/internal/app/storage/queries/eve_market_prices.sql
@@ -12,7 +12,7 @@ SELECT
 FROM
     eve_market_prices;
 
--- name: UpdateOrCreateEveMarketPrice :exec
+-- name: UpdateOrCreateEveMarketPrice :one
 INSERT INTO
     eve_market_prices (type_id, adjusted_price, average_price)
 VALUES
@@ -20,4 +20,4 @@ VALUES
 ON CONFLICT (type_id) DO UPDATE
 SET
     adjusted_price = ?2,
-    average_price = ?3;
+    average_price = ?3 RETURNING *;

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -2143,11 +2143,7 @@ func (f Factory) CreateEveMarketPrice(args ...storage.UpdateOrCreateEveMarketPri
 	if arg.AveragePrice == 0 {
 		arg.AveragePrice = rand.Float64() * 100_000
 	}
-	err := f.st.UpdateOrCreateEveMarketPrice(ctx, arg)
-	if err != nil {
-		panic(err)
-	}
-	o, err := f.st.GetEveMarketPrice(ctx, arg.TypeID)
+	o, err := f.st.UpdateOrCreateEveMarketPrice(ctx, arg)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/app/storage/testutil/factory.go
+++ b/internal/app/storage/testutil/factory.go
@@ -1066,6 +1066,14 @@ func (f Factory) CreateCorporation(corporationID ...int32) *app.Corporation {
 		id = ec.ID
 	} else {
 		id = corporationID[0]
+		_, err := f.st.GetEveCorporation(context.Background(), id)
+		if errors.Is(err, app.ErrNotFound) {
+			f.CreateEveCorporation(storage.UpdateOrCreateEveCorporationParams{
+				ID: corporationID[0],
+			})
+		} else if err != nil {
+			panic(err)
+		}
 	}
 	err := f.st.CreateCorporation(context.Background(), id)
 	if err != nil {

--- a/internal/app/storage/testutil/testutil.go
+++ b/internal/app/storage/testutil/testutil.go
@@ -152,3 +152,26 @@ func DumpTables(db *sql.DB, tables ...string) string {
 	}
 	return (string(b))
 }
+
+// ErrGroupDebug represents a replacement for errgroup.Group with the same API,
+// but it runs the callbacks without Goroutines, which makes debugging much easier.
+type ErrGroupDebug struct {
+	ff []func() error
+}
+
+func (g *ErrGroupDebug) Go(f func() error) {
+	if g.ff == nil {
+		g.ff = make([]func() error, 0)
+	}
+	g.ff = append(g.ff, f)
+}
+
+func (g *ErrGroupDebug) Wait() error {
+	for _, f := range g.ff {
+		err := f()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/app/storage/testutil/testutil.go
+++ b/internal/app/storage/testutil/testutil.go
@@ -88,9 +88,9 @@ func TruncateTables(dbRW *sql.DB) {
 
 // DumpTables returns the current content of the given SQL tables as JSON string.
 // When no tables are given all non-empty tables will be dumped.
-func DumpTables(dbRW *sql.DB, tables ...string) string {
+func DumpTables(db *sql.DB, tables ...string) string {
 	sql := `SELECT name FROM sqlite_master WHERE type = "table"`
-	rows, err := dbRW.Query(sql)
+	rows, err := db.Query(sql)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +116,7 @@ func DumpTables(dbRW *sql.DB, tables ...string) string {
 	world := make(map[string]any)
 	for _, table := range tables {
 		sql := fmt.Sprintf("SELECT * FROM %s;", table)
-		rows, err := dbRW.Query(sql)
+		rows, err := db.Query(sql)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -1234,11 +1234,18 @@ func (u *baseUI) updateCorporationsIfNeeded(ctx context.Context, forceUpdate boo
 		slog.Info("Skipping regular update of corporations during daily downtime")
 		return nil
 	}
-	ids, err := u.rs.ListCorporationIDs(ctx)
+	removed, err := u.rs.RemoveStaleCorporations(ctx)
 	if err != nil {
 		return err
 	}
-	for id := range ids.All() {
+	if removed {
+		u.updateStatus()
+	}
+	all, err := u.rs.ListCorporationIDs(ctx)
+	if err != nil {
+		return err
+	}
+	for id := range all.All() {
 		go u.updateCorporationAndRefreshIfNeeded(ctx, id, forceUpdate)
 	}
 	slog.Debug("started update status corporations")

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -907,12 +907,12 @@ func (u *baseUI) updateGeneralSectionsIfNeeded(ctx context.Context, forceUpdate 
 }
 
 func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, section app.GeneralSection, forceUpdate bool) {
-	hasChanged, err := u.eus.UpdateSection(ctx, section, forceUpdate)
+	changed, err := u.eus.UpdateSection(ctx, section, forceUpdate)
 	if err != nil {
 		slog.Error("Failed to update general section", "section", section, "err", err)
 		return
 	}
-	if !hasChanged && !forceUpdate {
+	if changed.Size() == 0 && !forceUpdate {
 		return
 	}
 	switch section {

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -815,7 +815,7 @@ func (u *baseUI) makeCorporationSwitchMenu(refresh func()) []*fyne.MenuItem {
 	if u.settings.HideLimitedCorporations() {
 		cc, err = u.rs.ListPrivilegedCorporations(context.Background())
 	} else {
-		cc, err = u.rs.ListCorporationsShort(context.Background())
+		cc, err = u.cs.ListCharacterCorporations(context.Background())
 	}
 	if err != nil {
 		slog.Error("Failed to fetch corporations", "error", err)

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -376,7 +376,7 @@ func (a *userSettings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButto
 					if _, err := a.u.eus.UpdateAllCorporationsESI(ctx); err != nil {
 						return err
 					}
-					if err := a.u.eus.UpdateAllEntitiesESI(ctx); err != nil {
+					if _, err := a.u.eus.UpdateAllEntitiesESI(ctx); err != nil {
 						return err
 					}
 					return nil

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -130,20 +130,31 @@ func (a *userSettings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButto
 		getter:       a.u.settings.SysTrayEnabled,
 		onChanged:    a.u.settings.SetSysTrayEnabled,
 	})
-
 	if a.u.isDesktop {
 		items = append(items, sysTray)
 	}
+
 	preferMarketTab := NewSettingItemSwitch(SettingItemSwitch{
 		label:     "Prefer market tab",
 		hint:      "Show market tab first for tradeable items",
 		getter:    a.u.settings.PreferMarketTab,
 		onChanged: a.u.settings.SetPreferMarketTab,
 	})
+	hideLimitedCorporations := NewSettingItemSwitch(SettingItemSwitch{
+		defaultValue: a.u.settings.HideLimitedCorporationsDefault(),
+		label:        "Hide limited corporations",
+		hint:         "Hide corporations with no privileged access, e.g. corporation wallet",
+		getter:       a.u.settings.HideLimitedCorporations,
+		onChanged: func(enabled bool) {
+			a.u.settings.SetHideLimitedCorporations(enabled)
+			a.u.updateStatus()
+		},
+	})
 
 	items = slices.Concat(items, []SettingItem{
 		NewSettingItemHeading("UI"),
 		preferMarketTab,
+		hideLimitedCorporations,
 	})
 
 	colorTheme := NewSettingItemOptions(SettingItemOptions{
@@ -282,6 +293,7 @@ func (a *userSettings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButto
 			disableDPIDetection.Reset()
 			fyneScale.Reset()
 			preferMarketTab.Reset()
+			hideLimitedCorporations.Reset()
 			maxMail.Reset()
 			maxWallet.Reset()
 		},

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -370,7 +370,7 @@ func (a *userSettings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButto
 			Action: func() {
 				pg := kxmodal.NewProgressInfinite("Restore names", "Please wait...", func() error {
 					ctx := context.Background()
-					if err := a.u.eus.UpdateAllCharactersESI(ctx); err != nil {
+					if _, err := a.u.eus.UpdateAllCharactersESI(ctx); err != nil {
 						return err
 					}
 					if err := a.u.eus.UpdateAllCorporationsESI(ctx); err != nil {

--- a/internal/app/ui/usersettings.go
+++ b/internal/app/ui/usersettings.go
@@ -373,7 +373,7 @@ func (a *userSettings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButto
 					if _, err := a.u.eus.UpdateAllCharactersESI(ctx); err != nil {
 						return err
 					}
-					if err := a.u.eus.UpdateAllCorporationsESI(ctx); err != nil {
+					if _, err := a.u.eus.UpdateAllCorporationsESI(ctx); err != nil {
 						return err
 					}
 					if err := a.u.eus.UpdateAllEntitiesESI(ctx); err != nil {

--- a/internal/memcache/memcache.go
+++ b/internal/memcache/memcache.go
@@ -1,4 +1,4 @@
-// Package cache implements a simple in-memory cache.
+// Package memcache implements a simple in-memory cache.
 package memcache
 
 import (
@@ -11,7 +11,7 @@ const (
 	cleanUpTimeOutDefault = time.Minute * 10
 )
 
-// An in-memory cache.
+// Cache represents an in-memory cache.
 type Cache struct {
 	items  sync.Map
 	closeC chan struct{}


### PR DESCRIPTION
## Stale corporations

When a character joins a new corporation the former remains visible in the selection menu and will also continue to be updated. As users no longer have any special access this is not very useful.

Corporations that no longer have any members are now automatically removed.

Fixes #217 

## Filter limited corporations

The data accessible for a corporations depends on the roles of user's member characters. For example in order to see the corporation wallets a user needs to have a character with an accountant role for that corporation.

Corporations with no special roles will just show public information and the member list.

Users who are not interested to see those limited corporations in the selection menu can disable them now. 

Fixes #216

## Improved UI eveuniverse updates 

Eveuniverse data is updated on a regular basis. This refers to public information about characters, public information about corporations, types and market prices. When a change is detected any potentially related UI screen is updated. This can lead to many unnecessary updates. For example any market price change will lead to a re-calculation of assets.

Now the app will only update the UI if it detects that an eveuniverse change is actually effecting the currently shown user data.