### PR TITLE
feat: limit number of active goroutines per group

### DIFF
--- a/internal/app/characterservice/assets.go
+++ b/internal/app/characterservice/assets.go
@@ -55,6 +55,7 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg app.Characte
 		ctx, arg,
 		func(ctx context.Context, characterID int32) (any, error) {
 			assets, err := xesi.FetchWithPaging(
+				s.concurrencyLimit,
 				func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
 					arg := &esi.GetCharactersCharacterIdAssetsOpts{
 						Page: esioptional.NewInt32(int32(pageNum)),
@@ -176,6 +177,7 @@ func (s *CharacterService) fetchAssetNamesESI(ctx context.Context, characterID i
 	}
 	results := make([][]esi.PostCharactersCharacterIdAssetsNames200Ok, numResults)
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for num, chunk := range xiter.Count(slices.Chunk(ids, assetNamesMaxIDs), 0) {
 		g.Go(func() error {
 			names, _, err := s.esiClient.ESI.AssetsApi.PostCharactersCharacterIdAssetsNames(ctx, characterID, chunk, nil)

--- a/internal/app/characterservice/communications.go
+++ b/internal/app/characterservice/communications.go
@@ -142,6 +142,7 @@ func (s *CharacterService) updateNotificationsESI(ctx context.Context, arg app.C
 			}
 			args := make([]storage.CreateCharacterNotificationParams, len(newNotifs))
 			g := new(errgroup.Group)
+			g.SetLimit(s.concurrencyLimit)
 			for i, n := range newNotifs {
 				g.Go(func() error {
 					arg := storage.CreateCharacterNotificationParams{

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -145,6 +145,7 @@ func (s *CharacterService) updateContractsESI(ctx context.Context, arg app.Chara
 		ctx, arg,
 		func(ctx context.Context, characterID int32) (any, error) {
 			contracts, err := xesi.FetchWithPaging(
+				s.concurrencyLimit,
 				func(pageNum int) ([]esi.GetCharactersCharacterIdContracts200Ok, *http.Response, error) {
 					return s.esiClient.ESI.ContractsApi.GetCharactersCharacterIdContracts(
 						ctx, characterID, &esi.GetCharactersCharacterIdContractsOpts{

--- a/internal/app/characterservice/mail.go
+++ b/internal/app/characterservice/mail.go
@@ -404,6 +404,7 @@ func (s *CharacterService) addNewMailsESI(ctx context.Context, characterID int32
 	}
 	mails := make([]esiMailWrapper, len(headers))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, h := range headers {
 		g.Go(func() error {
 			m, _, err := s.esiClient.ESI.MailApi.GetCharactersCharacterIdMailMailId(ctx, characterID, h.MailId, nil)

--- a/internal/app/characterservice/service.go
+++ b/internal/app/characterservice/service.go
@@ -1,0 +1,102 @@
+// Package characterservice contains the EVE character service.
+package characterservice
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/antihax/goesi"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/evenotification"
+	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/statuscacheservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
+	"github.com/ErikKalkoken/evebuddy/internal/set"
+)
+
+type SSOService interface {
+	Authenticate(ctx context.Context, scopes []string) (*app.Token, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*app.Token, error)
+}
+
+// CharacterService provides access to all managed Eve Online characters both online and from local storage.
+type CharacterService struct {
+	ens              *evenotification.EveNotificationService
+	esiClient        *goesi.APIClient
+	eus              *eveuniverseservice.EveUniverseService
+	httpClient       *http.Client
+	concurrencyLimit int
+	scs              *statuscacheservice.StatusCacheService
+	sfg              *singleflight.Group
+	sso              SSOService
+	st               *storage.Storage
+}
+
+type Params struct {
+	ConcurrencyLimit       int // max number of concurrent Goroutines (per group)
+	EveNotificationService *evenotification.EveNotificationService
+	EveUniverseService     *eveuniverseservice.EveUniverseService
+	SSOService             SSOService
+	StatusCacheService     *statuscacheservice.StatusCacheService
+	Storage                *storage.Storage
+	// optional
+	HTTPClient *http.Client
+	ESIClient  *goesi.APIClient
+}
+
+// New creates a new character service and returns it.
+// When nil is passed for any parameter a new default instance will be created for it (except for storage).
+func New(arg Params) *CharacterService {
+	s := &CharacterService{
+		concurrencyLimit: -1, // Default is no limit
+		ens:              arg.EveNotificationService,
+		eus:              arg.EveUniverseService,
+		scs:              arg.StatusCacheService,
+		sso:              arg.SSOService,
+		st:               arg.Storage,
+		sfg:              new(singleflight.Group),
+	}
+	if arg.HTTPClient == nil {
+		s.httpClient = http.DefaultClient
+	} else {
+		s.httpClient = arg.HTTPClient
+	}
+	if arg.ESIClient == nil {
+		s.esiClient = goesi.NewAPIClient(s.httpClient, "")
+	} else {
+		s.esiClient = arg.ESIClient
+	}
+	if arg.ConcurrencyLimit > 0 {
+		s.concurrencyLimit = arg.ConcurrencyLimit
+	}
+	return s
+}
+
+// DumpData returns the current content of the given SQL tables as JSON string.
+// When no tables are given all tables will be included.
+// This is a low-level method meant mainly for debugging.
+func (s *CharacterService) DumpData(tables ...string) string {
+	return s.st.DumpData(tables...)
+}
+
+func (s *CharacterService) addMissingEveEntitiesAndLocations(ctx context.Context, entityIDs set.Set[int32], locationIDs set.Set[int64]) error {
+	g := new(errgroup.Group)
+	if entityIDs.Size() > 0 {
+		g.Go(func() error {
+			_, err := s.eus.AddMissingEntities(ctx, entityIDs)
+			return err
+		})
+	}
+	if locationIDs.Size() > 0 {
+		g.Go(func() error {
+			return s.eus.AddMissingLocations(ctx, locationIDs)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/app/characterservice/wallet.go
+++ b/internal/app/characterservice/wallet.go
@@ -39,6 +39,7 @@ func (s *CharacterService) updateWalletJournalEntryESI(ctx context.Context, arg 
 		ctx, arg,
 		func(ctx context.Context, characterID int32) (any, error) {
 			entries, err := xesi.FetchWithPaging(
+				s.concurrencyLimit,
 				func(pageNum int) ([]esi.GetCharactersCharacterIdWalletJournal200Ok, *http.Response, error) {
 					arg := &esi.GetCharactersCharacterIdWalletJournalOpts{
 						Page: esioptional.NewInt32(int32(pageNum)),

--- a/internal/app/corporationservice/industry.go
+++ b/internal/app/corporationservice/industry.go
@@ -45,6 +45,7 @@ func (s *CorporationService) updateIndustryJobsESI(ctx context.Context, arg app.
 		ctx, arg,
 		func(ctx context.Context, arg app.CorporationUpdateSectionParams) (any, error) {
 			jobs, err := xesi.FetchWithPaging(
+				s.concurrencyLimit,
 				func(pageNum int) ([]esi.GetCorporationsCorporationIdIndustryJobs200Ok, *http.Response, error) {
 					return s.esiClient.ESI.IndustryApi.GetCorporationsCorporationIdIndustryJobs(
 						ctx, arg.CorporationID, &esi.GetCorporationsCorporationIdIndustryJobsOpts{

--- a/internal/app/corporationservice/wallet.go
+++ b/internal/app/corporationservice/wallet.go
@@ -205,6 +205,7 @@ func (s *CorporationService) updateWalletJournalESI(ctx context.Context, arg app
 		ctx, arg,
 		func(ctx context.Context, arg app.CorporationUpdateSectionParams) (any, error) {
 			entries, err := xesi.FetchWithPaging(
+				s.concurrencyLimit,
 				func(pageNum int) ([]esi.GetCorporationsCorporationIdWalletsDivisionJournal200Ok, *http.Response, error) {
 					opts := &esi.GetCorporationsCorporationIdWalletsDivisionJournalOpts{
 						Page: esioptional.NewInt32(int32(pageNum)),

--- a/internal/app/eveuniverseservice/character.go
+++ b/internal/app/eveuniverseservice/character.go
@@ -108,6 +108,7 @@ func (s *EveUniverseService) UpdateAllCharactersESI(ctx context.Context) (set.Se
 	ids2 := ids.Slice()
 	hasChanged := make([]bool, len(ids2))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, id := range ids2 {
 		g.Go(func() error {
 			changed, err := s.updateCharacterESI(ctx, id)

--- a/internal/app/eveuniverseservice/location.go
+++ b/internal/app/eveuniverseservice/location.go
@@ -182,6 +182,7 @@ func (s *EveUniverseService) AddMissingLocations(ctx context.Context, ids set.Se
 		return err
 	}
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for id := range missing.All() {
 		g.Go(func() error {
 			_, err := s.GetOrCreateLocationESI(ctx, id)
@@ -207,6 +208,7 @@ func (s *EveUniverseService) EntityIDsFromLocationsESI(ctx context.Context, ids 
 	}
 	entityIDs := make([]int32, len(ids))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, id := range ids {
 		g.Go(func() error {
 			switch app.LocationVariantFromID(id) {

--- a/internal/app/eveuniverseservice/map.go
+++ b/internal/app/eveuniverseservice/map.go
@@ -51,6 +51,7 @@ func (s *EveUniverseService) FetchRoute(ctx context.Context, args app.EveRouteHe
 	}
 	systems := make([]*app.EveSolarSystem, len(ids))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, id := range ids {
 		g.Go(func() error {
 			system, err := s.GetOrCreateSolarSystemESI(ctx, id)
@@ -71,6 +72,7 @@ func (s *EveUniverseService) FetchRoute(ctx context.Context, args app.EveRouteHe
 func (s *EveUniverseService) FetchRoutes(ctx context.Context, headers []app.EveRouteHeader) (map[app.EveRouteHeader][]*app.EveSolarSystem, error) {
 	results := make([][]*app.EveSolarSystem, len(headers))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, h := range headers {
 		g.Go(func() error {
 			route, err := s.FetchRoute(ctx, h)
@@ -94,6 +96,7 @@ func (s *EveUniverseService) FetchRoutes(ctx context.Context, headers []app.EveR
 // GetStargatesSolarSystemsESI fetches and returns the solar systems which relates to given stargates from ESI.
 func (s *EveUniverseService) GetStargatesSolarSystemsESI(ctx context.Context, stargateIDs []int32) ([]*app.EveSolarSystem, error) {
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	systemIDs := make([]int32, len(stargateIDs))
 	for i, id := range stargateIDs {
 		g.Go(func() error {
@@ -109,6 +112,7 @@ func (s *EveUniverseService) GetStargatesSolarSystemsESI(ctx context.Context, st
 		return nil, err
 	}
 	g = new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	systems := make([]*app.EveSolarSystem, len(systemIDs))
 	for i, id := range systemIDs {
 		g.Go(func() error {
@@ -133,6 +137,7 @@ func (s *EveUniverseService) GetStargatesSolarSystemsESI(ctx context.Context, st
 func (s *EveUniverseService) GetSolarSystemPlanets(ctx context.Context, planets []app.EveSolarSystemPlanet) ([]*app.EvePlanet, error) {
 	oo := make([]*app.EvePlanet, len(planets))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, p := range planets {
 		g.Go(func() error {
 			st, err := s.GetOrCreatePlanetESI(ctx, p.PlanetID)
@@ -215,6 +220,7 @@ func (s *EveUniverseService) GetConstellationSolarSystemsESI(ctx context.Context
 		return nil, err
 	}
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	systems := make([]*app.EveSolarSystem, len(o.Systems))
 	for i, id := range o.Systems {
 		g.Go(func() error {

--- a/internal/app/eveuniverseservice/organization.go
+++ b/internal/app/eveuniverseservice/organization.go
@@ -162,6 +162,7 @@ func (s *EveUniverseService) UpdateAllCorporationsESI(ctx context.Context) (set.
 	ids2 := ids.Slice()
 	hasChanged := make([]bool, len(ids2))
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for i, id := range ids2 {
 		g.Go(func() error {
 			c1, err := s.GetEveCorporation(ctx, id)

--- a/internal/app/eveuniverseservice/type.go
+++ b/internal/app/eveuniverseservice/type.go
@@ -210,6 +210,7 @@ func (s *EveUniverseService) AddMissingTypes(ctx context.Context, ids set.Set[in
 	}
 	slog.Debug("Trying to fetch missing EveTypes from ESI", "count", missing.Size())
 	g := new(errgroup.Group)
+	g.SetLimit(s.concurrencyLimit)
 	for id := range missing.All() {
 		g.Go(func() error {
 			_, err := s.GetOrCreateTypeESI(ctx, id)
@@ -231,6 +232,7 @@ func (s *EveUniverseService) UpdateCategoryWithChildrenESI(ctx context.Context, 
 			return nil, err
 		}
 		g := new(errgroup.Group)
+		g.SetLimit(s.concurrencyLimit)
 		for _, id := range category.Groups {
 			g.Go(func() error {
 				_, err := s.GetOrCreateGroupESI(ctx, id)
@@ -242,6 +244,7 @@ func (s *EveUniverseService) UpdateCategoryWithChildrenESI(ctx context.Context, 
 		}
 		groupTypes := make([][]int32, len(category.Groups))
 		g = new(errgroup.Group)
+		g.SetLimit(s.concurrencyLimit)
 		for i, id := range category.Groups {
 			g.Go(func() error {
 				group, _, err := s.esiClient.ESI.UniverseApi.GetUniverseGroupsGroupId(ctx, id, nil)

--- a/internal/xesi/xesi.go
+++ b/internal/xesi/xesi.go
@@ -11,7 +11,7 @@ import (
 
 // FetchWithPaging returns the combined list of items from all pages of an ESI endpoint.
 // This only works for ESI endpoints which support the X-Pages pattern and return a list.
-func FetchWithPaging[T any](fetch func(int) ([]T, *http.Response, error)) ([]T, error) {
+func FetchWithPaging[T any](concurrencyLimit int, fetch func(int) ([]T, *http.Response, error)) ([]T, error) {
 	result, r, err := fetch(1)
 	if err != nil {
 		return nil, err
@@ -26,6 +26,7 @@ func FetchWithPaging[T any](fetch func(int) ([]T, *http.Response, error)) ([]T, 
 	results := make([][]T, pages)
 	results[0] = result
 	g := new(errgroup.Group)
+	g.SetLimit(concurrencyLimit)
 	for p := 2; p <= pages; p++ {
 		p := p
 		g.Go(func() error {

--- a/internal/xesi/xesi_test.go
+++ b/internal/xesi/xesi_test.go
@@ -69,13 +69,12 @@ func TestFetchFromESIWithPaging(t *testing.T) {
 				},
 			}).HeaderSet(http.Header{"X-Pages": []string{pages}}))
 		// when
-		xx, err := FetchWithPaging(
-			func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
-				arg := &esi.GetCharactersCharacterIdAssetsOpts{
-					Page: esioptional.NewInt32(int32(pageNum)),
-				}
-				return client.ESI.AssetsApi.GetCharactersCharacterIdAssets(ctx, 99, arg)
-			})
+		xx, err := FetchWithPaging(-1, func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
+			arg := &esi.GetCharactersCharacterIdAssetsOpts{
+				Page: esioptional.NewInt32(int32(pageNum)),
+			}
+			return client.ESI.AssetsApi.GetCharactersCharacterIdAssets(ctx, 99, arg)
+		})
 		// then
 		if assert.NoError(t, err) {
 			assert.Len(t, xx, 3)
@@ -107,7 +106,7 @@ func TestFetchFromESIWithPaging(t *testing.T) {
 				},
 			}).HeaderSet(http.Header{"X-Pages": []string{pages}}))
 		// when
-		xx, err := FetchWithPaging(
+		xx, err := FetchWithPaging(-1,
 			func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
 				arg := &esi.GetCharactersCharacterIdAssetsOpts{
 					Page: esioptional.NewInt32(int32(pageNum)),
@@ -138,7 +137,7 @@ func TestFetchFromESIWithPaging(t *testing.T) {
 				},
 			}))
 		// when
-		xx, err := FetchWithPaging(
+		xx, err := FetchWithPaging(-1,
 			func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
 				arg := &esi.GetCharactersCharacterIdAssetsOpts{
 					Page: esioptional.NewInt32(int32(pageNum)),
@@ -154,7 +153,7 @@ func TestFetchFromESIWithPaging(t *testing.T) {
 		// given
 		myErr := errors.New("error")
 		// when
-		_, err := FetchWithPaging(
+		_, err := FetchWithPaging(-1,
 			func(pageNum int) ([]int, *http.Response, error) {
 				return nil, nil, myErr
 			})
@@ -169,7 +168,7 @@ func TestFetchFromESIWithPaging(t *testing.T) {
 			"https://esi.evetech.net/v4/characters/99/assets/",
 			httpmock.NewJsonResponderOrPanic(200, []map[string]any{}).HeaderSet(http.Header{"X-Pages": []string{"invalid"}}))
 		// when
-		_, err := FetchWithPaging(
+		_, err := FetchWithPaging(-1,
 			func(pageNum int) ([]esi.GetCharactersCharacterIdAssets200Ok, *http.Response, error) {
 				arg := &esi.GetCharactersCharacterIdAssetsOpts{
 					Page: esioptional.NewInt32(int32(pageNum)),


### PR DESCRIPTION
Currently the CPU usage may spike to 100% during heavy updates. This can be a problem for example on Windows which may look like a temporary freeze to the user.

With this change the maximum CPU usage is further curtailed by limiting the maximum number of Goroutines per group. In our tests this will significantly reduce CPU usage spikes.