### PR TITLE
feat: augmentations overview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ appimage: release build-appimage
 loc:
 	gocloc ./internal --by-file --include-lang=Go --not-match="\.sql\.go" --not-match-d="eveicon" --not-match="_test\.go"
 
-deploy-android: check-device make-android install-android
+deploy-android: check-device build-android install-android
 
-make-android:
+build-android:
 	fyne package -os android --release --tags migrated_fynedo
 
 install-android:

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -205,6 +205,7 @@ func (s *CharacterService) ListCharacterIDs(ctx context.Context) (set.Set[int32]
 	return ids, nil
 }
 
+// ListCharactersShort returns all characters in short form and ordered by name.
 func (s *CharacterService) ListCharactersShort(ctx context.Context) ([]*app.EntityShort[int32], error) {
 	return s.st.ListCharactersShort(ctx)
 }

--- a/internal/app/characterservice/implants.go
+++ b/internal/app/characterservice/implants.go
@@ -14,6 +14,10 @@ func (s *CharacterService) ListImplants(ctx context.Context, characterID int32) 
 	return s.st.ListCharacterImplants(ctx, characterID)
 }
 
+func (s *CharacterService) ListAllImplants(ctx context.Context) ([]*app.CharacterImplant, error) {
+	return s.st.ListAllCharacterImplants(ctx)
+}
+
 func (s *CharacterService) updateImplantsESI(ctx context.Context, arg app.CharacterUpdateSectionParams) (bool, error) {
 	if arg.Section != app.SectionCharacterImplants {
 		return false, fmt.Errorf("wrong section for update %s: %w", arg.Section, app.ErrInvalid)

--- a/internal/app/characterservice/tag.go
+++ b/internal/app/characterservice/tag.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -57,6 +58,13 @@ func (s *CharacterService) ListCharactersForTag(ctx context.Context, tagID int64
 	return
 }
 
-func (s *CharacterService) ListTagsForCharacter(ctx context.Context, characterID int32) ([]*app.CharacterTag, error) {
-	return s.st.ListCharacterTagsForCharacter(ctx, characterID)
+func (s *CharacterService) ListTagsForCharacter(ctx context.Context, characterID int32) (set.Set[string], error) {
+	oo, err := s.st.ListCharacterTagsForCharacter(ctx, characterID)
+	if err != nil {
+		return set.Set[string]{}, err
+	}
+	tags := set.Collect(xiter.MapSlice(oo, func(x *app.CharacterTag) string {
+		return x.Name
+	}))
+	return tags, nil
 }

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -168,6 +168,7 @@ func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error)
 	return cc, nil
 }
 
+// ListCharactersShort returns all characters in short form and ordered by name.
 func (st *Storage) ListCharactersShort(ctx context.Context) ([]*app.EntityShort[int32], error) {
 	rows, err := st.qRO.ListCharactersShort(ctx)
 	if err != nil {

--- a/internal/app/storage/characterimplant.go
+++ b/internal/app/storage/characterimplant.go
@@ -37,24 +37,40 @@ func (st *Storage) GetCharacterImplant(ctx context.Context, characterID int32, t
 }
 
 func (st *Storage) ListCharacterImplants(ctx context.Context, characterID int32) ([]*app.CharacterImplant, error) {
-	arg := queries.ListCharacterImplantsParams{
+	rows, err := st.qRO.ListCharacterImplants(ctx, queries.ListCharacterImplantsParams{
 		DogmaAttributeID: app.EveDogmaAttributeImplantSlot,
 		CharacterID:      int64(characterID),
-	}
-	rows, err := st.qRO.ListCharacterImplants(ctx, arg)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list implants for character ID %d: %w", characterID, err)
 	}
-	ii2 := make([]*app.CharacterImplant, len(rows))
-	for i, row := range rows {
-		ii2[i] = characterImplantFromDBModel(
-			row.CharacterImplant,
-			row.EveType,
-			row.EveGroup,
-			row.EveCategory,
-			row.SlotNum)
+	oo := make([]*app.CharacterImplant, len(rows))
+	for i, r := range rows {
+		oo[i] = characterImplantFromDBModel(
+			r.CharacterImplant,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			r.SlotNum)
 	}
-	return ii2, nil
+	return oo, nil
+}
+
+func (st *Storage) ListAllCharacterImplants(ctx context.Context) ([]*app.CharacterImplant, error) {
+	rows, err := st.qRO.ListAllCharacterImplants(ctx, app.EveDogmaAttributeImplantSlot)
+	if err != nil {
+		return nil, fmt.Errorf("list implants for all characters: %w", err)
+	}
+	oo := make([]*app.CharacterImplant, len(rows))
+	for i, r := range rows {
+		oo[i] = characterImplantFromDBModel(
+			r.CharacterImplant,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			r.SlotNum)
+	}
+	return oo, nil
 }
 
 func (st *Storage) ReplaceCharacterImplants(ctx context.Context, characterID int32, args []CreateCharacterImplantParams) error {

--- a/internal/app/storage/queries/character_implants.sql
+++ b/internal/app/storage/queries/character_implants.sql
@@ -40,3 +40,16 @@ JOIN eve_categories ON eve_categories.id = eve_groups.eve_category_id
 LEFT JOIN eve_type_dogma_attributes ON eve_type_dogma_attributes.eve_type_id = character_implants.eve_type_id AND eve_type_dogma_attributes.dogma_attribute_id = ?
 WHERE character_id = ?
 ORDER BY slot_num;
+
+-- name: ListAllCharacterImplants :many
+SELECT
+    sqlc.embed(character_implants),
+    sqlc.embed(eve_types),
+    sqlc.embed(eve_groups),
+    sqlc.embed(eve_categories),
+    eve_type_dogma_attributes.value as slot_num
+FROM character_implants
+JOIN eve_types ON eve_types.id = character_implants.eve_type_id
+JOIN eve_groups ON eve_groups.id = eve_types.eve_group_id
+JOIN eve_categories ON eve_categories.id = eve_groups.eve_category_id
+LEFT JOIN eve_type_dogma_attributes ON eve_type_dogma_attributes.eve_type_id = character_implants.eve_type_id AND eve_type_dogma_attributes.dogma_attribute_id = ?;

--- a/internal/app/ui/assets.go
+++ b/internal/app/ui/assets.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -469,9 +468,7 @@ func (*assets) fetchRows(s services) ([]assetRow, bool, error) {
 		if err != nil {
 			return nil, false, nil
 		}
-		tagsPerCharacter[c.ID] = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		tagsPerCharacter[c.ID] = tags
 	}
 	assets, err := s.cs.ListAllAssets(ctx)
 	if err != nil {

--- a/internal/app/ui/augmentations.go
+++ b/internal/app/ui/augmentations.go
@@ -130,7 +130,7 @@ func (a *augmentations) makeTree() *iwidget.Tree[characterImplantsNode] {
 }
 
 func (a *augmentations) filterTree() {
-	if a.treeData.Size() == 0 {
+	if a.treeData.IsEmpty() {
 		a.tree.Set(a.treeData)
 		return
 	}
@@ -142,7 +142,7 @@ func (a *augmentations) filterTree() {
 	if x := a.selectTag.Selected; x != "" {
 		for _, c := range characters {
 			if !c.tags.Contains(x) {
-				err := td.Remove(c.UID())
+				err := td.Delete(c.UID())
 				if err != nil {
 					panic("remove failed " + err.Error())
 				}

--- a/internal/app/ui/augmentations.go
+++ b/internal/app/ui/augmentations.go
@@ -137,8 +137,8 @@ func (a *augmentations) update() {
 	})
 }
 
-func (a *augmentations) updateTreeData() (iwidget.TreeNodes[characterImplantsNode], error) {
-	var tree iwidget.TreeNodes[characterImplantsNode]
+func (a *augmentations) updateTreeData() (iwidget.TreeData[characterImplantsNode], error) {
+	var tree iwidget.TreeData[characterImplantsNode]
 	ctx := context.Background()
 	characters, err := a.u.cs.ListCharactersShort(ctx)
 	if err != nil {

--- a/internal/app/ui/augmentations.go
+++ b/internal/app/ui/augmentations.go
@@ -1,0 +1,184 @@
+package ui
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
+	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
+)
+
+type characterImplantsNode struct {
+	implantCount           int
+	implantTypeID          int32
+	implantTypeName        string
+	implantTypeDescription string
+	characterID            int32
+	characterName          string
+}
+
+func (n characterImplantsNode) IsRoot() bool {
+	return n.implantTypeID == 0
+}
+
+func (n characterImplantsNode) UID() widget.TreeNodeID {
+	if n.characterID == 0 {
+		panic("some IDs are not set")
+	}
+	return fmt.Sprintf("%d-%d", n.characterID, n.implantTypeID)
+}
+
+type augmentations struct {
+	widget.BaseWidget
+
+	top  *widget.Label
+	tree *iwidget.Tree[characterImplantsNode]
+	u    *baseUI
+}
+
+func newAugmentations(u *baseUI) *augmentations {
+	top := widget.NewLabel("")
+	top.Wrapping = fyne.TextWrapWord
+	a := &augmentations{
+		top: top,
+		u:   u,
+	}
+	a.ExtendBaseWidget(a)
+	a.tree = a.makeTree()
+	return a
+}
+
+func (a *augmentations) CreateRenderer() fyne.WidgetRenderer {
+	c := container.NewBorder(a.top, nil, nil, nil, a.tree)
+	return widget.NewSimpleRenderer(c)
+}
+
+func (a *augmentations) makeTree() *iwidget.Tree[characterImplantsNode] {
+	t := iwidget.NewTree(
+		func(branch bool) fyne.CanvasObject {
+			iconMain := iwidget.NewImageFromResource(icons.BlankSvg, fyne.NewSquareSize(app.IconUnitSize))
+			main := widget.NewLabel("Template")
+			total := widget.NewLabel("9")
+			return container.NewBorder(
+				nil,
+				nil,
+				iconMain,
+				nil,
+				container.NewHBox(main, total),
+			)
+		},
+		func(n characterImplantsNode, b bool, co fyne.CanvasObject) {
+			border := co.(*fyne.Container).Objects
+			hbox := border[0].(*fyne.Container).Objects
+			main := hbox[0].(*widget.Label)
+			total := hbox[1].(*widget.Label)
+			iconMain := border[1].(*canvas.Image)
+			if n.IsRoot() {
+				go a.u.updateCharacterAvatar(n.characterID, func(r fyne.Resource) {
+					fyne.Do(func() {
+						iconMain.Resource = r
+						iconMain.Refresh()
+					})
+				})
+				main.SetText(n.characterName)
+				if n.implantCount > 0 {
+					total.SetText(fmt.Sprint(n.implantCount))
+					total.Show()
+				} else {
+					total.Hide()
+				}
+
+			} else {
+				iwidget.RefreshImageAsync(iconMain, func() (fyne.Resource, error) {
+					return a.u.eis.InventoryTypeIcon(n.implantTypeID, app.IconPixelSize)
+				})
+				main.SetText(n.implantTypeName)
+				total.Hide()
+			}
+		},
+	)
+	t.OnSelectedNode = func(n characterImplantsNode) {
+		defer t.UnselectAll()
+		if n.IsRoot() {
+			a.u.ShowInfoWindow(app.EveEntityCharacter, n.characterID)
+		} else {
+			a.u.ShowTypeInfoWindowWithCharacter(n.implantTypeID, n.characterID)
+		}
+	}
+	return t
+}
+
+func (a *augmentations) update() {
+	td, err := a.updateTreeData()
+	if err != nil {
+		slog.Error("Failed to refresh augmentations UI", "err", err)
+		fyne.Do(func() {
+			a.top.Text = "ERROR: " + a.u.humanizeError(err)
+			a.top.Importance = widget.DangerImportance
+			a.top.Refresh()
+			a.top.Show()
+		})
+		return
+	}
+	fyne.Do(func() {
+		a.tree.Set(td)
+		a.top.Hide()
+	})
+}
+
+func (a *augmentations) updateTreeData() (iwidget.TreeNodes[characterImplantsNode], error) {
+	var tree iwidget.TreeNodes[characterImplantsNode]
+	ctx := context.Background()
+	characters, err := a.u.cs.ListCharactersShort(ctx)
+	if err != nil {
+		return tree, err
+	}
+	m := make(map[int32][]*app.CharacterImplant)
+	for _, c := range characters {
+		m[c.ID] = make([]*app.CharacterImplant, 0)
+	}
+	oo, err := a.u.cs.ListAllImplants(ctx)
+	if err != nil {
+		return tree, err
+	}
+	for _, o := range oo {
+		_, ok := m[o.CharacterID]
+		if !ok {
+			slog.Warn("Unknown character for implant", "characterID", o.CharacterID)
+			continue
+		}
+		m[o.CharacterID] = append(m[o.CharacterID], o)
+	}
+	for k := range m {
+		slices.SortFunc(m[k], func(a, b *app.CharacterImplant) int {
+			return cmp.Compare(a.SlotNum, b.SlotNum)
+		})
+	}
+	for _, c := range characters {
+		n := characterImplantsNode{
+			characterID:   c.ID,
+			characterName: c.Name,
+			implantCount:  len(m[c.ID]),
+		}
+		uid := tree.MustAdd(iwidget.RootUID, n)
+		for _, o := range m[c.ID] {
+			n := characterImplantsNode{
+				implantTypeDescription: o.EveType.DescriptionPlain(),
+				implantTypeID:          o.EveType.ID,
+				implantTypeName:        o.EveType.Name,
+				characterID:            c.ID,
+			}
+			tree.MustAdd(uid, n)
+		}
+	}
+	return tree, err
+}

--- a/internal/app/ui/augmentations.go
+++ b/internal/app/ui/augmentations.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/widget"
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
@@ -66,7 +67,7 @@ func (a *augmentations) makeTree() *iwidget.Tree[characterImplantsNode] {
 	t := iwidget.NewTree(
 		func(branch bool) fyne.CanvasObject {
 			iconMain := iwidget.NewImageFromResource(icons.BlankSvg, fyne.NewSquareSize(app.IconUnitSize))
-			main := widget.NewLabel("Template")
+			main := ttwidget.NewLabel("Template")
 			total := widget.NewLabel("9")
 			return container.NewBorder(
 				nil,
@@ -79,7 +80,7 @@ func (a *augmentations) makeTree() *iwidget.Tree[characterImplantsNode] {
 		func(n characterImplantsNode, b bool, co fyne.CanvasObject) {
 			border := co.(*fyne.Container).Objects
 			hbox := border[0].(*fyne.Container).Objects
-			main := hbox[0].(*widget.Label)
+			main := hbox[0].(*ttwidget.Label)
 			total := hbox[1].(*widget.Label)
 			iconMain := border[1].(*canvas.Image)
 			if n.IsRoot() {
@@ -90,18 +91,19 @@ func (a *augmentations) makeTree() *iwidget.Tree[characterImplantsNode] {
 					})
 				})
 				main.SetText(n.characterName)
+				main.SetToolTip("")
 				if n.implantCount > 0 {
 					total.SetText(fmt.Sprint(n.implantCount))
 					total.Show()
 				} else {
 					total.Hide()
 				}
-
 			} else {
 				iwidget.RefreshImageAsync(iconMain, func() (fyne.Resource, error) {
 					return a.u.eis.InventoryTypeIcon(n.implantTypeID, app.IconPixelSize)
 				})
 				main.SetText(n.implantTypeName)
+				main.SetToolTip(n.implantTypeDescription)
 				total.Hide()
 			}
 		},

--- a/internal/app/ui/characterassets.go
+++ b/internal/app/ui/characterassets.go
@@ -258,9 +258,9 @@ func (a *characterAssets) update() {
 	}
 }
 
-func (*characterAssets) fetchData(characterID int32, s services) (assetcollection.AssetCollection, iwidget.TreeNodes[locationNode], error) {
+func (*characterAssets) fetchData(characterID int32, s services) (assetcollection.AssetCollection, iwidget.TreeData[locationNode], error) {
 	var ac assetcollection.AssetCollection
-	var locations iwidget.TreeNodes[locationNode]
+	var locations iwidget.TreeData[locationNode]
 	if characterID == 0 {
 		return ac, locations, nil
 	}
@@ -282,8 +282,8 @@ func (*characterAssets) fetchData(characterID int32, s services) (assetcollectio
 	return ac, locations, nil
 }
 
-func makeLocationTreeData(locationNodes []assetcollection.LocationNode, characterID int32) iwidget.TreeNodes[locationNode] {
-	var tree iwidget.TreeNodes[locationNode]
+func makeLocationTreeData(locationNodes []assetcollection.LocationNode, characterID int32) iwidget.TreeData[locationNode] {
+	var tree iwidget.TreeData[locationNode]
 	for _, ln := range locationNodes {
 		location := locationNode{
 			characterID: characterID,

--- a/internal/app/ui/characterassets.go
+++ b/internal/app/ui/characterassets.go
@@ -119,7 +119,7 @@ func (a *characterAssets) makeLocationsTree() *iwidget.Tree[locationNode] {
 			spacer := row[1].(*fyne.Container).Objects[0]
 			prefix := row[1].(*fyne.Container).Objects[1].(*widget.Label)
 			label.SetText(n.displayName())
-			if n.isRoot() {
+			if n.isTop() {
 				if !n.isUnknown {
 					prefix.Text = fmt.Sprintf("%.1f", n.systemSecurityValue)
 					prefix.Importance = n.systemSecurityType.ToImportance()
@@ -697,7 +697,8 @@ func (n locationNode) displayName() string {
 	// return fmt.Sprintf("%s - %s Items", n.name, humanize.Comma(int64(n.count)))
 }
 
-func (n locationNode) isRoot() bool {
+// isTop reports whether a node is at the very top of the tree.
+func (n locationNode) isTop() bool {
 	return n.variant == nodeLocation
 }
 

--- a/internal/app/ui/characterassets.go
+++ b/internal/app/ui/characterassets.go
@@ -299,7 +299,7 @@ func makeLocationTreeData(locationNodes []assetcollection.LocationNode, characte
 		} else {
 			location.isUnknown = true
 		}
-		locationUID := tree.MustAdd(iwidget.RootUID, location)
+		locationUID := tree.MustAdd(iwidget.TreeRootID, location)
 		topAssets := ln.Nodes()
 		slices.SortFunc(topAssets, func(a, b assetcollection.AssetNode) int {
 			return cmp.Compare(a.Asset.DisplayName(), b.Asset.DisplayName())

--- a/internal/app/ui/characterassets.go
+++ b/internal/app/ui/characterassets.go
@@ -194,8 +194,8 @@ func (a *characterAssets) makeAssetGrid() *widget.GridWrap {
 				return
 			}
 			location := a.selectedLocation.ValueOrZero()
-			for _, uid := range a.locations.Nodes().ChildUIDs(location.UID()) {
-				n, ok := a.locations.Nodes().Node(uid)
+			for _, uid := range a.locations.Data().ChildUIDs(location.UID()) {
+				n, ok := a.locations.Data().Node(uid)
 				if !ok {
 					continue
 				}
@@ -503,8 +503,8 @@ func (a *characterAssets) selectLocation(location locationNode) error {
 	a.assetGrid.Refresh()
 	a.selectedLocation.Set(location)
 	selectedUID := location.UID()
-	for _, uid := range a.locations.Nodes().Path(selectedUID) {
-		n, ok := a.locations.Nodes().Node(uid)
+	for _, uid := range a.locations.Data().Path(selectedUID) {
+		n, ok := a.locations.Data().Node(uid)
 		if !ok {
 			continue
 		}
@@ -626,8 +626,8 @@ func (a *characterAssets) selectLocation(location locationNode) error {
 
 func (a *characterAssets) updateLocationPath(location locationNode) {
 	path := make([]locationNode, 0)
-	for _, uid := range a.locations.Nodes().Path(location.UID()) {
-		n, ok := a.locations.Nodes().Node(uid)
+	for _, uid := range a.locations.Data().Path(location.UID()) {
+		n, ok := a.locations.Data().Node(uid)
 		if !ok {
 			continue
 		}

--- a/internal/app/ui/characterassets_internal_test.go
+++ b/internal/app/ui/characterassets_internal_test.go
@@ -29,7 +29,7 @@ func TestCharacterAssetsMakeLocationTreeData(t *testing.T) {
 		locations := []*app.EveLocation{el}
 		ac := assetcollection.New(assets, locations)
 		tree := makeLocationTreeData(ac.Locations(), 42)
-		assert.Greater(t, tree.Size(), 0)
+		assert.False(t, tree.IsEmpty())
 	})
 	t.Run("can have multiple locations with items in space", func(t *testing.T) {
 		l1 := &app.EveLocation{
@@ -51,7 +51,7 @@ func TestCharacterAssetsMakeLocationTreeData(t *testing.T) {
 		locations := []*app.EveLocation{l1, l2}
 		ac := assetcollection.New(assets, locations)
 		tree := makeLocationTreeData(ac.Locations(), 42)
-		assert.Greater(t, tree.Size(), 0)
+		assert.False(t, tree.IsEmpty())
 	})
 }
 

--- a/internal/app/ui/characteraugmentations.go
+++ b/internal/app/ui/characteraugmentations.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
@@ -51,7 +52,7 @@ func (a *characterAugmentations) makeImplantList() *widget.List {
 		func() fyne.CanvasObject {
 			iconMain := iwidget.NewImageFromResource(icons.BlankSvg, fyne.NewSquareSize(app.IconUnitSize*1.2))
 			iconInfo := widget.NewIcon(theme.InfoIcon())
-			name := widget.NewLabel("placeholder")
+			name := ttwidget.NewLabel("placeholder")
 			name.Truncation = fyne.TextTruncateEllipsis
 			slot := widget.NewLabel("placeholder")
 			slot.Truncation = fyne.TextTruncateEllipsis
@@ -74,8 +75,9 @@ func (a *characterAugmentations) makeImplantList() *widget.List {
 			o := a.implants[id]
 			row := co.(*fyne.Container).Objects
 			vbox := row[0].(*fyne.Container).Objects
-			name := vbox[0].(*fyne.Container).Objects[0].(*widget.Label)
+			name := vbox[0].(*fyne.Container).Objects[0].(*ttwidget.Label)
 			name.SetText(o.EveType.Name)
+			name.SetToolTip(o.EveType.Description)
 			slot := vbox[1].(*fyne.Container).Objects[0].(*widget.Label)
 			slot.SetText(fmt.Sprintf("Slot %d", o.SlotNum))
 			iconMain := row[1].(*canvas.Image)

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -151,7 +151,8 @@ func (a *characterJumpClones) update() {
 			}))
 		})
 	} else {
-		a.refreshTop(td.RootChildrenCount())
+		n, _ := td.ChildrenCount(iwidget.TreeRootID)
+		a.refreshTop(n)
 		fyne.Do(func() {
 			a.tree.Set(td)
 		})
@@ -269,11 +270,11 @@ func (a *characterJumpClones) startUpdateTicker() {
 	go func() {
 		for {
 			<-ticker.C
-			var c int
+			var n int
 			fyne.DoAndWait(func() {
-				c = a.tree.Nodes().RootChildrenCount()
+				n, _ = a.tree.Data().ChildrenCount(iwidget.TreeRootID)
 			})
-			a.refreshTop(c)
+			a.refreshTop(n)
 		}
 	}()
 }

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -139,7 +139,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 }
 
 func (a *characterJumpClones) update() {
-	td, err := a.newTreeData()
+	td, err := a.updateTreeData()
 	if err != nil {
 		slog.Error("Failed to refresh jump clones UI", "err", err)
 		fyne.Do(func() {
@@ -148,19 +148,14 @@ func (a *characterJumpClones) update() {
 			}))
 		})
 	} else {
-		a.refreshTop(cloneCount(td))
+		a.refreshTop(td.RootSize())
 		fyne.Do(func() {
 			a.tree.Set(td)
 		})
 	}
 }
 
-func cloneCount(td iwidget.TreeNodes[jumpCloneNode]) int {
-	return len(td.ChildUIDs(""))
-
-}
-
-func (a *characterJumpClones) newTreeData() (iwidget.TreeNodes[jumpCloneNode], error) {
+func (a *characterJumpClones) updateTreeData() (iwidget.TreeNodes[jumpCloneNode], error) {
 	var tree iwidget.TreeNodes[jumpCloneNode]
 	if !a.u.hasCharacter() {
 		return tree, nil
@@ -273,7 +268,7 @@ func (a *characterJumpClones) startUpdateTicker() {
 			<-ticker.C
 			var c int
 			fyne.DoAndWait(func() {
-				c = cloneCount(a.tree.Nodes())
+				c = a.tree.Nodes().RootSize()
 			})
 			a.refreshTop(c)
 		}

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -151,7 +151,7 @@ func (a *characterJumpClones) update() {
 			}))
 		})
 	} else {
-		a.refreshTop(td.RootSize())
+		a.refreshTop(td.RootChildrenCount())
 		fyne.Do(func() {
 			a.tree.Set(td)
 		})
@@ -185,7 +185,7 @@ func (a *characterJumpClones) updateTreeData() (iwidget.TreeData[jumpCloneNode],
 			n.locationName = fmt.Sprintf("Unknown location #%d", c.Location.ID)
 			n.isUnknown = true
 		}
-		uid := tree.MustAdd(iwidget.RootUID, n)
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
 		for _, i := range c.Implants {
 			n := jumpCloneNode{
 				implantTypeDescription: i.EveType.DescriptionPlain(),
@@ -271,7 +271,7 @@ func (a *characterJumpClones) startUpdateTicker() {
 			<-ticker.C
 			var c int
 			fyne.DoAndWait(func() {
-				c = a.tree.Nodes().RootSize()
+				c = a.tree.Nodes().RootChildrenCount()
 			})
 			a.refreshTop(c)
 		}

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -158,8 +158,8 @@ func (a *characterJumpClones) update() {
 	}
 }
 
-func (a *characterJumpClones) updateTreeData() (iwidget.TreeNodes[jumpCloneNode], error) {
-	var tree iwidget.TreeNodes[jumpCloneNode]
+func (a *characterJumpClones) updateTreeData() (iwidget.TreeData[jumpCloneNode], error) {
+	var tree iwidget.TreeData[jumpCloneNode]
 	if !a.u.hasCharacter() {
 		return tree, nil
 	}

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	"github.com/dustin/go-humanize"
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
@@ -75,7 +76,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 	t := iwidget.NewTree(
 		func(branch bool) fyne.CanvasObject {
 			iconMain := iwidget.NewImageFromResource(icons.BlankSvg, fyne.NewSquareSize(app.IconUnitSize))
-			main := widget.NewLabel("Template")
+			main := ttwidget.NewLabel("Template")
 			main.Truncation = fyne.TextTruncateEllipsis
 			iconInfo := widget.NewIcon(theme.InfoIcon())
 			spacer := canvas.NewRectangle(color.Transparent)
@@ -91,7 +92,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 		},
 		func(n jumpCloneNode, b bool, co fyne.CanvasObject) {
 			border := co.(*fyne.Container).Objects
-			main := border[0].(*widget.Label)
+			main := border[0].(*ttwidget.Label)
 			hbox := border[1].(*fyne.Container).Objects
 			iconMain := hbox[0].(*canvas.Image)
 			spacer := hbox[1].(*fyne.Container).Objects[0]
@@ -106,6 +107,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 					iconInfo.Hide()
 				}
 				main.SetText(n.locationName)
+				main.SetToolTip("")
 				if !n.isUnknown {
 					prefix.Text = fmt.Sprintf("%.1f", n.systemSecurityValue)
 					prefix.Importance = n.systemSecurityType.ToImportance()
@@ -120,6 +122,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 					return a.u.eis.InventoryTypeIcon(n.implantTypeID, app.IconPixelSize)
 				})
 				main.SetText(n.implantTypeName)
+				main.SetToolTip(n.implantTypeDescription)
 				prefix.Hide()
 				spacer.Hide()
 			}

--- a/internal/app/ui/characterjumpclones.go
+++ b/internal/app/ui/characterjumpclones.go
@@ -36,7 +36,7 @@ type jumpCloneNode struct {
 	systemSecurityType     app.SolarSystemSecurityType
 }
 
-func (n jumpCloneNode) IsRoot() bool {
+func (n jumpCloneNode) isTop() bool {
 	return n.implantTypeID == 0
 }
 
@@ -98,7 +98,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 			spacer := hbox[1].(*fyne.Container).Objects[0]
 			prefix := hbox[1].(*fyne.Container).Objects[1].(*widget.Label)
 			iconInfo := border[2]
-			if n.IsRoot() {
+			if n.isTop() {
 				iconMain.Resource = eveicon.FromName(eveicon.CloningCenter)
 				iconMain.Refresh()
 				if !n.isUnknown {
@@ -130,7 +130,7 @@ func (a *characterJumpClones) makeTree() *iwidget.Tree[jumpCloneNode] {
 	)
 	t.OnSelectedNode = func(n jumpCloneNode) {
 		defer t.UnselectAll()
-		if n.IsRoot() {
+		if n.isTop() {
 			if !n.isUnknown {
 				a.u.ShowLocationInfoWindow(n.locationID)
 			}

--- a/internal/app/ui/characterlocations.go
+++ b/internal/app/ui/characterlocations.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -288,9 +287,7 @@ func (*characterLocations) fetchData(s services) ([]characterLocationRow, error)
 		if err != nil {
 			return nil, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		rows = append(rows, r)
 	}
 	return rows, nil

--- a/internal/app/ui/charactermails.go
+++ b/internal/app/ui/charactermails.go
@@ -407,7 +407,7 @@ func calcUnreadTotals(labelCounts, listCounts map[int32]int) (int, int, int) {
 func (a *characterMails) makeFolderMenu() []*fyne.MenuItem {
 	// current := u.MailArea.CurrentFolder.ValueOrZero()
 	items1 := make([]*fyne.MenuItem, 0)
-	for f := range a.folders.Nodes().All() {
+	for f := range a.folders.Data().All() {
 		s := f.Name
 		if f.UnreadCount > 0 {
 			s += fmt.Sprintf(" (%d)", f.UnreadCount)

--- a/internal/app/ui/charactermails.go
+++ b/internal/app/ui/charactermails.go
@@ -217,7 +217,7 @@ func (a *characterMails) makeFolderTree() *iwidget.Tree[mailFolderNode] {
 func (a *characterMails) update() {
 	characterID := a.u.currentCharacterID()
 	hasData := a.u.scs.HasCharacterSection(characterID, app.SectionCharacterMails)
-	var tree iwidget.TreeNodes[mailFolderNode]
+	var tree iwidget.TreeData[mailFolderNode]
 	folderAll := mailFolderNode{}
 	var err error
 	if hasData {
@@ -263,8 +263,8 @@ func (a *characterMails) update() {
 	}
 }
 
-func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.TreeNodes[mailFolderNode], mailFolderNode, error) {
-	var tree iwidget.TreeNodes[mailFolderNode]
+func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.TreeData[mailFolderNode], mailFolderNode, error) {
+	var tree iwidget.TreeData[mailFolderNode]
 	if characterID == 0 {
 		return tree, emptyFolder, nil
 	}

--- a/internal/app/ui/charactermails.go
+++ b/internal/app/ui/charactermails.go
@@ -288,7 +288,7 @@ func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.Tree
 		ObjID:       app.MailLabelUnread,
 		UnreadCount: totalUnreadCount,
 	}
-	tree.MustAdd(iwidget.RootUID, folderUnread)
+	tree.MustAdd(iwidget.TreeRootID, folderUnread)
 
 	// Add default folders
 	defaultFolders := []struct {
@@ -314,7 +314,7 @@ func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.Tree
 			ObjID:       o.labelID,
 			UnreadCount: u,
 		}
-		tree.MustAdd(iwidget.RootUID, n)
+		tree.MustAdd(iwidget.TreeRootID, n)
 	}
 
 	// Add custom labels
@@ -329,7 +329,7 @@ func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.Tree
 			Name:        "Labels",
 			UnreadCount: totalLabelsUnreadCount,
 		}
-		uid := tree.MustAdd(iwidget.RootUID, n)
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
 		for _, l := range labels {
 			u, ok := labelUnreadCounts[l.LabelID]
 			if !ok {
@@ -359,7 +359,7 @@ func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.Tree
 			Name:        "Mailing Lists",
 			UnreadCount: totalListUnreadCount,
 		}
-		uid := tree.MustAdd(iwidget.RootUID, n)
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
 		for _, l := range lists {
 			u, ok := listUnreadCounts[l.ID]
 			if !ok {
@@ -385,7 +385,7 @@ func (*characterMails) fetchFolders(characterID int32, s services) (iwidget.Tree
 		ObjID:       app.MailLabelAll,
 		UnreadCount: totalUnreadCount,
 	}
-	tree.MustAdd(iwidget.RootUID, folderAll)
+	tree.MustAdd(iwidget.TreeRootID, folderAll)
 	return tree, folderAll, nil
 }
 

--- a/internal/app/ui/characteroverview.go
+++ b/internal/app/ui/characteroverview.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -338,9 +337,7 @@ func (*characterOverview) fetchRows(s services) ([]characterOverviewRow, overvie
 		if err != nil {
 			return nil, totals, err
 		}
-		cc[i].tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		cc[i].tags = tags
 	}
 	return cc, totals, nil
 }

--- a/internal/app/ui/clones.go
+++ b/internal/app/ui/clones.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -320,9 +319,7 @@ func (*clones) fetchRows(s services) ([]cloneRow, error) {
 		if err != nil {
 			return nil, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		rows = append(rows, r)
 	}
 	return rows, nil

--- a/internal/app/ui/colonies.go
+++ b/internal/app/ui/colonies.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -344,9 +343,7 @@ func (a *colonies) fetchRows(s services) ([]colonyRow, int, error) {
 		if err != nil {
 			return nil, 0, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		rows = append(rows, r)
 		if p.IsExpired() {
 			expired++

--- a/internal/app/ui/contracts.go
+++ b/internal/app/ui/contracts.go
@@ -20,7 +20,6 @@ import (
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -380,9 +379,7 @@ func (a *contracts) fetchRows(s services) ([]contractRow, int, error) {
 		if err != nil {
 			return nil, 0, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		rows = append(rows, r)
 		if c.IsActive() {
 			activeCount++

--- a/internal/app/ui/desktopui.go
+++ b/internal/app/ui/desktopui.go
@@ -195,7 +195,10 @@ func NewDesktopUI(bu *baseUI) *DesktopUI {
 		iwidget.NewNavPage(
 			"Clones",
 			theme.NewThemedResource(icons.HeadSnowflakeSvg),
-			makePageWithTitle("Clones", u.clones),
+			makePageWithTitle("Clones", container.NewAppTabs(
+				container.NewTabItem("Augmentations", u.augmentations),
+				container.NewTabItem("Jump Clones", u.clones),
+			)),
 		),
 		contracts,
 		overviewColonies,

--- a/internal/app/ui/gamesearch.go
+++ b/internal/app/ui/gamesearch.go
@@ -375,7 +375,7 @@ func (a *gameSearch) doSearch2(search string) {
 	if total == 0 {
 		return
 	}
-	var t iwidget.TreeNodes[resultNode]
+	var t iwidget.TreeData[resultNode]
 	var categoriesFound int
 	for _, c := range categories {
 		_, ok := results[c]

--- a/internal/app/ui/gamesearch.go
+++ b/internal/app/ui/gamesearch.go
@@ -384,7 +384,7 @@ func (a *gameSearch) doSearch2(search string) {
 		}
 		categoriesFound++
 		n := resultNode{category: c, count: len(results[c])}
-		parentUID, err := t.Add(iwidget.RootUID, n)
+		parentUID, err := t.Add(iwidget.TreeRootID, n)
 		if err != nil {
 			slog.Error("game search: adding node", "node", n)
 			continue

--- a/internal/app/ui/industryjob.go
+++ b/internal/app/ui/industryjob.go
@@ -481,9 +481,7 @@ func (a *industryJobs) update() {
 			reportError(err)
 			return
 		}
-		tagsPerCharacter[c.ID] = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		tagsPerCharacter[c.ID] = tags
 	}
 	myCharacters := set.Of(xslices.Map(cc, func(c *app.EntityShort[int32]) int32 {
 		return c.ID

--- a/internal/app/ui/industryslot.go
+++ b/internal/app/ui/industryslot.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -321,9 +320,7 @@ func (*industrySlots) fetchData(s services, slotType app.IndustryJobType) ([]ind
 		if err != nil {
 			return nil, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		rows = append(rows, r)
 	}
 	return rows, nil

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -615,7 +615,10 @@ func makeHomeNav(u *MobileUI) *iwidget.Navigator {
 			"Clones",
 			theme.NewThemedResource(icons.HeadSnowflakeSvg),
 			func() {
-				homeNav.Push(iwidget.NewAppBar("Clones", u.clones))
+				homeNav.Push(iwidget.NewAppBar("Clones", container.NewAppTabs(
+					container.NewTabItem("Augmentations", u.augmentations),
+					container.NewTabItem("Jump Clones", u.clones),
+				)))
 			},
 		),
 		navItemContracts,

--- a/internal/app/ui/statusbar.go
+++ b/internal/app/ui/statusbar.go
@@ -220,7 +220,11 @@ func (a *statusBar) update() {
 func (a *statusBar) refreshUpdateStatus() {
 	fyne.Do(func() {
 		x := a.u.scs.Summary()
-		a.updateStatus.SetTextAndImportance(x.DisplayShort(), x.Status().ToImportance())
+		status := x.DisplayShort()
+		if a.u.isUpdateDisabled {
+			status += " [disabled]"
+		}
+		a.updateStatus.SetTextAndImportance(status, x.Status().ToImportance())
 	})
 }
 

--- a/internal/app/ui/training.go
+++ b/internal/app/ui/training.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"
-	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
@@ -397,9 +396,7 @@ func (*training) fetchRows(s services) ([]trainingRow, error) {
 		if err != nil {
 			return nil, err
 		}
-		r.tags = set.Collect(xiter.MapSlice(tags, func(x *app.CharacterTag) string {
-			return x.Name
-		}))
+		r.tags = tags
 		queue := app.NewCharacterSkillqueue()
 		if err := queue.Update(ctx, s.cs, c.ID); err != nil {
 			return nil, err

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -101,6 +101,7 @@ type baseUI struct {
 
 	// UI elements
 	assets                  *assets
+	augmentations           *augmentations
 	characterAsset          *characterAssets
 	characterAttributes     *characterAttributes
 	characterAugmentations  *characterAugmentations
@@ -221,37 +222,39 @@ func NewBaseUI(args BaseUIParams) *baseUI {
 		defaultImageScaleMode = canvas.ImageScaleFastest
 	}
 
+	u.assets = newAssets(u)
+	u.augmentations = newAugmentations(u)
 	u.characterAsset = newCharacterAssets(u)
 	u.characterAttributes = newCharacterAttributes(u)
+	u.characterAugmentations = newCharacterAugmentations(u)
 	u.characterBiography = newCharacterBiography(u)
 	u.characterCommunications = newCharacterCommunications(u)
-	u.characterAugmentations = newCharacterAugmentations(u)
-	u.characterJumpClones = newCharacterJumpClones(u)
-	u.characterMail = newCharacterMails(u)
-	u.characterSheet = newCharacterSheet(u)
 	u.characterCorporation = newCorporationSheet(u, false)
+	u.characterJumpClones = newCharacterJumpClones(u)
+	u.characterLocations = newCharacterLocations(u)
+	u.characterMail = newCharacterMails(u)
+	u.characterOverview = newCharacterOverview(u)
+	u.characterSheet = newCharacterSheet(u)
 	u.characterShips = newCharacterFlyableShips(u)
 	u.characterSkillCatalogue = newCharacterSkillCatalogue(u)
 	u.characterSkillQueue = newCharacterSkillQueue(u)
 	u.characterWallet = newCharacterWallet(u)
-	u.corporationSheet = newCorporationSheet(u, true)
+	u.clones = newClones(u)
+	u.colonies = newColonies(u)
+	u.contracts = newContracts(u)
 	u.corporationMember = newCorporationMember(u)
+	u.corporationSheet = newCorporationSheet(u, true)
 	for _, d := range app.Divisions {
 		u.corporationWallets[d] = newCorporationWallet(u, d)
 	}
-	u.contracts = newContracts(u)
 	u.gameSearch = newGameSearch(u)
 	u.industryJobs = newIndustryJobs(u)
 	u.slotsManufacturing = newIndustrySlots(u, app.ManufacturingJob)
 	u.slotsReactions = newIndustrySlots(u, app.ReactionJob)
 	u.slotsResearch = newIndustrySlots(u, app.ScienceJob)
-	u.assets = newAssets(u)
-	u.characterOverview = newCharacterOverview(u)
-	u.clones = newClones(u)
-	u.colonies = newColonies(u)
-	u.characterLocations = newCharacterLocations(u)
 	u.training = newTraining(u)
 	u.wealth = newWealth(u)
+
 	u.snackbar = iwidget.NewSnackbar(u.window)
 	u.MainWindow().SetMaster()
 
@@ -668,7 +671,8 @@ func (u *baseUI) updateHome() {
 
 func (u *baseUI) defineHomeUpdates() map[string]func() {
 	ff := map[string]func(){
-		"assetSearch":        u.assets.update,
+		"assets":             u.assets.update,
+		"augmentations":      u.augmentations.update,
 		"contracts":          u.contracts.update,
 		"cloneSearch":        u.clones.update,
 		"colony":             u.colonies.update,
@@ -1133,8 +1137,11 @@ func (u *baseUI) updateCharacterSectionAndRefreshIfNeeded(ctx context.Context, c
 			}()
 		}
 	case app.SectionCharacterImplants:
-		if isShown && needsRefresh {
-			u.characterAugmentations.update()
+		if needsRefresh {
+			u.augmentations.update()
+			if isShown {
+				u.characterAugmentations.update()
+			}
 		}
 	case app.SectionCharacterJumpClones:
 		if needsRefresh {
@@ -1549,9 +1556,9 @@ func (u *baseUI) ShowTypeInfoWindow(id int32) {
 	iw.Show(app.EveEntityInventoryType, id)
 }
 
-func (u *baseUI) ShowTypeInfoWindowWithCharacter(entityID, characterID int32) {
+func (u *baseUI) ShowTypeInfoWindowWithCharacter(typeID, characterID int32) {
 	iw := newInfoWindow(u)
-	iw.showWithCharacterID(infoInventoryType, int64(entityID), characterID)
+	iw.showWithCharacterID(infoInventoryType, int64(typeID), characterID)
 }
 
 func (u *baseUI) ShowEveEntityInfoWindow(o *app.EveEntity) {

--- a/internal/widget/tree.go
+++ b/internal/widget/tree.go
@@ -274,7 +274,12 @@ func (t TreeNodes[T]) Parent(uid widget.TreeNodeID) (parent widget.TreeNodeID, o
 	return
 }
 
-// Size returns the number of nodes in the tree
+// Size returns the total number of nodes in the tree.
 func (t TreeNodes[T]) Size() int {
 	return len(t.nodes)
+}
+
+// RootSize returns the number of children of the root node.
+func (t TreeNodes[T]) RootSize() int {
+	return len(t.ChildUIDs(RootUID))
 }

--- a/internal/widget/tree_test.go
+++ b/internal/widget/tree_test.go
@@ -33,7 +33,7 @@ func TestTree_CanCreate(t *testing.T) {
 			co.(*widget.Label).SetText(n.Value)
 		},
 	)
-	var nodes iwidget.TreeNodes[MyNode]
+	var nodes iwidget.TreeData[MyNode]
 	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
@@ -57,7 +57,7 @@ func TestTree_CanReturnNodes(t *testing.T) {
 			co.(*widget.Label).SetText(n.Value)
 		},
 	)
-	var nodes iwidget.TreeNodes[MyNode]
+	var nodes iwidget.TreeData[MyNode]
 	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
@@ -78,7 +78,7 @@ func TestTree_CanClear(t *testing.T) {
 			co.(*widget.Label).SetText(n.Value)
 		},
 	)
-	var nodes iwidget.TreeNodes[MyNode]
+	var nodes iwidget.TreeData[MyNode]
 	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
@@ -106,7 +106,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	tree.OnSelectedNode = func(n MyNode) {
 		selected = n
 	}
-	var nodes iwidget.TreeNodes[MyNode]
+	var nodes iwidget.TreeData[MyNode]
 	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 	alpha := MyNode{"2", "Alpha"}
 	nodes.Add(root, alpha)
@@ -120,7 +120,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 
 func TestTreeNodes_Create(t *testing.T) {
 	t.Run("can create tree", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		n11 := tree.MustAdd(n1, MyNode{"11", "one"})
 		n12 := tree.MustAdd(n1, MyNode{"12", "two"})
@@ -148,7 +148,7 @@ func TestTreeNodes_Create(t *testing.T) {
 
 func TestTreeNodes_Add(t *testing.T) {
 	t.Run("can add a node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
 		uid, err := tree.Add(iwidget.RootUID, n)
 		if assert.NoError(t, err) {
@@ -156,12 +156,12 @@ func TestTreeNodes_Add(t *testing.T) {
 		}
 	})
 	t.Run("should return error when node parent UID does not exist", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		_, err := tree.Add("invalid", MyNode{"1", "Alpha"})
 		assert.Error(t, err)
 	})
 	t.Run("can add a node to zero value", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
 		uid, err := tree.Add(iwidget.RootUID, n)
 		if assert.NoError(t, err) {
@@ -169,7 +169,7 @@ func TestTreeNodes_Add(t *testing.T) {
 		}
 	})
 	t.Run("should return error when trying to add to a nil pointer", func(t *testing.T) {
-		var tree *iwidget.TreeNodes[MyNode]
+		var tree *iwidget.TreeData[MyNode]
 		_, err := tree.Add(iwidget.RootUID, MyNode{"1", "Alpha"})
 		assert.ErrorIs(t, err, iwidget.ErrUndefined)
 	})
@@ -177,37 +177,37 @@ func TestTreeNodes_Add(t *testing.T) {
 
 func TestTreeNodes_MustAdd(t *testing.T) {
 	t.Run("can add a node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
 		uid := tree.MustAdd(iwidget.RootUID, n)
 		assert.Equal(t, n, tree.MustNode(uid))
 	})
 	t.Run("should return error when node UID already exists", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		_, err := tree.Add(iwidget.RootUID, MyNode{"1", "Bravo"})
 		assert.Error(t, err)
 	})
 	t.Run("should return error when node UID is root", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		_, err := tree.Add(iwidget.RootUID, MyNode{iwidget.RootUID, "Bravo"})
 		assert.Error(t, err)
 	})
 	t.Run("should panic when node node can not be added", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		assert.Panics(t, func() {
 			tree.MustAdd("invalid", MyNode{"1", "Alpha"})
 		})
 	})
 	t.Run("can add a node to zero value", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
 		uid := tree.MustAdd(iwidget.RootUID, n)
 		assert.Equal(t, n, tree.MustNode(uid))
 	})
 	t.Run("should panic when object is invalid", func(t *testing.T) {
-		var tree *iwidget.TreeNodes[MyNode]
+		var tree *iwidget.TreeData[MyNode]
 		assert.PanicsWithError(t, iwidget.ErrUndefined.Error(), func() {
 			tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		})
@@ -216,7 +216,7 @@ func TestTreeNodes_MustAdd(t *testing.T) {
 
 func TestTreeNodes_Node(t *testing.T) {
 	t.Run("should return node when it exists", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n1 := MyNode{"1", "Alpha"}
 		uid := tree.MustAdd(iwidget.RootUID, n1)
 		n2, ok := tree.Node(uid)
@@ -225,7 +225,7 @@ func TestTreeNodes_Node(t *testing.T) {
 
 	})
 	t.Run("should report when node does not exist", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		_, ok := tree.Node("invalid")
 		assert.False(t, ok)
 	})
@@ -233,14 +233,14 @@ func TestTreeNodes_Node(t *testing.T) {
 
 func TestTreeNodes_MustNode(t *testing.T) {
 	t.Run("can return a node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		n1 := MyNode{"1", "Alpha"}
 		uid := tree.MustAdd(iwidget.RootUID, n1)
 		n2 := tree.MustNode(uid)
 		assert.Equal(t, n1, n2)
 	})
 	t.Run("should panic when node does not exist", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		assert.Panics(t, func() {
 			tree.MustNode("invalid")
 
@@ -250,7 +250,7 @@ func TestTreeNodes_MustNode(t *testing.T) {
 
 func TestTreeNodes_Path(t *testing.T) {
 	t.Run("should return path for an existing node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		uid1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
 		uid3 := tree.MustAdd(uid2, MyNode{"3", "Charlie"})
@@ -258,12 +258,12 @@ func TestTreeNodes_Path(t *testing.T) {
 		assert.Equal(t, []widget.TreeNodeID{uid1, uid2}, p)
 	})
 	t.Run("should return empty array for root node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		p := tree.Path(iwidget.RootUID)
 		assert.Equal(t, []widget.TreeNodeID{}, p)
 	})
 	t.Run("should return empty array for a top node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		uid := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		p := tree.Path(uid)
 		assert.Equal(t, []widget.TreeNodeID{}, p)
@@ -272,7 +272,7 @@ func TestTreeNodes_Path(t *testing.T) {
 
 func TestTreeNodes_Parent(t *testing.T) {
 	t.Run("can return parent of a top node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		uid := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		p, ok := tree.Parent(uid)
 		assert.True(t, ok)
@@ -280,7 +280,7 @@ func TestTreeNodes_Parent(t *testing.T) {
 	})
 
 	t.Run("can return parent of a random node", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		uid1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
 		p, ok := tree.Parent(uid2)
@@ -288,7 +288,7 @@ func TestTreeNodes_Parent(t *testing.T) {
 		assert.Equal(t, uid1, p)
 	})
 	t.Run("can report when a parent does not exist", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		_, ok := tree.Parent("1")
 		assert.False(t, ok)
 	})
@@ -296,13 +296,13 @@ func TestTreeNodes_Parent(t *testing.T) {
 
 func TestTreeNodes_Size(t *testing.T) {
 	t.Run("can return size of tree with nodes", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		got := tree.Size()
 		assert.Equal(t, 1, got)
 	})
 	t.Run("can return size of zero tree", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		got := tree.Size()
 		assert.Equal(t, 0, got)
 	})
@@ -310,18 +310,18 @@ func TestTreeNodes_Size(t *testing.T) {
 
 func TestTreeNodes_Clear(t *testing.T) {
 	t.Run("can clear tree with nodes", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
 		tree.Clear()
 		assert.Equal(t, 0, tree.Size())
 	})
 	t.Run("can clear empty tree", func(t *testing.T) {
-		var tree iwidget.TreeNodes[MyNode]
+		var tree iwidget.TreeData[MyNode]
 		tree.Clear()
 		assert.Equal(t, 0, tree.Size())
 	})
 	t.Run("panics with specific error when object is undefined", func(t *testing.T) {
-		var tree *iwidget.TreeNodes[MyNode]
+		var tree *iwidget.TreeData[MyNode]
 		assert.PanicsWithError(t, iwidget.ErrUndefined.Error(), func() {
 			tree.Clear()
 		})
@@ -330,7 +330,7 @@ func TestTreeNodes_Clear(t *testing.T) {
 
 func TestTreeNodes_All(t *testing.T) {
 	t.Run("returns list of all nodes", func(t *testing.T) {
-		var nodes iwidget.TreeNodes[MyNode]
+		var nodes iwidget.TreeData[MyNode]
 		root := MyNode{"1", "Root"}
 		nodes.MustAdd(iwidget.RootUID, root)
 		alpha := MyNode{"2", "Alpha"}
@@ -345,7 +345,7 @@ func TestTreeNodes_All(t *testing.T) {
 
 func TestTreeNodes_Equal(t *testing.T) {
 	t.Run("report equal", func(t *testing.T) {
-		var n1, n2 iwidget.TreeNodes[MyNode]
+		var n1, n2 iwidget.TreeData[MyNode]
 		root1 := n1.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 		n1.Add(root1, MyNode{"2", "Alpha"})
 		n1.Add(root1, MyNode{"3", "Bravo"})
@@ -355,7 +355,7 @@ func TestTreeNodes_Equal(t *testing.T) {
 		assert.True(t, n1.Equal(n2))
 	})
 	t.Run("report not equal", func(t *testing.T) {
-		var n1, n2 iwidget.TreeNodes[MyNode]
+		var n1, n2 iwidget.TreeData[MyNode]
 		root1 := n1.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
 		n1.Add(root1, MyNode{"2", "Alpha"})
 		n1.Add(root1, MyNode{"3", "Bravo"})

--- a/internal/widget/tree_test.go
+++ b/internal/widget/tree_test.go
@@ -1,6 +1,7 @@
 package widget_test
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -63,8 +64,8 @@ func TestTree_CanReturnNodes(t *testing.T) {
 	nodes.Add(root, MyNode{"3", "Bravo"})
 	tree.Set(nodes)
 
-	got := tree.Nodes()
-	assert.True(t, nodes.Equal(got))
+	got := tree.Data()
+	assert.True(t, nodes.Equal(got), "got %q, wanted %q", got, nodes)
 }
 
 func TestTree_CanClear(t *testing.T) {
@@ -86,8 +87,8 @@ func TestTree_CanClear(t *testing.T) {
 
 	tree.Clear()
 
-	got := tree.Nodes()
-	assert.Equal(t, 0, got.Size())
+	got := tree.Data()
+	assert.True(t, got.IsEmpty())
 }
 
 func TestTree_OnSelectedNode(t *testing.T) {
@@ -118,32 +119,30 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	assert.Equal(t, alpha.UID(), selected.UID())
 }
 
-func TestTreeData_Create(t *testing.T) {
-	t.Run("can create tree", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		b1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		n11 := tree.MustAdd(b1, MyNode{"11", "one"})
-		n12 := tree.MustAdd(b1, MyNode{"12", "two"})
-		b2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
-		assert.Equal(t, 4, tree.Size())
-		assert.Equal(t, []string{n11, n12}, tree.ChildUIDs(b1))
-		assert.Len(t, tree.ChildUIDs(b2), 0)
-		nodes := []struct {
-			uid      string
-			value    string
-			isBranch bool
-		}{
-			{b1, "Alpha", true},
-			{n11, "one", false},
-			{n12, "two", false},
-			{b2, "Bravo", false},
-		}
-		for _, x := range nodes {
-			b := tree.MustNode(x.uid)
-			assert.Equal(t, MyNode{x.uid, x.value}, b)
-			assert.Equal(t, x.isBranch, tree.IsBranch(x.uid))
-		}
-	})
+func TestTreeData_CanCreateFullTree(t *testing.T) {
+	var tree iwidget.TreeData[MyNode]
+	b1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+	n11 := tree.MustAdd(b1, MyNode{"11", "one"})
+	n12 := tree.MustAdd(b1, MyNode{"12", "two"})
+	b2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
+	assert.Equal(t, 5, tree.Size())
+	assert.Equal(t, []string{n11, n12}, tree.ChildUIDs(b1))
+	assert.Len(t, tree.ChildUIDs(b2), 0)
+	nodes := []struct {
+		uid      string
+		value    string
+		isBranch bool
+	}{
+		{b1, "Alpha", true},
+		{n11, "one", false},
+		{n12, "two", false},
+		{b2, "Bravo", false},
+	}
+	for _, x := range nodes {
+		b := node(tree, x.uid)
+		assert.Equal(t, MyNode{x.uid, x.value}, b)
+		assert.Equal(t, x.isBranch, tree.IsBranch(x.uid))
+	}
 }
 
 func TestTreeData_Add(t *testing.T) {
@@ -152,7 +151,7 @@ func TestTreeData_Add(t *testing.T) {
 		n := MyNode{"1", "Alpha"}
 		uid, err := tree.Add(iwidget.TreeRootID, n)
 		if assert.NoError(t, err) {
-			assert.Equal(t, n, tree.MustNode(uid))
+			assert.Equal(t, n, node(tree, uid))
 		}
 	})
 	t.Run("should return error when node parent UID does not exist", func(t *testing.T) {
@@ -165,7 +164,7 @@ func TestTreeData_Add(t *testing.T) {
 		n := MyNode{"1", "Alpha"}
 		uid, err := tree.Add(iwidget.TreeRootID, n)
 		if assert.NoError(t, err) {
-			assert.Equal(t, n, tree.MustNode(uid))
+			assert.Equal(t, n, node(tree, uid))
 		}
 	})
 	t.Run("should return error when trying to add to a nil pointer", func(t *testing.T) {
@@ -175,98 +174,87 @@ func TestTreeData_Add(t *testing.T) {
 	})
 }
 
-func TestTreeData_MustAdd(t *testing.T) {
-	t.Run("can add a node", func(t *testing.T) {
+func TestTreeData_Children(t *testing.T) {
+	t.Run("can return children of a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		n := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.TreeRootID, n)
-		assert.Equal(t, n, tree.MustNode(uid))
+		branch := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		tree.Add(branch, MyNode{"2", "Alpha"})
+		tree.Add(branch, MyNode{"3", "Bravo"})
+		got, err := tree.Children(branch)
+		if assert.NoError(t, err) {
+			want := []MyNode{{"2", "Alpha"}, {"3", "Bravo"}}
+			assert.Equal(t, want, got)
+		}
 	})
-	t.Run("should return error when node UID already exists", func(t *testing.T) {
+	t.Run("can return children of root", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		_, err := tree.Add(iwidget.TreeRootID, MyNode{"1", "Bravo"})
-		assert.Error(t, err)
+		branch := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Branch"})
+		tree.Add(branch, MyNode{"2", "Alpha"})
+		tree.Add(branch, MyNode{"3", "Bravo"})
+		got, err := tree.Children(iwidget.TreeRootID)
+		if assert.NoError(t, err) {
+			want := []MyNode{{"1", "Branch"}}
+			assert.Equal(t, want, got)
+		}
 	})
-	t.Run("should return error when node UID is root", func(t *testing.T) {
+	t.Run("returns empty if a node has no children", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		_, err := tree.Add(iwidget.TreeRootID, MyNode{iwidget.TreeRootID, "Bravo"})
-		assert.Error(t, err)
+		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		got, err := tree.Children(uid)
+		if assert.NoError(t, err) {
+			assert.Len(t, got, 0)
+		}
 	})
-	t.Run("should panic when node node can not be added", func(t *testing.T) {
+	t.Run("the root ID always exists", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		assert.Panics(t, func() {
-			tree.MustAdd("invalid", MyNode{"1", "Alpha"})
-		})
+		got, err := tree.Children(iwidget.TreeRootID)
+		if assert.NoError(t, err) {
+			assert.Len(t, got, 0)
+		}
 	})
-	t.Run("can add a node to zero value", func(t *testing.T) {
+	t.Run("should return error when node not found", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		n := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.TreeRootID, n)
-		assert.Equal(t, n, tree.MustNode(uid))
-	})
-	t.Run("should panic when object is invalid", func(t *testing.T) {
-		var tree *iwidget.TreeData[MyNode]
-		assert.PanicsWithError(t, iwidget.ErrInvalid.Error(), func() {
-			tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		})
-	})
-}
-
-func TestTreeData_Node(t *testing.T) {
-	t.Run("should return node when it exists", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		n1 := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.TreeRootID, n1)
-		n2, ok := tree.Node(uid)
-		assert.True(t, ok)
-		assert.Equal(t, n1, n2)
-
-	})
-	t.Run("should report when node does not exist", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		_, ok := tree.Node("invalid")
-		assert.False(t, ok)
+		_, err := tree.Children("abc")
+		assert.ErrorIs(t, err, iwidget.ErrNotFound)
 	})
 }
 
-func TestTreeData_MustNode(t *testing.T) {
-	t.Run("can return a node", func(t *testing.T) {
+func TestTreeData_ChildrenCount(t *testing.T) {
+	t.Run("can return count for a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		n1 := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.TreeRootID, n1)
-		n2 := tree.MustNode(uid)
-		assert.Equal(t, n1, n2)
+		branch1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		tree.Add(branch1, MyNode{"2", "Alpha"})
+		tree.Add(branch1, MyNode{"3", "Bravo"})
+		branch2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"4", "Root2"})
+		tree.Add(branch2, MyNode{"5", "Alpha2"})
+		tree.Add(branch2, MyNode{"6", "Bravo2"})
+		got, err := tree.ChildrenCount(branch1)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, got)
+		}
 	})
-	t.Run("should panic when node does not exist", func(t *testing.T) {
+	t.Run("can return count for a root node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		assert.Panics(t, func() {
-			tree.MustNode("invalid")
-
-		})
+		branch1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		tree.Add(branch1, MyNode{"2", "Alpha"})
+		branch2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"4", "Root2"})
+		tree.Add(branch2, MyNode{"5", "Alpha2"})
+		got, err := tree.ChildrenCount(iwidget.TreeRootID)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, got)
+		}
 	})
-}
-
-func TestTreeData_Path(t *testing.T) {
-	t.Run("should return path for an existing node", func(t *testing.T) {
+	t.Run("can return the count for of an empty tree", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		uid1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
-		uid3 := tree.MustAdd(uid2, MyNode{"3", "Charlie"})
-		p := tree.Path(uid3)
-		assert.Equal(t, []widget.TreeNodeID{uid1, uid2}, p)
+		got, err := tree.ChildrenCount(iwidget.TreeRootID)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 0, got)
+		}
 	})
-	t.Run("should return empty array for root node", func(t *testing.T) {
+	t.Run("should return error when node not found", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		p := tree.Path(iwidget.TreeRootID)
-		assert.Equal(t, []widget.TreeNodeID{}, p)
-	})
-	t.Run("should return empty array for a top node", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		p := tree.Path(uid)
-		assert.Equal(t, []widget.TreeNodeID{}, p)
+		_, err := tree.ChildrenCount("abc")
+		assert.ErrorIs(t, err, iwidget.ErrNotFound)
 	})
 }
 
@@ -299,18 +287,134 @@ func TestTreeData_ChildUIDs(t *testing.T) {
 		got := tree.ChildUIDs("xx")
 		assert.Empty(t, got)
 	})
+	t.Run("should return empty when tree is zero for root node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		got := tree.ChildUIDs(iwidget.TreeRootID)
+		assert.Empty(t, got)
+	})
+}
+
+func TestTreeData_Delete(t *testing.T) {
+	t.Run("can remove a node from simple tree", func(t *testing.T) {
+		var t1, t2 iwidget.TreeData[MyNode]
+		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
+		err := t1.Delete(n1)
+		if assert.NoError(t, err) {
+			t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
+			assert.True(t, t1.Equal(t2), "got %q, wanted %q", t1, t2)
+		}
+	})
+	t.Run("can remove node from complex tree", func(t *testing.T) {
+		var t1 iwidget.TreeData[MyNode]
+		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Branch1"})
+		t1.Add(n1, MyNode{"11", "Alpha"})
+		n2 := t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
+		t1.Add(n2, MyNode{"21", "Bravo"})
+		t1.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
+		err := t1.Delete(n1)
+		if assert.NoError(t, err) {
+			var t2 iwidget.TreeData[MyNode]
+			n3 := t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
+			t2.Add(n3, MyNode{"21", "Bravo"})
+			t2.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
+			assert.True(t, t1.Equal(t2), "got %q, wanted %q", t1, t2)
+		}
+	})
+	t.Run("can not remove the root node", func(t *testing.T) {
+		var td iwidget.TreeData[MyNode]
+		err := td.Delete(iwidget.TreeRootID)
+		assert.ErrorIs(t, err, iwidget.ErrInvalid)
+	})
+	t.Run("can not remove node from empty tree", func(t *testing.T) {
+		var td iwidget.TreeData[MyNode]
+		err := td.Delete("xxx")
+		assert.ErrorIs(t, err, iwidget.ErrNotFound)
+	})
+	t.Run("return error when trying to remove non-existing node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.Add(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		err := tree.Delete("xxx")
+		assert.ErrorIs(t, err, iwidget.ErrNotFound)
+	})
+}
+
+func TestTreeData_IsEmpty(t *testing.T) {
+	t.Run("can report non-empty tree", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		assert.Equal(t, false, tree.IsEmpty())
+	})
+	t.Run("can report empty tree", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		assert.Equal(t, true, tree.IsEmpty())
+	})
+}
+
+func TestTreeData_MustAdd(t *testing.T) {
+	t.Run("can add a node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		n := MyNode{"1", "Alpha"}
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
+		assert.Equal(t, n, node(tree, uid))
+	})
+	t.Run("should return error when node UID already exists", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		_, err := tree.Add(iwidget.TreeRootID, MyNode{"1", "Bravo"})
+		assert.Error(t, err)
+	})
+	t.Run("should return error when node UID is root", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		_, err := tree.Add(iwidget.TreeRootID, MyNode{iwidget.TreeRootID, "Bravo"})
+		assert.Error(t, err)
+	})
+	t.Run("should panic when node node can not be added", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		assert.Panics(t, func() {
+			tree.MustAdd("invalid", MyNode{"1", "Alpha"})
+		})
+	})
+	t.Run("can add a node to zero value", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		n := MyNode{"1", "Alpha"}
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
+		assert.Equal(t, n, node(tree, uid))
+	})
+	t.Run("should panic when object is invalid", func(t *testing.T) {
+		var tree *iwidget.TreeData[MyNode]
+		assert.PanicsWithError(t, iwidget.ErrInvalid.Error(), func() {
+			tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		})
+	})
+}
+
+func TestTreeData_Node(t *testing.T) {
+	t.Run("should return node when it exists", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		n1 := MyNode{"1", "Alpha"}
+		uid := tree.MustAdd(iwidget.TreeRootID, n1)
+		n2, ok := tree.Node(uid)
+		assert.True(t, ok)
+		assert.Equal(t, n1, n2)
+
+	})
+	t.Run("should report when node does not exist", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		_, ok := tree.Node("invalid")
+		assert.False(t, ok)
+	})
+	t.Run("the root node always exists", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		n, ok := tree.Node(iwidget.TreeRootID)
+		assert.True(t, ok)
+		assert.Equal(t, MyNode{}, n)
+	})
 }
 
 func TestTreeData_Parent(t *testing.T) {
-	t.Run("can return parent of a top node", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		p, ok := tree.Parent(uid)
-		assert.True(t, ok)
-		assert.Equal(t, iwidget.TreeRootID, p)
-	})
-
-	t.Run("can return parent of a random node", func(t *testing.T) {
+	t.Run("can return parent of a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		uid1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
@@ -318,12 +422,47 @@ func TestTreeData_Parent(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, uid1, p)
 	})
+	t.Run("the parent of a top node is the root node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		p, ok := tree.Parent(uid)
+		assert.True(t, ok)
+		assert.Equal(t, iwidget.TreeRootID, p)
+	})
 	t.Run("can report when a parent does not exist", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		_, ok := tree.Parent("1")
 		assert.False(t, ok)
 	})
+	t.Run("the root node has no parents", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		_, ok := tree.Parent(iwidget.TreeRootID)
+		assert.False(t, ok)
+	})
 }
+
+func TestTreeData_Path(t *testing.T) {
+	t.Run("should return path for an existing node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		uid1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
+		uid3 := tree.MustAdd(uid2, MyNode{"3", "Charlie"})
+		p := tree.Path(uid3)
+		assert.Equal(t, []widget.TreeNodeID{uid1, uid2}, p)
+	})
+	t.Run("should return empty array for root node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		p := tree.Path(iwidget.TreeRootID)
+		assert.Equal(t, []widget.TreeNodeID{}, p)
+	})
+	t.Run("should return empty array for a top node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		p := tree.Path(uid)
+		assert.Equal(t, []widget.TreeNodeID{}, p)
+	})
+}
+
 func TestTreeData_All(t *testing.T) {
 	t.Run("returns list of all nodes", func(t *testing.T) {
 		var nodes iwidget.TreeData[MyNode]
@@ -344,18 +483,16 @@ func TestTreeData_Clear(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		tree.Clear()
-		assert.Equal(t, 0, tree.Size())
+		assert.True(t, tree.IsEmpty())
 	})
 	t.Run("can clear empty tree", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		tree.Clear()
-		assert.Equal(t, 0, tree.Size())
+		assert.True(t, tree.IsEmpty())
 	})
-	t.Run("panics with specific error when object is undefined", func(t *testing.T) {
+	t.Run("can clear nill tree", func(t *testing.T) {
 		var tree *iwidget.TreeData[MyNode]
-		assert.PanicsWithError(t, iwidget.ErrInvalid.Error(), func() {
-			tree.Clear()
-		})
+		tree.Clear()
 	})
 }
 
@@ -386,14 +523,14 @@ func TestTreeData_Clone(t *testing.T) {
 
 func TestTreeData_Equal(t *testing.T) {
 	t.Run("report equal", func(t *testing.T) {
-		var tree1, tree2 iwidget.TreeData[MyNode]
-		sub1 := tree1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
-		tree1.Add(sub1, MyNode{"2", "Alpha"})
-		tree1.Add(sub1, MyNode{"3", "Bravo"})
-		sub2 := tree2.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
-		tree2.Add(sub2, MyNode{"2", "Alpha"})
-		tree2.Add(sub2, MyNode{"3", "Bravo"})
-		assert.True(t, tree1.Equal(tree2))
+		var t1, t2 iwidget.TreeData[MyNode]
+		sub1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		t1.Add(sub1, MyNode{"2", "Alpha"})
+		t1.Add(sub1, MyNode{"3", "Bravo"})
+		sub2 := t2.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		t2.Add(sub2, MyNode{"2", "Alpha"})
+		t2.Add(sub2, MyNode{"3", "Bravo"})
+		assert.True(t, t1.Equal(t2), "got %q, wanted %q", t, t2)
 	})
 	t.Run("report not equal", func(t *testing.T) {
 		var n1, n2 iwidget.TreeData[MyNode]
@@ -411,61 +548,30 @@ func TestTreeData_Size(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		got := tree.Size()
-		assert.Equal(t, 1, got)
+		assert.Equal(t, 2, got)
 	})
 	t.Run("can return size of zero tree", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		got := tree.Size()
-		assert.Equal(t, 0, got)
+		assert.Equal(t, 1, got)
 	})
 }
 
-func TestTreeData_RootChildrenCount(t *testing.T) {
-	t.Run("can return count for tree with nodes", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		branch1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
-		tree.Add(branch1, MyNode{"2", "Alpha"})
-		tree.Add(branch1, MyNode{"3", "Bravo"})
-		branch2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"4", "Root2"})
-		tree.Add(branch2, MyNode{"5", "Alpha2"})
-		tree.Add(branch2, MyNode{"6", "Bravo2"})
-		got := tree.RootChildrenCount()
-		assert.Equal(t, 2, got)
-	})
-	t.Run("can return the count for of an empty tree", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		got := tree.RootChildrenCount()
-		assert.Equal(t, 0, got)
-	})
+func TestTreeData_String(t *testing.T) {
+	var tree iwidget.TreeData[MyNode]
+	uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+	tree.MustAdd(uid, MyNode{"2", "Bravo"})
+	s := fmt.Sprint(tree)
+	assert.Equal(t, "{nodes map[1:{ID:1 Value:Alpha} 2:{ID:2 Value:Bravo}], children: map[:[1] 1:[2]]}", s)
 }
 
-func TestTreeData_Remove(t *testing.T) {
-	t.Run("can remove a node from simple tree", func(t *testing.T) {
-		var t1, t2 iwidget.TreeData[MyNode]
-		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
-		t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
-		err := t1.Remove(n1)
-		if assert.NoError(t, err) {
-			t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
-			assert.True(t, t1.Equal(t2))
-		}
-	})
-	t.Run("can remove node from complex tree", func(t *testing.T) {
-		var t1 iwidget.TreeData[MyNode]
-		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Branch1"})
-		t1.Add(n1, MyNode{"11", "Alpha"})
-		n2 := t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
-		t1.Add(n2, MyNode{"21", "Bravo"})
-		t1.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
-		err := t1.Remove(n1)
-		if assert.NoError(t, err) {
-			var t2 iwidget.TreeData[MyNode]
-			n3 := t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
-			t2.Add(n3, MyNode{"21", "Bravo"})
-			t2.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
-			t1.Print("")
-			t2.Print("")
-			assert.True(t, t1.Equal(t2))
-		}
-	})
+// node returns a node from a tree or a zero node if not found.
+// This is a helper for simpler test code.
+func node[T iwidget.TreeNode](td iwidget.TreeData[T], uid widget.TreeNodeID) T {
+	var zero T
+	v, ok := td.Node(uid)
+	if !ok {
+		return zero
+	}
+	return v
 }

--- a/internal/widget/tree_test.go
+++ b/internal/widget/tree_test.go
@@ -34,7 +34,7 @@ func TestTree_CanCreate(t *testing.T) {
 		},
 	)
 	var nodes iwidget.TreeData[MyNode]
-	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
+	root := nodes.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
 	tree.Set(nodes)
@@ -58,7 +58,7 @@ func TestTree_CanReturnNodes(t *testing.T) {
 		},
 	)
 	var nodes iwidget.TreeData[MyNode]
-	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
+	root := nodes.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
 	tree.Set(nodes)
@@ -79,7 +79,7 @@ func TestTree_CanClear(t *testing.T) {
 		},
 	)
 	var nodes iwidget.TreeData[MyNode]
-	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
+	root := nodes.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
 	nodes.Add(root, MyNode{"2", "Alpha"})
 	nodes.Add(root, MyNode{"3", "Bravo"})
 	tree.Set(nodes)
@@ -107,7 +107,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 		selected = n
 	}
 	var nodes iwidget.TreeData[MyNode]
-	root := nodes.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
+	root := nodes.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
 	alpha := MyNode{"2", "Alpha"}
 	nodes.Add(root, alpha)
 	nodes.Add(root, MyNode{"3", "Bravo"})
@@ -118,25 +118,25 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	assert.Equal(t, alpha.UID(), selected.UID())
 }
 
-func TestTreeNodes_Create(t *testing.T) {
+func TestTreeData_Create(t *testing.T) {
 	t.Run("can create tree", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		n1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
-		n11 := tree.MustAdd(n1, MyNode{"11", "one"})
-		n12 := tree.MustAdd(n1, MyNode{"12", "two"})
-		n2 := tree.MustAdd(iwidget.RootUID, MyNode{"2", "Bravo"})
+		b1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		n11 := tree.MustAdd(b1, MyNode{"11", "one"})
+		n12 := tree.MustAdd(b1, MyNode{"12", "two"})
+		b2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
 		assert.Equal(t, 4, tree.Size())
-		assert.Equal(t, []string{n11, n12}, tree.ChildUIDs(n1))
-		assert.Len(t, tree.ChildUIDs(n2), 0)
+		assert.Equal(t, []string{n11, n12}, tree.ChildUIDs(b1))
+		assert.Len(t, tree.ChildUIDs(b2), 0)
 		nodes := []struct {
 			uid      string
 			value    string
 			isBranch bool
 		}{
-			{n1, "Alpha", true},
+			{b1, "Alpha", true},
 			{n11, "one", false},
 			{n12, "two", false},
-			{n2, "Bravo", false},
+			{b2, "Bravo", false},
 		}
 		for _, x := range nodes {
 			b := tree.MustNode(x.uid)
@@ -146,11 +146,11 @@ func TestTreeNodes_Create(t *testing.T) {
 	})
 }
 
-func TestTreeNodes_Add(t *testing.T) {
+func TestTreeData_Add(t *testing.T) {
 	t.Run("can add a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
-		uid, err := tree.Add(iwidget.RootUID, n)
+		uid, err := tree.Add(iwidget.TreeRootID, n)
 		if assert.NoError(t, err) {
 			assert.Equal(t, n, tree.MustNode(uid))
 		}
@@ -163,35 +163,35 @@ func TestTreeNodes_Add(t *testing.T) {
 	t.Run("can add a node to zero value", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
-		uid, err := tree.Add(iwidget.RootUID, n)
+		uid, err := tree.Add(iwidget.TreeRootID, n)
 		if assert.NoError(t, err) {
 			assert.Equal(t, n, tree.MustNode(uid))
 		}
 	})
 	t.Run("should return error when trying to add to a nil pointer", func(t *testing.T) {
 		var tree *iwidget.TreeData[MyNode]
-		_, err := tree.Add(iwidget.RootUID, MyNode{"1", "Alpha"})
-		assert.ErrorIs(t, err, iwidget.ErrUndefined)
+		_, err := tree.Add(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		assert.ErrorIs(t, err, iwidget.ErrInvalid)
 	})
 }
 
-func TestTreeNodes_MustAdd(t *testing.T) {
+func TestTreeData_MustAdd(t *testing.T) {
 	t.Run("can add a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.RootUID, n)
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
 		assert.Equal(t, n, tree.MustNode(uid))
 	})
 	t.Run("should return error when node UID already exists", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
-		_, err := tree.Add(iwidget.RootUID, MyNode{"1", "Bravo"})
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		_, err := tree.Add(iwidget.TreeRootID, MyNode{"1", "Bravo"})
 		assert.Error(t, err)
 	})
 	t.Run("should return error when node UID is root", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
-		_, err := tree.Add(iwidget.RootUID, MyNode{iwidget.RootUID, "Bravo"})
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		_, err := tree.Add(iwidget.TreeRootID, MyNode{iwidget.TreeRootID, "Bravo"})
 		assert.Error(t, err)
 	})
 	t.Run("should panic when node node can not be added", func(t *testing.T) {
@@ -203,22 +203,22 @@ func TestTreeNodes_MustAdd(t *testing.T) {
 	t.Run("can add a node to zero value", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.RootUID, n)
+		uid := tree.MustAdd(iwidget.TreeRootID, n)
 		assert.Equal(t, n, tree.MustNode(uid))
 	})
 	t.Run("should panic when object is invalid", func(t *testing.T) {
 		var tree *iwidget.TreeData[MyNode]
-		assert.PanicsWithError(t, iwidget.ErrUndefined.Error(), func() {
-			tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		assert.PanicsWithError(t, iwidget.ErrInvalid.Error(), func() {
+			tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		})
 	})
 }
 
-func TestTreeNodes_Node(t *testing.T) {
+func TestTreeData_Node(t *testing.T) {
 	t.Run("should return node when it exists", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n1 := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.RootUID, n1)
+		uid := tree.MustAdd(iwidget.TreeRootID, n1)
 		n2, ok := tree.Node(uid)
 		assert.True(t, ok)
 		assert.Equal(t, n1, n2)
@@ -231,11 +231,11 @@ func TestTreeNodes_Node(t *testing.T) {
 	})
 }
 
-func TestTreeNodes_MustNode(t *testing.T) {
+func TestTreeData_MustNode(t *testing.T) {
 	t.Run("can return a node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
 		n1 := MyNode{"1", "Alpha"}
-		uid := tree.MustAdd(iwidget.RootUID, n1)
+		uid := tree.MustAdd(iwidget.TreeRootID, n1)
 		n2 := tree.MustNode(uid)
 		assert.Equal(t, n1, n2)
 	})
@@ -248,10 +248,10 @@ func TestTreeNodes_MustNode(t *testing.T) {
 	})
 }
 
-func TestTreeNodes_Path(t *testing.T) {
+func TestTreeData_Path(t *testing.T) {
 	t.Run("should return path for an existing node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		uid1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		uid1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
 		uid3 := tree.MustAdd(uid2, MyNode{"3", "Charlie"})
 		p := tree.Path(uid3)
@@ -259,29 +259,60 @@ func TestTreeNodes_Path(t *testing.T) {
 	})
 	t.Run("should return empty array for root node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		p := tree.Path(iwidget.RootUID)
+		p := tree.Path(iwidget.TreeRootID)
 		assert.Equal(t, []widget.TreeNodeID{}, p)
 	})
 	t.Run("should return empty array for a top node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		uid := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		p := tree.Path(uid)
 		assert.Equal(t, []widget.TreeNodeID{}, p)
 	})
 }
 
-func TestTreeNodes_Parent(t *testing.T) {
+func TestTreeData_ChildUIDs(t *testing.T) {
+	t.Run("can return child UIDs of existing node", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		sub1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		c1 := tree.MustAdd(sub1, MyNode{"2", "Bravo"})
+		c2 := tree.MustAdd(sub1, MyNode{"3", "Charlie"})
+		sub2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"4", "Delta"})
+		tree.MustAdd(sub2, MyNode{"5", "Echo"})
+		got := tree.ChildUIDs(sub1)
+		want := []widget.TreeNodeID{c1, c2}
+		assert.ElementsMatch(t, want, got)
+	})
+	t.Run("should return empty when node does not exist", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		got := tree.ChildUIDs("xy")
+		assert.Empty(t, got)
+	})
+	t.Run("should return empty when node has not children", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		n1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		got := tree.ChildUIDs(n1)
+		assert.Empty(t, got)
+	})
+	t.Run("should return empty when tree is zero", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		got := tree.ChildUIDs("xx")
+		assert.Empty(t, got)
+	})
+}
+
+func TestTreeData_Parent(t *testing.T) {
 	t.Run("can return parent of a top node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		uid := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		uid := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		p, ok := tree.Parent(uid)
 		assert.True(t, ok)
-		assert.Equal(t, iwidget.RootUID, p)
+		assert.Equal(t, iwidget.TreeRootID, p)
 	})
 
 	t.Run("can return parent of a random node", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		uid1 := tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		uid1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		uid2 := tree.MustAdd(uid1, MyNode{"2", "Bravo"})
 		p, ok := tree.Parent(uid2)
 		assert.True(t, ok)
@@ -293,25 +324,25 @@ func TestTreeNodes_Parent(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
-
-func TestTreeNodes_Size(t *testing.T) {
-	t.Run("can return size of tree with nodes", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
-		got := tree.Size()
-		assert.Equal(t, 1, got)
-	})
-	t.Run("can return size of zero tree", func(t *testing.T) {
-		var tree iwidget.TreeData[MyNode]
-		got := tree.Size()
-		assert.Equal(t, 0, got)
+func TestTreeData_All(t *testing.T) {
+	t.Run("returns list of all nodes", func(t *testing.T) {
+		var nodes iwidget.TreeData[MyNode]
+		branch := MyNode{"1", "Root"}
+		nodes.MustAdd(iwidget.TreeRootID, branch)
+		alpha := MyNode{"2", "Alpha"}
+		nodes.Add(branch.UID(), alpha)
+		bravo := MyNode{"3", "Bravo"}
+		nodes.Add(branch.UID(), bravo)
+		got := slices.Collect(nodes.All())
+		want := []MyNode{branch, alpha, bravo}
+		assert.ElementsMatch(t, want, got)
 	})
 }
 
-func TestTreeNodes_Clear(t *testing.T) {
+func TestTreeData_Clear(t *testing.T) {
 	t.Run("can clear tree with nodes", func(t *testing.T) {
 		var tree iwidget.TreeData[MyNode]
-		tree.MustAdd(iwidget.RootUID, MyNode{"1", "Alpha"})
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
 		tree.Clear()
 		assert.Equal(t, 0, tree.Size())
 	})
@@ -322,45 +353,119 @@ func TestTreeNodes_Clear(t *testing.T) {
 	})
 	t.Run("panics with specific error when object is undefined", func(t *testing.T) {
 		var tree *iwidget.TreeData[MyNode]
-		assert.PanicsWithError(t, iwidget.ErrUndefined.Error(), func() {
+		assert.PanicsWithError(t, iwidget.ErrInvalid.Error(), func() {
 			tree.Clear()
 		})
 	})
 }
 
-func TestTreeNodes_All(t *testing.T) {
-	t.Run("returns list of all nodes", func(t *testing.T) {
-		var nodes iwidget.TreeData[MyNode]
+func TestTreeData_Clone(t *testing.T) {
+	t.Run("can clone a td object", func(t *testing.T) {
+		// given
+		var td iwidget.TreeData[MyNode]
 		root := MyNode{"1", "Root"}
-		nodes.MustAdd(iwidget.RootUID, root)
+		td.MustAdd(iwidget.TreeRootID, root)
 		alpha := MyNode{"2", "Alpha"}
-		nodes.Add(root.UID(), alpha)
+		td.Add(root.UID(), alpha)
 		bravo := MyNode{"3", "Bravo"}
-		nodes.Add(root.UID(), bravo)
-		got := slices.Collect(nodes.All())
-		want := []MyNode{root, alpha, bravo}
-		assert.ElementsMatch(t, want, got)
+		td.Add(root.UID(), bravo)
+		// when
+		got := td.Clone()
+		// then
+		assert.True(t, got.Equal(td), "got %q, wanted %q", got, td)
+	})
+	t.Run("can clone a empty td object", func(t *testing.T) {
+		// given
+		var td iwidget.TreeData[MyNode]
+		// when
+		got := td.Clone()
+		// then
+		assert.True(t, got.Equal(td), "got %q, wanted %q", got, td)
 	})
 }
 
-func TestTreeNodes_Equal(t *testing.T) {
+func TestTreeData_Equal(t *testing.T) {
 	t.Run("report equal", func(t *testing.T) {
-		var n1, n2 iwidget.TreeData[MyNode]
-		root1 := n1.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
-		n1.Add(root1, MyNode{"2", "Alpha"})
-		n1.Add(root1, MyNode{"3", "Bravo"})
-		root2 := n2.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
-		n2.Add(root2, MyNode{"2", "Alpha"})
-		n2.Add(root2, MyNode{"3", "Bravo"})
-		assert.True(t, n1.Equal(n2))
+		var tree1, tree2 iwidget.TreeData[MyNode]
+		sub1 := tree1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		tree1.Add(sub1, MyNode{"2", "Alpha"})
+		tree1.Add(sub1, MyNode{"3", "Bravo"})
+		sub2 := tree2.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		tree2.Add(sub2, MyNode{"2", "Alpha"})
+		tree2.Add(sub2, MyNode{"3", "Bravo"})
+		assert.True(t, tree1.Equal(tree2))
 	})
 	t.Run("report not equal", func(t *testing.T) {
 		var n1, n2 iwidget.TreeData[MyNode]
-		root1 := n1.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
-		n1.Add(root1, MyNode{"2", "Alpha"})
-		n1.Add(root1, MyNode{"3", "Bravo"})
-		root2 := n2.MustAdd(iwidget.RootUID, MyNode{"1", "Root"})
-		n2.Add(root2, MyNode{"2", "Alpha"})
+		sub1 := n1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		n1.Add(sub1, MyNode{"2", "Alpha"})
+		n1.Add(sub1, MyNode{"3", "Bravo"})
+		sub2 := n2.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root"})
+		n2.Add(sub2, MyNode{"2", "Alpha"})
 		assert.False(t, n1.Equal(n2))
+	})
+}
+
+func TestTreeData_Size(t *testing.T) {
+	t.Run("can return size of tree with nodes", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		got := tree.Size()
+		assert.Equal(t, 1, got)
+	})
+	t.Run("can return size of zero tree", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		got := tree.Size()
+		assert.Equal(t, 0, got)
+	})
+}
+
+func TestTreeData_RootChildrenCount(t *testing.T) {
+	t.Run("can return count for tree with nodes", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		branch1 := tree.MustAdd(iwidget.TreeRootID, MyNode{"1", "Root1"})
+		tree.Add(branch1, MyNode{"2", "Alpha"})
+		tree.Add(branch1, MyNode{"3", "Bravo"})
+		branch2 := tree.MustAdd(iwidget.TreeRootID, MyNode{"4", "Root2"})
+		tree.Add(branch2, MyNode{"5", "Alpha2"})
+		tree.Add(branch2, MyNode{"6", "Bravo2"})
+		got := tree.RootChildrenCount()
+		assert.Equal(t, 2, got)
+	})
+	t.Run("can return the count for of an empty tree", func(t *testing.T) {
+		var tree iwidget.TreeData[MyNode]
+		got := tree.RootChildrenCount()
+		assert.Equal(t, 0, got)
+	})
+}
+
+func TestTreeData_Remove(t *testing.T) {
+	t.Run("can remove a node from simple tree", func(t *testing.T) {
+		var t1, t2 iwidget.TreeData[MyNode]
+		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Alpha"})
+		t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
+		err := t1.Remove(n1)
+		if assert.NoError(t, err) {
+			t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Bravo"})
+			assert.True(t, t1.Equal(t2))
+		}
+	})
+	t.Run("can remove node from complex tree", func(t *testing.T) {
+		var t1 iwidget.TreeData[MyNode]
+		n1 := t1.MustAdd(iwidget.TreeRootID, MyNode{"1", "Branch1"})
+		t1.Add(n1, MyNode{"11", "Alpha"})
+		n2 := t1.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
+		t1.Add(n2, MyNode{"21", "Bravo"})
+		t1.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
+		err := t1.Remove(n1)
+		if assert.NoError(t, err) {
+			var t2 iwidget.TreeData[MyNode]
+			n3 := t2.MustAdd(iwidget.TreeRootID, MyNode{"2", "Branch2"})
+			t2.Add(n3, MyNode{"21", "Bravo"})
+			t2.MustAdd(iwidget.TreeRootID, MyNode{"3", "Charlie"})
+			t1.Print("")
+			t2.Print("")
+			assert.True(t, t1.Equal(t2))
+		}
 	})
 }


### PR DESCRIPTION
## Augmentation overview

Adds an overview that shows the current augmentations for all characters.
The user can filter by tags.

Preview: 

<img width="916" height="660" alt="Screenshot from 2025-08-11 00-11-55" src="https://github.com/user-attachments/assets/47214c40-56fb-497c-bcca-e1ec78fa5405" />

Also contains many improvements to the tree widget.

Fixes #214 