### PR TITLE
feat: add support for back gesture on Android (#282)

### DIFF
--- a/internal/app/ui/infowindow.go
+++ b/internal/app/ui/infowindow.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/mobile"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -168,6 +169,13 @@ func (iw *infoWindow) showWithCharacterID(v infoVariant, entityID int64, charact
 				f()
 			}
 		})
+		if fyne.CurrentDevice().IsMobile() {
+			w.Canvas().SetOnTypedKey(func(ev *fyne.KeyEvent) {
+				if ev.Name == mobile.KeyBack {
+					iw.nav.Pop()
+				}
+			})
+		}
 		w.Show()
 	} else {
 		iw.nav.Push(ab)

--- a/internal/app/ui/mobileui.go
+++ b/internal/app/ui/mobileui.go
@@ -9,6 +9,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/mobile"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -421,6 +422,29 @@ func NewMobileUI(bu *baseUI) *MobileUI {
 	searchNav.NavBar = navBar
 
 	u.snackbar.Bottom = 90
+
+	w := u.MainWindow()
+	w.Canvas().SetOnTypedKey(func(ev *fyne.KeyEvent) {
+		if ev.Name != mobile.KeyBack {
+			return
+		}
+		id, ok := navBar.Selected()
+		if !ok {
+			return
+		}
+		switch id {
+		case 0:
+			homeNav.Pop()
+		case 1:
+			characterNav.Pop()
+		case 2:
+			corpNav.Pop()
+		case 3:
+			searchNav.Pop()
+		case 4:
+			moreNav.Pop()
+		}
+	})
 
 	// initial state
 	navBar.Disable(0)

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/driver/mobile"
 
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -1217,6 +1218,14 @@ func (u *baseUI) getOrCreateWindowWithOnClosed(id string, titles ...string) (win
 	}
 	w = u.App().NewWindow(u.makeWindowTitle(titles...))
 	u.windows[id] = w
+	if fyne.CurrentDevice().IsMobile() {
+		w.Canvas().SetOnTypedKey(func(ev *fyne.KeyEvent) {
+			if ev.Name != mobile.KeyBack {
+				return
+			}
+			// Back gesture does nothing
+		})
+	}
 	f := func() {
 		delete(u.windows, id)
 	}


### PR DESCRIPTION
Adds support for back gesture on Android:
- Main pages, e.g. Character / Mail: Goes back to previous back
- Info window: Goes back to previous entity
- Other windows: Does nothing

Resolves #282 