### PR TITLE
fix: crash when showing unknown structure

### DIFF
--- a/internal/app/evelocation.go
+++ b/internal/app/evelocation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2/widget"
+
 	"github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	iwidget "github.com/ErikKalkoken/evebuddy/internal/widget"

--- a/internal/app/ui/infowindow_internal_test.go
+++ b/internal/app/ui/infowindow_internal_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+)
+
+func TestInfoWindow_CanRenderLocationInfo(t *testing.T) {
+	test.ApplyTheme(t, test.Theme())
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	u := MakeFakeBaseUI(st, test.NewTempApp(t), true)
+
+	t.Run("can render full location", func(t *testing.T) {
+		l := factory.CreateEveLocationStation()
+		iw := newInfoWindow(u)
+		a := newLocationInfo(iw, l.ID)
+		a.update()
+		test.RenderObjectToMarkup(a)
+	})
+	t.Run("can render minimal location", func(t *testing.T) {
+		l := factory.CreateEveLocationEmptyStructure()
+		iw := newInfoWindow(u)
+		a := newLocationInfo(iw, l.ID)
+		a.update()
+		test.RenderObjectToMarkup(a)
+	})
+}


### PR DESCRIPTION
Fix for:

When trying to open an info window for an unknown location the app crashes. Example crash report:

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11f407d]

goroutine 3110 [running]:
github.com/ErikKalkoken/evebuddy/internal/app/ui.(*locationInfo).update.func1()
	github.com/ErikKalkoken/evebuddy/internal/app/ui/infowindow.go:1244 +0x3d
golang.org/x/sync/errgroup.(*Group).Go.func1()
	golang.org/x/sync@v0.18.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 3123
	golang.org/x/sync@v0.18.0/errgroup/errgroup.go:78 +0x95
```