### PR TITLE
fix: update status

### DIFF
--- a/internal/app/eveuniverseservice/type.go
+++ b/internal/app/eveuniverseservice/type.go
@@ -442,10 +442,16 @@ func (s *EveUniverseService) MarketPrice(ctx context.Context, typeID int64) (opt
 
 // TODO: Change to bulk create
 
+// updateMarketPricesESI updates all market prices from ESI and reports which have changed.
+// Will only reports changes on prices for known types.
 func (s *EveUniverseService) updateMarketPricesESI(ctx context.Context) (set.Set[int64], error) {
 	x, err, _ := s.sfg.Do("updateMarketPricesESI", func() (any, error) {
 		var changed set.Set[int64]
 		prices, _, err := s.esiClient.MarketAPI.GetMarketsPrices(ctx).Execute()
+		if err != nil {
+			return changed, err
+		}
+		knownTypes, err := s.ListEveTypeIDs(ctx)
 		if err != nil {
 			return changed, err
 		}
@@ -454,19 +460,19 @@ func (s *EveUniverseService) updateMarketPricesESI(ctx context.Context) (set.Set
 			if err != nil && !errors.Is(err, app.ErrNotFound) {
 				return changed, err
 			}
-			arg := storage.UpdateOrCreateEveMarketPriceParams{
+			o2, err := s.st.UpdateOrCreateEveMarketPrice(ctx, storage.UpdateOrCreateEveMarketPriceParams{
 				TypeID:        p.TypeId,
 				AdjustedPrice: optional.FromPtr(p.AdjustedPrice),
 				AveragePrice:  optional.FromPtr(p.AveragePrice),
-			}
-			o2, err := s.st.UpdateOrCreateEveMarketPrice(ctx, arg)
+			})
 			if err != nil {
 				return changed, err
 			}
-			if o1 == nil || !o2.Equal(*o1) {
+			if knownTypes.Contains(p.TypeId) && (o1 == nil || !o2.Equal(*o1)) {
 				changed.Add(o2.TypeID)
 			}
 		}
+
 		slog.Info("Updated market prices", "total", len(prices), "changed", changed.Size())
 		return changed, nil
 	})

--- a/internal/app/eveuniverseservice/type.go
+++ b/internal/app/eveuniverseservice/type.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/dustin/go-humanize"
+	"github.com/fnt-eve/goesi-openapi/esi"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 func eveEntityCategoryFromESICategory(c string) app.EveEntityCategory {
@@ -446,19 +448,19 @@ func (s *EveUniverseService) MarketPrice(ctx context.Context, typeID int64) (opt
 // Will only reports changes on prices for known types.
 func (s *EveUniverseService) updateMarketPricesESI(ctx context.Context) (set.Set[int64], error) {
 	x, err, _ := s.sfg.Do("updateMarketPricesESI", func() (any, error) {
-		var changed set.Set[int64]
 		prices, _, err := s.esiClient.MarketAPI.GetMarketsPrices(ctx).Execute()
 		if err != nil {
-			return changed, err
+			return set.Set[int64]{}, err
 		}
 		knownTypes, err := s.ListEveTypeIDs(ctx)
 		if err != nil {
-			return changed, err
+			return set.Set[int64]{}, err
 		}
+		var changed set.Set[int64]
 		for _, p := range prices {
 			o1, err := s.st.GetEveMarketPrice(ctx, p.TypeId)
 			if err != nil && !errors.Is(err, app.ErrNotFound) {
-				return changed, err
+				return set.Set[int64]{}, err
 			}
 			o2, err := s.st.UpdateOrCreateEveMarketPrice(ctx, storage.UpdateOrCreateEveMarketPriceParams{
 				TypeID:        p.TypeId,
@@ -466,14 +468,29 @@ func (s *EveUniverseService) updateMarketPricesESI(ctx context.Context) (set.Set
 				AveragePrice:  optional.FromPtr(p.AveragePrice),
 			})
 			if err != nil {
-				return changed, err
+				return set.Set[int64]{}, err
 			}
 			if knownTypes.Contains(p.TypeId) && (o1 == nil || !o2.Equal(*o1)) {
 				changed.Add(o2.TypeID)
 			}
 		}
-
-		slog.Info("Updated market prices", "total", len(prices), "changed", changed.Size())
+		slog.Info("Updated market prices", "count", len(prices), "changed", changed.Size())
+		// remove obsolete prices
+		incoming := set.Collect(xiter.MapSlice(prices, func(x esi.MarketsPricesGetInner) int64 {
+			return x.TypeId
+		}))
+		current, err := s.st.ListEveMarketPriceIDs(ctx)
+		if err != nil {
+			return set.Set[int64]{}, err
+		}
+		obsolete := set.Difference(current, incoming)
+		if obsolete.Size() > 0 {
+			err := s.st.DeleteEveMarketPrices(ctx, obsolete)
+			if err != nil {
+				return set.Set[int64]{}, err
+			}
+			slog.Info("Removed obsolete market prices", "count", obsolete.Size())
+		}
 		return changed, nil
 	})
 	return x.(set.Set[int64]), err

--- a/internal/app/eveuniverseservice/type_internal_test.go
+++ b/internal/app/eveuniverseservice/type_internal_test.go
@@ -52,6 +52,7 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 		require.NoError(t, err)
 		want := set.Of[int64](knownTypeID)
 		xassert.Equal2(t, want, got)
+		// id, err := st.ListMarket
 		o, err := st.GetEveMarketPrice(ctx, knownTypeID)
 		require.NoError(t, err)
 		xassert.Equal(t, 306988.09, o.AdjustedPrice.MustValue())

--- a/internal/app/eveuniverseservice/type_internal_test.go
+++ b/internal/app/eveuniverseservice/type_internal_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -22,38 +22,49 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	s := NewTestService(st)
 	ctx := context.Background()
+	const (
+		knownTypeID = 32772
+		otherTypeID = 10001
+	)
 	t.Run("should create new objects from ESI", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
+		factory.CreateEveType(storage.CreateEveTypeParams{
+			ID: knownTypeID,
+		})
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
 			"https://esi.evetech.net/markets/prices",
-			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
-				{
-					"adjusted_price": 306988.09,
-					"average_price":  306292.67,
-					"type_id":        32772,
-				},
-			}))
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"adjusted_price": 306988.09,
+				"average_price":  306292.67,
+				"type_id":        knownTypeID,
+			}, {
+				"adjusted_price": 123.45,
+				"average_price":  456.78,
+				"type_id":        otherTypeID,
+			}}),
+		)
 		// when
 		got, err := s.updateMarketPricesESI(ctx)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of[int64](32772)
-			xassert.Equal2(t, want, got)
-			o, err := st.GetEveMarketPrice(ctx, 32772)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, 306988.09, o.AdjustedPrice.ValueOrZero())
-				xassert.Equal(t, 306292.67, o.AveragePrice.ValueOrZero())
-			}
-		}
+		require.NoError(t, err)
+		want := set.Of[int64](knownTypeID)
+		xassert.Equal2(t, want, got)
+		o, err := st.GetEveMarketPrice(ctx, knownTypeID)
+		require.NoError(t, err)
+		xassert.Equal(t, 306988.09, o.AdjustedPrice.MustValue())
+		xassert.Equal(t, 306292.67, o.AveragePrice.MustValue())
 	})
 	t.Run("should update existing objects from ESI", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
+		factory.CreateEveType(storage.CreateEveTypeParams{
+			ID: knownTypeID,
+		})
 		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
-			TypeID:        32772,
+			TypeID:        knownTypeID,
 			AdjustedPrice: optional.New(2.0),
 			AveragePrice:  optional.New(3.0),
 		})
