### PR TITLE
fix: dont try to create npc corp for character

### DIFF
--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/statuscacheservice"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/set"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 type CharacterService interface {
@@ -151,6 +152,9 @@ func (s *CorporationService) UpdateCorporations(ctx context.Context) (bool, erro
 	if err != nil {
 		return false, wrapErr(err)
 	}
+	valid = set.Collect(xiter.Filter(valid.All(), func(id int32) bool {
+		return !app.IsNPCCorporation(id)
+	}))
 	obsolete := set.Difference(current, valid)
 	if obsolete.Size() > 0 {
 		for id := range obsolete.All() {

--- a/internal/app/eveentity.go
+++ b/internal/app/eveentity.go
@@ -41,9 +41,9 @@ func (ee EveEntity) IsCharacter() bool {
 func (ee EveEntity) IsNPC() optional.Optional[bool] {
 	switch ee.Category {
 	case EveEntityCharacter:
-		return optional.New(ee.ID >= npcCharacterIDBegin && ee.ID < npcCharacterIDEnd)
+		return optional.New(IsNPCCharacter(ee.ID))
 	case EveEntityCorporation:
-		return optional.New(ee.ID >= npcCorporationIDBegin && ee.ID < npcCorporationIDEnd)
+		return optional.New(IsNPCCorporation(ee.ID))
 	}
 	return optional.Optional[bool]{}
 }
@@ -104,4 +104,20 @@ func (eec EveEntityCategory) String() string {
 	default:
 		return "?"
 	}
+}
+
+// IsNPCCharacter reports whether an entity ID represents a NPC character.
+func IsNPCCharacter(id int32) bool {
+	if id >= npcCharacterIDBegin && id < npcCharacterIDEnd {
+		return true
+	}
+	return false
+}
+
+// IsNPCCorporation reports whether an entity ID represents a NPC corporation.
+func IsNPCCorporation(id int32) bool {
+	if id >= npcCorporationIDBegin && id < npcCorporationIDEnd {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
`CorporationService.UpdateCorporations()`  was trying to create missing corporations for characters even when they were NPC