@@ -61,31 +72,31 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 		httpmock.RegisterResponder(
 			"GET",
 			"https://esi.evetech.net/markets/prices",
-			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
-				{
-					"adjusted_price": 306988.09,
-					"average_price":  306292.67,
-					"type_id":        32772,
-				},
-			}))
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"adjusted_price": 306988.09,
+				"average_price":  306292.67,
+				"type_id":        knownTypeID,
+			}}),
+		)
 		// when
 		got, err := s.updateMarketPricesESI(ctx)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of[int64](32772)
-			xassert.Equal2(t, want, got)
-			o, err := st.GetEveMarketPrice(ctx, 32772)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, 306988.09, o.AdjustedPrice.ValueOrZero())
-				xassert.Equal(t, 306292.67, o.AveragePrice.ValueOrZero())
-			}
-		}
+		require.NoError(t, err)
+		want := set.Of[int64](knownTypeID)
+		xassert.Equal2(t, want, got)
+		o, err := st.GetEveMarketPrice(ctx, knownTypeID)
+		require.NoError(t, err)
+		xassert.Equal(t, 306988.09, o.AdjustedPrice.ValueOrZero())
+		xassert.Equal(t, 306292.67, o.AveragePrice.ValueOrZero())
 	})
 	t.Run("should detect when object has not changed", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
+		factory.CreateEveType(storage.CreateEveTypeParams{
+			ID: knownTypeID,
+		})
 		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
-			TypeID:        32772,
+			TypeID:        knownTypeID,
 			AdjustedPrice: optional.New(306988.09),
 			AveragePrice:  optional.New(306292.67),
 		})
@@ -93,20 +104,18 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 		httpmock.RegisterResponder(
 			"GET",
 			"https://esi.evetech.net/markets/prices",
-			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
-				{
-					"adjusted_price": 306988.09,
-					"average_price":  306292.67,
-					"type_id":        32772,
-				},
-			}))
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"adjusted_price": 306988.09,
+				"average_price":  306292.67,
+				"type_id":        knownTypeID,
+			}}),
+		)
 		// when
 		got, err := s.updateMarketPricesESI(ctx)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of[int64]()
-			xassert.Equal2(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of[int64]()
+		xassert.Equal2(t, want, got)
 	})
 }
 

--- a/internal/app/eveuniverseservice/type_internal_test.go
+++ b/internal/app/eveuniverseservice/type_internal_test.go
@@ -52,11 +52,19 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 		require.NoError(t, err)
 		want := set.Of[int64](knownTypeID)
 		xassert.Equal2(t, want, got)
-		// id, err := st.ListMarket
-		o, err := st.GetEveMarketPrice(ctx, knownTypeID)
+		prices, err := st.ListEveMarketPrices(ctx)
 		require.NoError(t, err)
-		xassert.Equal(t, 306988.09, o.AdjustedPrice.MustValue())
-		xassert.Equal(t, 306292.67, o.AveragePrice.MustValue())
+		require.Len(t, prices, 2)
+		for _, o := range prices {
+			switch o.TypeID {
+			case knownTypeID:
+				xassert.Equal(t, 306988.09, o.AdjustedPrice.MustValue())
+				xassert.Equal(t, 306292.67, o.AveragePrice.MustValue())
+			case o.TypeID:
+				xassert.Equal(t, 123.45, o.AdjustedPrice.MustValue())
+				xassert.Equal(t, 456.78, o.AveragePrice.MustValue())
+			}
+		}
 	})
 	t.Run("should update existing objects from ESI", func(t *testing.T) {
 		// given
@@ -90,7 +98,7 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 		xassert.Equal(t, 306988.09, o.AdjustedPrice.ValueOrZero())
 		xassert.Equal(t, 306292.67, o.AveragePrice.ValueOrZero())
 	})
-	t.Run("should detect when object has not changed", func(t *testing.T) {
+	t.Run("should only report changes for known types", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		factory.CreateEveType(storage.CreateEveTypeParams{
@@ -100,6 +108,40 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 			TypeID:        knownTypeID,
 			AdjustedPrice: optional.New(306988.09),
 			AveragePrice:  optional.New(306292.67),
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:        otherTypeID,
+			AdjustedPrice: optional.New(111.09),
+			AveragePrice:  optional.New(222.67),
+		})
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://esi.evetech.net/markets/prices",
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"adjusted_price": 306988.09,
+				"average_price":  306292.67,
+				"type_id":        knownTypeID,
+			}, {
+				"adjusted_price": 123.45,
+				"average_price":  456.78,
+				"type_id":        otherTypeID,
+			}}),
+		)
+		// when
+		got, err := s.updateMarketPricesESI(ctx)
+		// then
+		require.NoError(t, err)
+		want := set.Of[int64]()
+		xassert.Equal2(t, want, got)
+	})
+
+	t.Run("should remove obsolete prices", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			AdjustedPrice: optional.New(111.09),
+			AveragePrice:  optional.New(222.67),
 		})
 		httpmock.Reset()
 		httpmock.RegisterResponder(
@@ -112,10 +154,12 @@ func TestUpdateEveMarketPricesESI(t *testing.T) {
 			}}),
 		)
 		// when
-		got, err := s.updateMarketPricesESI(ctx)
+		_, err := s.updateMarketPricesESI(ctx)
 		// then
 		require.NoError(t, err)
-		want := set.Of[int64]()
+		got, err := s.st.ListEveMarketPriceIDs(ctx)
+		require.NoError(t, err)
+		want := set.Of[int64](knownTypeID)
 		xassert.Equal2(t, want, got)
 	})
 }

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -211,7 +212,7 @@ func (st *Storage) listCharacterIDs(ctx context.Context, q *queries.Queries) (se
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("list character IDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 

--- a/internal/app/storage/characterrole.go
+++ b/internal/app/storage/characterrole.go
@@ -78,7 +78,7 @@ func init() {
 }
 
 func (st *Storage) ListCharacterRoles(ctx context.Context, characterID int64) (set.Set[app.Role], error) {
-	s, err := st.qRO.ListCharacterRoles(ctx,characterID)
+	s, err := st.qRO.ListCharacterRoles(ctx, characterID)
 	if err != nil {
 		return set.Set[app.Role]{}, fmt.Errorf("list roles for character %d: %w", characterID, err)
 	}
@@ -90,7 +90,7 @@ func (st *Storage) ListCharacterRoles(ctx context.Context, characterID int64) (s
 
 func (st *Storage) UpdateCharacterRoles(ctx context.Context, characterID int64, roles set.Set[app.Role]) error {
 	incoming := roles2names(roles)
-	s, err := st.qRO.ListCharacterRoles(ctx,characterID)
+	s, err := st.qRO.ListCharacterRoles(ctx, characterID)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (st *Storage) UpdateCharacterRoles(ctx context.Context, characterID int64, 
 	added := set.Difference(incoming, current)
 	for s := range added.All() {
 		arg := queries.CreateCharacterRoleParams{
-			CharacterID:characterID,
+			CharacterID: characterID,
 			Name:        s,
 		}
 		if err := st.qRW.CreateCharacterRole(ctx, arg); err != nil {
@@ -108,7 +108,7 @@ func (st *Storage) UpdateCharacterRoles(ctx context.Context, characterID int64, 
 	removed := set.Difference(current, incoming)
 	for s := range removed.All() {
 		arg := queries.DeleteCharacterRoleParams{
-			CharacterID:characterID,
+			CharacterID: characterID,
 			Name:        s,
 		}
 		if err := st.qRW.DeleteCharacterRole(ctx, arg); err != nil {

--- a/internal/app/storage/corporation.go
+++ b/internal/app/storage/corporation.go
@@ -158,7 +158,7 @@ func (st *Storage) ListCorporationIDs(ctx context.Context) (set.Set[int64], erro
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("list corporation IDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 
@@ -168,7 +168,7 @@ func (st *Storage) ListOrphanedCorporationIDs(ctx context.Context) (set.Set[int6
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("list orphaned corporation IDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 

--- a/internal/app/storage/evecharacter.go
+++ b/internal/app/storage/evecharacter.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -90,7 +91,7 @@ func (st *Storage) ListEveCharacterIDs(ctx context.Context) (set.Set[int64], err
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("list EveCharacterIDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 

--- a/internal/app/storage/evecorporation.go
+++ b/internal/app/storage/evecorporation.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -53,7 +54,7 @@ func (st *Storage) ListEveCorporationIDs(ctx context.Context) (set.Set[int64], e
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("ListEveCorporationIDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 

--- a/internal/app/storage/eveentity.go
+++ b/internal/app/storage/eveentity.go
@@ -141,7 +141,7 @@ func (st *Storage) ListEveEntityIDs(ctx context.Context) (set.Set[int64], error)
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("list eve entity id: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 

--- a/internal/app/storage/evelocation.go
+++ b/internal/app/storage/evelocation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -98,7 +99,7 @@ func (st *Storage) MissingEveLocations(ctx context.Context, ids set.Set[int64]) 
 	if err != nil {
 		return set.Set[int64]{}, err
 	}
-	current := set.Of(currentIDs...)
+	current := set.Collect(slices.Values(currentIDs))
 	missing := set.Difference(ids, current)
 	return missing, nil
 }

--- a/internal/app/storage/evemarketprice.go
+++ b/internal/app/storage/evemarketprice.go
@@ -3,11 +3,18 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
+
+	"github.com/ErikKalkoken/go-set"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage/queries"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 )
+
+func (st *Storage) DeleteEveMarketPrices(ctx context.Context, typeIDs set.Set[int64]) error {
+	return st.qRW.DeleteEveMarketPrices(ctx, slices.Collect(typeIDs.All()))
+}
 
 func (st *Storage) GetEveMarketPrice(ctx context.Context, typeID int64) (*app.EveMarketPrice, error) {
 	wrapErr := func(err error) error {
@@ -33,6 +40,15 @@ func (st *Storage) ListEveMarketPrices(ctx context.Context) ([]*app.EveMarketPri
 		oo = append(oo, eveMarketPriceFromDBModel(r))
 	}
 	return oo, nil
+}
+
+func (st *Storage) ListEveMarketPriceIDs(ctx context.Context) (set.Set[int64], error) {
+	ids, err := st.qRO.ListEveMarketPriceIDs(ctx)
+	if err != nil {
+		return set.Set[int64]{}, fmt.Errorf("ListEveMarketPriceIDs: %w", err)
+	}
+	ids2 := set.Collect(slices.Values(ids))
+	return ids2, nil
 }
 
 type UpdateOrCreateEveMarketPriceParams struct {

--- a/internal/app/storage/evemarketprice.go
+++ b/internal/app/storage/evemarketprice.go
@@ -10,12 +10,29 @@ import (
 )
 
 func (st *Storage) GetEveMarketPrice(ctx context.Context, typeID int64) (*app.EveMarketPrice, error) {
-	row, err := st.qRO.GetEveMarketPrice(ctx,typeID)
-	if err != nil {
-		return nil, fmt.Errorf("get eve market price for type %d: %w", typeID, convertGetError(err))
+	wrapErr := func(err error) error {
+		return fmt.Errorf("GetEveMarketPrice %d: %w", typeID, err)
 	}
-	t2 := eveMarketPriceFromDBModel(row)
-	return t2, nil
+	if typeID == 0 {
+		return nil, wrapErr(app.ErrInvalid)
+	}
+	row, err := st.qRO.GetEveMarketPrice(ctx, typeID)
+	if err != nil {
+		return nil, wrapErr(convertGetError(err))
+	}
+	return eveMarketPriceFromDBModel(row), nil
+}
+
+func (st *Storage) ListEveMarketPrices(ctx context.Context) ([]*app.EveMarketPrice, error) {
+	rows, err := st.qRO.ListEveMarketPrices(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ListEveMarketPrices: %w", err)
+	}
+	oo := make([]*app.EveMarketPrice, 0)
+	for _, r := range rows {
+		oo = append(oo, eveMarketPriceFromDBModel(r))
+	}
+	return oo, nil
 }
 
 type UpdateOrCreateEveMarketPriceParams struct {
@@ -32,7 +49,7 @@ func (st *Storage) UpdateOrCreateEveMarketPrice(ctx context.Context, arg UpdateO
 		return nil, wrapErr(app.ErrInvalid)
 	}
 	r, err := st.qRW.UpdateOrCreateEveMarketPrice(ctx, queries.UpdateOrCreateEveMarketPriceParams{
-		TypeID:       arg.TypeID,
+		TypeID:        arg.TypeID,
 		AdjustedPrice: arg.AdjustedPrice.ValueOrZero(),
 		AveragePrice:  arg.AveragePrice.ValueOrZero(),
 	})
@@ -42,13 +59,11 @@ func (st *Storage) UpdateOrCreateEveMarketPrice(ctx context.Context, arg UpdateO
 	return eveMarketPriceFromDBModel(r), nil
 }
 
-func eveMarketPriceFromDBModel(o queries.EveMarketPrice) *app.EveMarketPrice {
-	if o.TypeID == 0 {
-		panic("missing type ID")
+func eveMarketPriceFromDBModel(r queries.EveMarketPrice) *app.EveMarketPrice {
+	o := &app.EveMarketPrice{
+		TypeID:        r.TypeID,
+		AdjustedPrice: optional.FromZeroValue(r.AdjustedPrice),
+		AveragePrice:  optional.FromZeroValue(r.AveragePrice),
 	}
-	return &app.EveMarketPrice{
-		TypeID:       o.TypeID,
-		AdjustedPrice: optional.FromZeroValue(o.AdjustedPrice),
-		AveragePrice:  optional.FromZeroValue(o.AveragePrice),
-	}
+	return o
 }

--- a/internal/app/storage/evemarketprice_test.go
+++ b/internal/app/storage/evemarketprice_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ErikKalkoken/go-set"
+
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
@@ -14,7 +16,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
-func TestStorage_UpdateOrCreateEveMarketPrice(t *testing.T) {
+func TestStorage_EveMarketPrices(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
@@ -83,5 +85,33 @@ func TestStorage_UpdateOrCreateEveMarketPrice(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []*app.EveMarketPrice{o1, o2}, got)
+	})
+
+	t.Run("can list ids", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o1 := factory.CreateEveMarketPrice()
+		o2 := factory.CreateEveMarketPrice()
+		// when
+		got, err := st.ListEveMarketPriceIDs(ctx)
+		// then
+		require.NoError(t, err)
+		want := set.Of(o1.TypeID, o2.TypeID)
+		xassert.Equal2(t, want, got)
+	})
+
+	t.Run("can delete prices by id", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o1 := factory.CreateEveMarketPrice()
+		o2 := factory.CreateEveMarketPrice()
+		// when
+		err := st.DeleteEveMarketPrices(ctx, set.Of(o2.TypeID))
+		require.NoError(t, err)
+		// then
+		got, err := st.ListEveMarketPriceIDs(ctx)
+		require.NoError(t, err)
+		want := set.Of(o1.TypeID)
+		xassert.Equal2(t, want, got)
 	})
 }

--- a/internal/app/storage/evemarketprice_test.go
+++ b/internal/app/storage/evemarketprice_test.go
@@ -5,33 +5,33 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
-func TestEveMarketPrice(t *testing.T) {
+func TestStorage_UpdateOrCreateEveMarketPrice(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		arg := storage.UpdateOrCreateEveMarketPriceParams{
+		// when
+		x, err := st.UpdateOrCreateEveMarketPrice(ctx, storage.UpdateOrCreateEveMarketPriceParams{
 			TypeID:        42,
 			AdjustedPrice: optional.New(1.23),
 			AveragePrice:  optional.New(4.56),
-		}
-		// when
-		x, err := st.UpdateOrCreateEveMarketPrice(ctx, arg)
+		})
 		// then
-		if assert.NoError(t, err) {
-			xassert.Equal(t, 42, x.TypeID)
-			xassert.Equal(t, 1.23, x.AdjustedPrice.ValueOrZero())
-			xassert.Equal(t, 4.56, x.AveragePrice.ValueOrZero())
-		}
+		require.NoError(t, err)
+		xassert.Equal(t, 42, x.TypeID)
+		xassert.Equal(t, 1.23, x.AdjustedPrice.ValueOrZero())
+		xassert.Equal(t, 4.56, x.AveragePrice.ValueOrZero())
 	})
 	t.Run("can update existing", func(t *testing.T) {
 		// given
@@ -41,18 +41,47 @@ func TestEveMarketPrice(t *testing.T) {
 			AdjustedPrice: optional.New(4.0),
 			AveragePrice:  optional.New(5.0),
 		})
-		arg := storage.UpdateOrCreateEveMarketPriceParams{
+		// when
+		x, err := st.UpdateOrCreateEveMarketPrice(ctx, storage.UpdateOrCreateEveMarketPriceParams{
 			TypeID:        42,
 			AdjustedPrice: optional.New(1.23),
 			AveragePrice:  optional.New(4.56),
-		}
-		// when
-		x, err := st.UpdateOrCreateEveMarketPrice(ctx, arg)
+		})
 		// then
-		if assert.NoError(t, err) {
-			xassert.Equal(t, 42, x.TypeID)
-			xassert.Equal(t, 1.23, x.AdjustedPrice.ValueOrZero())
-			xassert.Equal(t, 4.56, x.AveragePrice.ValueOrZero())
-		}
+		require.NoError(t, err)
+		xassert.Equal(t, 42, x.TypeID)
+		xassert.Equal(t, 1.23, x.AdjustedPrice.ValueOrZero())
+		xassert.Equal(t, 4.56, x.AveragePrice.ValueOrZero())
+	})
+
+	t.Run("can fetch existing", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		x := factory.CreateEveMarketPrice()
+		// when
+		got, err := st.GetEveMarketPrice(ctx, x.TypeID)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, x, got)
+	})
+	t.Run("should return not found when price does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := st.GetEveMarketPrice(ctx, 42)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+
+	t.Run("can list prices", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o1 := factory.CreateEveMarketPrice()
+		o2 := factory.CreateEveMarketPrice()
+		// when
+		got, err := st.ListEveMarketPrices(ctx)
+		// then
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*app.EveMarketPrice{o1, o2}, got)
 	})
 }

--- a/internal/app/storage/everegion.go
+++ b/internal/app/storage/everegion.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ErikKalkoken/go-set"
 
@@ -62,7 +63,7 @@ func (st *Storage) MissingEveRegions(ctx context.Context, ids set.Set[int64]) (s
 	if err != nil {
 		return set.Set[int64]{}, err
 	}
-	current := set.Of(currentIDs...)
+	current := set.Collect(slices.Values(currentIDs))
 	missing := set.Difference(ids, current)
 	return missing, nil
 }

--- a/internal/app/storage/evesolarsystem.go
+++ b/internal/app/storage/evesolarsystem.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ErikKalkoken/go-set"
 
@@ -65,7 +66,7 @@ func (st *Storage) MissingEveSolarSystems(ctx context.Context, ids set.Set[int64
 	if err != nil {
 		return set.Set[int64]{}, err
 	}
-	current := set.Of(currentIDs...)
+	current := set.Collect(slices.Values(currentIDs))
 	missing := set.Difference(ids, current)
 	return missing, nil
 }

--- a/internal/app/storage/evetype.go
+++ b/internal/app/storage/evetype.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ErikKalkoken/go-set"
 
@@ -143,7 +144,7 @@ func (st *Storage) ListEveTypeIDs(ctx context.Context) (set.Set[int64], error) {
 	if err != nil {
 		return set.Set[int64]{}, fmt.Errorf("ListEveTypeIDs: %w", err)
 	}
-	ids2 := set.Of(ids...)
+	ids2 := set.Collect(slices.Values(ids))
 	return ids2, nil
 }
 
@@ -152,7 +153,7 @@ func (st *Storage) MissingEveTypes(ctx context.Context, ids set.Set[int64]) (set
 	if err != nil {
 		return set.Set[int64]{}, err
 	}
-	current := set.Of(currentIDs...)
+	current := set.Collect(slices.Values(currentIDs))
 	missing := set.Difference(ids, current)
 	return missing, nil
 }

--- a/internal/app/storage/queries/eve_market_prices.sql
+++ b/internal/app/storage/queries/eve_market_prices.sql
@@ -6,7 +6,7 @@ FROM
 WHERE
     type_id = ?;
 
--- name: ListEveMarketPrices :one
+-- name: ListEveMarketPrices :many
 SELECT
     *
 FROM

--- a/internal/app/storage/queries/eve_market_prices.sql
+++ b/internal/app/storage/queries/eve_market_prices.sql
@@ -1,3 +1,8 @@
+-- name: DeleteEveMarketPrices :exec
+DELETE FROM eve_market_prices
+WHERE
+    type_id IN (sqlc.slice('type_ids'));
+
 -- name: GetEveMarketPrice :one
 SELECT
     *
@@ -12,6 +17,12 @@ SELECT
 FROM
     eve_market_prices;
 
+-- name: ListEveMarketPriceIDs :many
+SELECT
+    type_id
+FROM
+    eve_market_prices;
+
 -- name: UpdateOrCreateEveMarketPrice :one
 INSERT INTO
     eve_market_prices (type_id, adjusted_price, average_price)
@@ -20,4 +31,6 @@ VALUES
 ON CONFLICT (type_id) DO UPDATE
 SET
     adjusted_price = ?2,
-    average_price = ?3 RETURNING *;
+    average_price = ?3
+RETURNING
+    *;

--- a/internal/app/storage/queries/eve_market_prices.sql.go
+++ b/internal/app/storage/queries/eve_market_prices.sql.go
@@ -7,7 +7,29 @@ package queries
 
 import (
 	"context"
+	"strings"
 )
+
+const deleteEveMarketPrices = `-- name: DeleteEveMarketPrices :exec
+DELETE FROM eve_market_prices
+WHERE
+    type_id IN (/*SLICE:type_ids*/?)
+`
+
+func (q *Queries) DeleteEveMarketPrices(ctx context.Context, typeIds []int64) error {
+	query := deleteEveMarketPrices
+	var queryParams []interface{}
+	if len(typeIds) > 0 {
+		for _, v := range typeIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:type_ids*/?", strings.Repeat(",?", len(typeIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:type_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
 
 const getEveMarketPrice = `-- name: GetEveMarketPrice :one
 SELECT
@@ -23,6 +45,36 @@ func (q *Queries) GetEveMarketPrice(ctx context.Context, typeID int64) (EveMarke
 	var i EveMarketPrice
 	err := row.Scan(&i.TypeID, &i.AdjustedPrice, &i.AveragePrice)
 	return i, err
+}
+
+const listEveMarketPriceIDs = `-- name: ListEveMarketPriceIDs :many
+SELECT
+    type_id
+FROM
+    eve_market_prices
+`
+
+func (q *Queries) ListEveMarketPriceIDs(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, listEveMarketPriceIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var type_id int64
+		if err := rows.Scan(&type_id); err != nil {
+			return nil, err
+		}
+		items = append(items, type_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listEveMarketPrices = `-- name: ListEveMarketPrices :many
@@ -63,7 +115,9 @@ VALUES
 ON CONFLICT (type_id) DO UPDATE
 SET
     adjusted_price = ?2,
-    average_price = ?3 RETURNING type_id, adjusted_price, average_price
+    average_price = ?3
+RETURNING
+    type_id, adjusted_price, average_price
 `
 
 type UpdateOrCreateEveMarketPriceParams struct {

--- a/internal/app/storage/queries/eve_market_prices.sql.go
+++ b/internal/app/storage/queries/eve_market_prices.sql.go
@@ -25,18 +25,34 @@ func (q *Queries) GetEveMarketPrice(ctx context.Context, typeID int64) (EveMarke
 	return i, err
 }
 
-const listEveMarketPrices = `-- name: ListEveMarketPrices :one
+const listEveMarketPrices = `-- name: ListEveMarketPrices :many
 SELECT
     type_id, adjusted_price, average_price
 FROM
     eve_market_prices
 `
 
-func (q *Queries) ListEveMarketPrices(ctx context.Context) (EveMarketPrice, error) {
-	row := q.db.QueryRowContext(ctx, listEveMarketPrices)
-	var i EveMarketPrice
-	err := row.Scan(&i.TypeID, &i.AdjustedPrice, &i.AveragePrice)
-	return i, err
+func (q *Queries) ListEveMarketPrices(ctx context.Context) ([]EveMarketPrice, error) {
+	rows, err := q.db.QueryContext(ctx, listEveMarketPrices)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []EveMarketPrice
+	for rows.Next() {
+		var i EveMarketPrice
+		if err := rows.Scan(&i.TypeID, &i.AdjustedPrice, &i.AveragePrice); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const updateOrCreateEveMarketPrice = `-- name: UpdateOrCreateEveMarketPrice :one

--- a/internal/app/testutil/factory.go
+++ b/internal/app/testutil/factory.go
@@ -2519,7 +2519,7 @@ func (f Factory) CreateEveMarketPrice(args ...storage.UpdateOrCreateEveMarketPri
 		arg = args[0]
 	}
 	if arg.TypeID == 0 {
-		arg.TypeID = int64(f.calcNewID("eve_market_price", "type_id", 1))
+		arg.TypeID = int64(f.calcNewID("eve_market_prices", "type_id", 1))
 	}
 	if arg.AdjustedPrice.IsEmpty() {
 		arg.AdjustedPrice.Set(rand.Float64() * 100_000)

--- a/internal/app/ui/characterskillqueue.go
+++ b/internal/app/ui/characterskillqueue.go
@@ -50,7 +50,7 @@ func newCharacterSkillQueueWithCharacter(u *baseUI, c *app.Character) *character
 	a := &characterSkillQueue{
 		emptyInfo:            emptyInfo,
 		showCurrentCharacter: c == nil,
-		signalKey:            generateUniqueID(),
+		signalKey:            "characterSkillQueue-" + uniqueID(),
 		skillqueue:           app.NewCharacterSkillqueue(),
 		statusResource:       statusResources,
 		status:               ttwidget.NewIcon(theme.NewDisabledResource(statusResources)),

--- a/internal/app/ui/helper.go
+++ b/internal/app/ui/helper.go
@@ -1,11 +1,10 @@
 package ui
 
 import (
-	"crypto/rand"
 	"fmt"
 	"image/color"
 	"math"
-	"math/big"
+	"math/rand/v2"
 	"slices"
 	"time"
 
@@ -232,9 +231,9 @@ func corporationNameOrZero(c *app.Corporation) string {
 	return c.EveCorporation.Name
 }
 
-// generateUniqueID returns a unique ID.
-func generateUniqueID() string {
+// uniqueID returns a pseudo unique ID.
+func uniqueID() string {
 	currentTime := time.Now().UnixNano()
-	randomNumber, _ := rand.Int(rand.Reader, big.NewInt(1000000))
+	randomNumber := rand.Uint64()
 	return fmt.Sprintf("%d-%d", currentTime, randomNumber)
 }

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -102,8 +102,9 @@ type corporationSectionUpdated struct {
 }
 
 type generalSectionUpdated struct {
-	changed set.Set[int64]
-	section app.GeneralSection
+	changed      set.Set[int64]
+	section      app.GeneralSection
+	needsRefresh bool
 }
 
 // baseUI represents the core UI logic and is used by both the desktop and mobile UI.

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -98,6 +98,7 @@ type characterSectionUpdated struct {
 type corporationSectionUpdated struct {
 	corporationID int64
 	section       app.CorporationSection
+	needsRefresh  bool
 }
 
 type generalSectionUpdated struct {
@@ -184,10 +185,14 @@ type baseUI struct {
 	currentCorporationExchanged signals.Signal[*app.Corporation]
 	// A corporation has been added or removed.
 	corporationsChanged signals.Signal[struct{}]
-	// A character section has changed after an update from ESI.
+	// A corporation section has changed after an update from ESI.
 	corporationSectionChanged signals.Signal[corporationSectionUpdated]
+	// A corporation section has been updated from ESI.
+	corporationSectionUpdated signals.Signal[corporationSectionUpdated]
 	// A general section has changed after an update from ESI.
 	generalSectionChanged signals.Signal[generalSectionUpdated]
+	// A general section has been updated after an update from ESI.
+	generalSectionUpdated signals.Signal[generalSectionUpdated]
 	// Ticker for dynamic UI refresh has expired.
 	refreshTickerExpired signals.Signal[struct{}]
 	// A tag as been added, removed or renamed.
@@ -212,9 +217,9 @@ type baseUI struct {
 	corporation        atomic.Pointer[app.Corporation]
 	dataPaths          xmaps.OrderedMap[string, string] // Paths to user data
 	defaultTheme       fyne.Theme
-	isMobile           bool        // whether Fyne has detected the app running on a mobile. Else we assume it's a desktop.
 	isFakeMobile       bool        // Show mobile variant on a desktop (for development)
 	isForeground       atomic.Bool // whether the app is currently shown in the foreground
+	isMobile           bool        // whether Fyne has detected the app running on a mobile. Else we assume it's a desktop.
 	isOffline          bool        // Run the app in offline mode
 	isStartupCompleted atomic.Bool // whether the app has completed startup (for testing)
 	isUpdateDisabled   bool        // Whether to disable update tickers (useful for debugging)
@@ -257,6 +262,7 @@ func NewBaseUI(arg BaseUIParams) *baseUI {
 		concurrencyLimit:            -1, // Default is no limit
 		corporationsChanged:         signals.New[struct{}](),
 		corporationSectionChanged:   signals.New[corporationSectionUpdated](),
+		corporationSectionUpdated:   signals.New[corporationSectionUpdated](),
 		corporationWallets:          make(map[app.Division]*corporationWallet),
 		cs:                          arg.CharacterService,
 		currentCharacterExchanged:   signals.New[*app.Character](),
@@ -265,8 +271,9 @@ func NewBaseUI(arg BaseUIParams) *baseUI {
 		ess:                         arg.ESIStatusService,
 		eus:                         arg.EveUniverseService,
 		generalSectionChanged:       signals.New[generalSectionUpdated](),
-		isMobile:                    arg.IsMobile,
+		generalSectionUpdated:       signals.New[generalSectionUpdated](),
 		isFakeMobile:                arg.IsFakeMobile,
+		isMobile:                    arg.IsMobile,
 		isOffline:                   arg.IsOffline,
 		isUpdateDisabled:            arg.IsUpdateDisabled,
 		js:                          arg.JaniceService,

--- a/internal/app/ui/updatestatus.go
+++ b/internal/app/ui/updatestatus.go
@@ -72,7 +72,7 @@ func showUpdateStatusWindow(u *baseUI) {
 		return
 	}
 	a := newUpdateStatus(u)
-	a.update()
+	a.update(context.Background())
 	w.SetContent(a)
 	w.Resize(fyne.Size{Width: 1100, Height: 500})
 	w.SetOnClosed(func() {
@@ -135,20 +135,20 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 	}
 
 	// Signals
-	a.u.characterAdded.AddListener(func(_ context.Context, _ *app.Character) {
-		a.update()
+	a.u.characterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
+		a.update(ctx)
 	}, a.signalKey)
-	a.u.characterRemoved.AddListener(func(_ context.Context, _ *app.EntityShort[int64]) {
-		a.update()
+	a.u.characterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort[int64]) {
+		a.update(ctx)
 	}, a.signalKey)
-	a.u.characterSectionUpdated.AddListener(func(_ context.Context, arg characterSectionUpdated) {
-		a.update()
+	a.u.characterSectionUpdated.AddListener(func(ctx context.Context, arg characterSectionUpdated) {
+		a.update(ctx)
 	}, a.signalKey)
-	a.u.corporationSectionUpdated.AddListener(func(_ context.Context, arg corporationSectionUpdated) {
-		a.update()
+	a.u.corporationSectionUpdated.AddListener(func(ctx context.Context, arg corporationSectionUpdated) {
+		a.update(ctx)
 	}, a.signalKey)
-	a.u.generalSectionChanged.AddListener(func(_ context.Context, arg generalSectionUpdated) {
-		a.update()
+	a.u.generalSectionUpdated.AddListener(func(ctx context.Context, arg generalSectionUpdated) {
+		a.update(ctx)
 	}, a.signalKey)
 	return a
 }
@@ -158,7 +158,7 @@ func (a *updateStatus) stop() {
 	a.u.characterRemoved.RemoveListener(a.signalKey)
 	a.u.characterSectionUpdated.RemoveListener(a.signalKey)
 	a.u.corporationSectionUpdated.RemoveListener(a.signalKey)
-	a.u.generalSectionChanged.RemoveListener(a.signalKey)
+	a.u.generalSectionUpdated.RemoveListener(a.signalKey)
 }
 
 func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {
@@ -312,8 +312,8 @@ func (a *updateStatus) makeUpdateAllAction() func() {
 	}
 }
 
-func (a *updateStatus) update() {
-	entities, count := a.updateEntityList(a.u.services())
+func (a *updateStatus) update(ctx context.Context) {
+	entities, count := a.updateEntityList(ctx, a.u.services())
 
 	fyne.Do(func() {
 		a.sectionEntities = entities
@@ -324,7 +324,7 @@ func (a *updateStatus) update() {
 	})
 }
 
-func (*updateStatus) updateEntityList(s services) ([]sectionEntity, int) {
+func (*updateStatus) updateEntityList(_ context.Context, s services) ([]sectionEntity, int) {
 	var count int
 	entities := make([]sectionEntity, 0)
 	cc := s.scs.ListCharacters()

--- a/internal/app/ui/updatestatus.go
+++ b/internal/app/ui/updatestatus.go
@@ -144,7 +144,7 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 	a.u.characterSectionUpdated.AddListener(func(_ context.Context, arg characterSectionUpdated) {
 		a.update()
 	}, a.signalKey)
-	a.u.corporationSectionChanged.AddListener(func(_ context.Context, arg corporationSectionUpdated) {
+	a.u.corporationSectionUpdated.AddListener(func(_ context.Context, arg corporationSectionUpdated) {
 		a.update()
 	}, a.signalKey)
 	a.u.generalSectionChanged.AddListener(func(_ context.Context, arg generalSectionUpdated) {
@@ -157,7 +157,7 @@ func (a *updateStatus) stop() {
 	a.u.characterAdded.RemoveListener(a.signalKey)
 	a.u.characterRemoved.RemoveListener(a.signalKey)
 	a.u.characterSectionUpdated.RemoveListener(a.signalKey)
-	a.u.corporationSectionChanged.RemoveListener(a.signalKey)
+	a.u.corporationSectionUpdated.RemoveListener(a.signalKey)
 	a.u.generalSectionChanged.RemoveListener(a.signalKey)
 }
 

--- a/internal/app/ui/updatestatus.go
+++ b/internal/app/ui/updatestatus.go
@@ -57,6 +57,7 @@ type updateStatus struct {
 	sectionsTop       *widget.Label
 	selectedEntityID  int
 	selectedSectionID int
+	signalKey         string
 	top2              fyne.CanvasObject
 	top3              fyne.CanvasObject
 	u                 *baseUI
@@ -65,7 +66,7 @@ type updateStatus struct {
 }
 
 func showUpdateStatusWindow(u *baseUI) {
-	w, ok := u.getOrCreateWindow("update-status", "Update Status")
+	w, ok, onClosed := u.getOrCreateWindowWithOnClosed("update-status", "Update Status")
 	if !ok {
 		w.Show()
 		return
@@ -74,6 +75,10 @@ func showUpdateStatusWindow(u *baseUI) {
 	a.update()
 	w.SetContent(a)
 	w.Resize(fyne.Size{Width: 1100, Height: 500})
+	w.SetOnClosed(func() {
+		a.stop()
+		onClosed()
+	})
 	w.Show()
 }
 
@@ -87,6 +92,7 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 		sectionsTop:       makeTopLabel(),
 		selectedEntityID:  -1,
 		selectedSectionID: -1,
+		signalKey:         "updateStatus-" + uniqueID(),
 		u:                 u,
 	}
 	a.ExtendBaseWidget(a)
@@ -129,23 +135,30 @@ func newUpdateStatus(u *baseUI) *updateStatus {
 	}
 
 	// Signals
-	a.u.corporationSectionChanged.AddListener(func(_ context.Context, arg corporationSectionUpdated) {
-		a.update()
-	})
-
-	a.u.characterSectionUpdated.AddListener(func(_ context.Context, arg characterSectionUpdated) {
-		a.update()
-	})
 	a.u.characterAdded.AddListener(func(_ context.Context, _ *app.Character) {
 		a.update()
-	})
+	}, a.signalKey)
 	a.u.characterRemoved.AddListener(func(_ context.Context, _ *app.EntityShort[int64]) {
 		a.update()
-	})
+	}, a.signalKey)
+	a.u.characterSectionUpdated.AddListener(func(_ context.Context, arg characterSectionUpdated) {
+		a.update()
+	}, a.signalKey)
+	a.u.corporationSectionChanged.AddListener(func(_ context.Context, arg corporationSectionUpdated) {
+		a.update()
+	}, a.signalKey)
 	a.u.generalSectionChanged.AddListener(func(_ context.Context, arg generalSectionUpdated) {
 		a.update()
-	})
+	}, a.signalKey)
 	return a
+}
+
+func (a *updateStatus) stop() {
+	a.u.characterAdded.RemoveListener(a.signalKey)
+	a.u.characterRemoved.RemoveListener(a.signalKey)
+	a.u.characterSectionUpdated.RemoveListener(a.signalKey)
+	a.u.corporationSectionChanged.RemoveListener(a.signalKey)
+	a.u.generalSectionChanged.RemoveListener(a.signalKey)
 }
 
 func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {

--- a/internal/app/ui/updateticker.go
+++ b/internal/app/ui/updateticker.go
@@ -69,27 +69,15 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 		return
 	}
 
-	var hasChanged bool
-	switch section {
-	case app.SectionEveMarketPrices:
-		types, err := u.eus.ListEveTypeIDs(ctx)
-		if err != nil {
-			logErr(err)
-			return
-		}
-		hasChanged = changedIDs.ContainsAny(types.All())
-	default:
-		hasChanged = changedIDs.Size() > 0
-	}
-
-	needsRefresh := hasChanged || forceUpdate
+	needsRefresh := changedIDs.Size() > 0 || forceUpdate
 	if !needsRefresh {
 		return
 	}
 
 	go u.generalSectionChanged.Emit(ctx, generalSectionUpdated{
-		section: section,
-		changed: changedIDs,
+		section:      section,
+		changed:      changedIDs,
+		needsRefresh: needsRefresh,
 	})
 }
 

--- a/internal/app/ui/updateticker.go
+++ b/internal/app/ui/updateticker.go
@@ -70,15 +70,22 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 	}
 
 	needsRefresh := changedIDs.Size() > 0 || forceUpdate
-	if !needsRefresh {
-		return
-	}
-
-	go u.generalSectionChanged.Emit(ctx, generalSectionUpdated{
+	arg := generalSectionUpdated{
 		section:      section,
 		changed:      changedIDs,
 		needsRefresh: needsRefresh,
+	}
+
+	var wg sync.WaitGroup
+	if needsRefresh {
+		wg.Go(func() {
+			u.generalSectionChanged.Emit(ctx, arg)
+		})
+	}
+	wg.Go(func() {
+		u.generalSectionUpdated.Emit(ctx, arg)
 	})
+	wg.Wait()
 }
 
 // update character sections

--- a/internal/app/ui/updateticker.go
+++ b/internal/app/ui/updateticker.go
@@ -58,7 +58,7 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 		u.onSectionUpdateStarted()
 		defer u.onSectionUpdateCompleted()
 	}
-	changed, err := u.eus.UpdateSectionIfNeeded(ctx, app.GeneralSectionUpdateParams{
+	changedIDs, err := u.eus.UpdateSectionIfNeeded(ctx, app.GeneralSectionUpdateParams{
 		Section:           section,
 		ForceUpdate:       forceUpdate,
 		OnUpdateStarted:   u.onSectionUpdateStarted,
@@ -68,9 +68,8 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 		logErr(err)
 		return
 	}
-	if changed.Size() == 0 && !forceUpdate {
-		return
-	}
+
+	var hasChanged bool
 	switch section {
 	case app.SectionEveMarketPrices:
 		types, err := u.eus.ListEveTypeIDs(ctx)
@@ -78,13 +77,19 @@ func (u *baseUI) updateGeneralSectionAndRefreshIfNeeded(ctx context.Context, sec
 			logErr(err)
 			return
 		}
-		if !changed.ContainsAny(types.All()) {
-			return
-		}
+		hasChanged = changedIDs.ContainsAny(types.All())
+	default:
+		hasChanged = changedIDs.Size() > 0
 	}
+
+	needsRefresh := hasChanged || forceUpdate
+	if !needsRefresh {
+		return
+	}
+
 	go u.generalSectionChanged.Emit(ctx, generalSectionUpdated{
 		section: section,
-		changed: changed,
+		changed: changedIDs,
 	})
 }
 
@@ -449,11 +454,20 @@ func (u *baseUI) updateCorporationSectionAndRefreshIfNeeded(ctx context.Context,
 		slog.Error("Failed to update corporation section", "corporationID", corporationID, "section", section, "err", err)
 		return
 	}
-	if !hasChanged && !forceUpdate {
-		return
-	}
-	go u.corporationSectionChanged.Emit(ctx, corporationSectionUpdated{
+	needsRefresh := hasChanged || forceUpdate
+	arg := corporationSectionUpdated{
 		corporationID: corporationID,
 		section:       section,
+		needsRefresh:  needsRefresh,
+	}
+	var wg sync.WaitGroup
+	if needsRefresh {
+		wg.Go(func() {
+			u.corporationSectionChanged.Emit(ctx, arg)
+		})
+	}
+	wg.Go(func() {
+		u.corporationSectionUpdated.Emit(ctx, arg)
 	})
+	wg.Wait()
 }


### PR DESCRIPTION
- Fix: the update status window is not removed from the signals at terminating. Leading to overhead when the window is opened multiple times.
- Change: Update status of corporations and general sections with the same frequency then character sections
- Change: Obsolete market prices are now removed
- Change: Various performance tuning and refactorings in the storage package