### PR TITLE
fix: deleted communications not removed

### DIFF
--- a/internal/app/characterservice/communications.go
+++ b/internal/app/characterservice/communications.go
@@ -113,9 +113,11 @@ func (s *CharacterService) updateNotificationsESI(ctx context.Context, arg chara
 			if err != nil {
 				return false, err
 			}
+			var incomingIDs set.Set[int64]
 			var newNotifs []esi.CharactersCharacterIdNotificationsGetInner
 			var existingNotifs []esi.CharactersCharacterIdNotificationsGetInner
 			for _, n := range notifications {
+				incomingIDs.Add(n.NotificationId)
 				if existingIDs.Contains(n.NotificationId) {
 					existingNotifs = append(existingNotifs, n)
 				} else {
@@ -125,6 +127,15 @@ func (s *CharacterService) updateNotificationsESI(ctx context.Context, arg chara
 			if err := s.loadEntitiesForNotifications(ctx, characterID, existingNotifs); err != nil {
 				return false, err
 			}
+
+			// Remove deleted notifications
+			if ids := set.Difference(existingIDs, incomingIDs); ids.Size() > 0 {
+				if err := s.st.DeleteCharacterNotifications(ctx, characterID, ids); err != nil {
+					return false, err
+				}
+				slog.Info("Removed deleted notifications", "characterID", characterID, "count", ids.Size())
+			}
+
 			var updatedCount int
 			for _, n := range existingNotifs {
 				o, err := s.st.GetCharacterNotification(ctx, characterID, n.NotificationId)
@@ -241,6 +252,7 @@ func (s *CharacterService) updateNotificationsESI(ctx context.Context, arg chara
 				}
 			}
 			slog.Info("Stored new notifications", "characterID", characterID, "entries", len(newNotifs))
+
 			return true, nil
 		})
 }

--- a/internal/app/characterservice/communications_internal_test.go
+++ b/internal/app/characterservice/communications_internal_test.go
@@ -127,13 +127,20 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
 		n1 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
-		// factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID}) // this should be removed
+		factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID}) // this should be removed
 		sender := factory.CreateEveEntityCorporation()
 		timestamp := time.Now().Round(time.Second)
 		httpmock.RegisterResponder(
 			"GET",
 			fmt.Sprintf("https://esi.evetech.net/characters/%d/notifications", c.ID),
 			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"notification_id": n1.NotificationID,
+				"sender_id":       n1.Sender.ID,
+				"sender_type":     n1.Sender.Category.String(),
+				"text":            n1.Text.ValueOrZero(),
+				"timestamp":       n1.Timestamp.Format(time.RFC3339),
+				"type":            n1.Type.String(),
+			}, {
 				"notification_id": newNotificationID,
 				"sender_id":       sender.ID,
 				"sender_type":     "corporation",

--- a/internal/app/characterservice/communications_internal_test.go
+++ b/internal/app/characterservice/communications_internal_test.go
@@ -32,40 +32,45 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		c := factory.CreateCharacter()
 		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
-		sender := factory.CreateEveEntityCorporation(app.EveEntity{ID: 54321})
+		const notificationID = 42
+		sender := factory.CreateEveEntityCorporation()
+		timestamp := time.Now().Round(time.Second)
 		httpmock.RegisterResponder(
 			"GET",
 			fmt.Sprintf("https://esi.evetech.net/characters/%d/notifications", c.ID),
 			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
 				"is_read":         true,
-				"notification_id": 42,
+				"notification_id": notificationID,
 				"sender_id":       sender.ID,
 				"sender_type":     "corporation",
 				"text":            "amount: 3731016.4000000004\\nitemID: 1024881021663\\npayout: 1\\n",
-				"timestamp":       "2017-08-16T10:08:00Z",
+				"timestamp":       timestamp.Format(time.RFC3339),
 				"type":            "InsurancePayoutMsg",
 			}}),
 		)
+
 		// when
 		changed, err := s.updateNotificationsESI(ctx, characterSectionUpdateParams{
 			characterID: c.ID,
 			section:     app.SectionCharacterNotifications,
 		})
+
 		// then
 		require.NoError(t, err)
 		assert.True(t, changed)
-		o, err := st.GetCharacterNotification(ctx, c.ID, 42)
+		o, err := st.GetCharacterNotification(ctx, c.ID, notificationID)
 		require.NoError(t, err)
 		assert.True(t, o.IsRead.ValueOrZero())
-		xassert.Equal(t, int64(42), o.NotificationID)
+		xassert.Equal(t, notificationID, o.NotificationID)
 		xassert.Equal(t, sender, o.Sender)
 		xassert.Equal(t, app.InsurancePayoutMsg, o.Type)
 		xassert.Equal(t, "amount: 3731016.4000000004\\nitemID: 1024881021663\\npayout: 1\\n", o.Text.ValueOrZero())
-		xassert.Equal(t, time.Date(2017, 8, 16, 10, 8, 0, 0, time.UTC), o.Timestamp)
+		xassert.Equal(t, timestamp, o.Timestamp)
 		xassert.Equal(t, c.ID, o.Recipient.ValueOrZero().ID)
+
 		ids, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, set.Of[int64](42), ids)
+		xassert.Equal(t, set.Of[int64](notificationID), ids)
 	})
 	// t.Run("should create new notification from scratch 2", func(t *testing.T) {
 	// 	// given
@@ -112,51 +117,57 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 	// 		}
 	// 	}
 	// })
-	t.Run("should add new notification", func(t *testing.T) {
+
+	t.Run("should add new and remove deleted notification", func(t *testing.T) {
 		// given
-		const (
-			notificationID = 42
-			text           = "amount: 3731016.4000000004\\nitemID: 1024881021663\\npayout: 1\\n"
-		)
+		const newNotificationID = 9942
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
 		n1 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
-		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
-		sender := factory.CreateEveEntityCorporation(app.EveEntity{ID: 54321})
+		// factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID}) // this should be removed
+		sender := factory.CreateEveEntityCorporation()
+		timestamp := time.Now().Round(time.Second)
 		httpmock.RegisterResponder(
 			"GET",
 			fmt.Sprintf("https://esi.evetech.net/characters/%d/notifications", c.ID),
 			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
-				"is_read":         true,
-				"notification_id": notificationID,
+				"notification_id": newNotificationID,
 				"sender_id":       sender.ID,
 				"sender_type":     "corporation",
-				"text":            text,
-				"timestamp":       "2017-08-16T10:08:00Z",
-				"type":            "InsurancePayoutMsg",
-			}}))
+				"text":            "",
+				"timestamp":       timestamp.Format(time.RFC3339),
+				"type":            "CorpNoLongerWarEligible",
+			}}),
+		)
+
 		// when
 		changed, err := s.updateNotificationsESI(ctx, characterSectionUpdateParams{
 			characterID: c.ID,
 			section:     app.SectionCharacterNotifications,
 		})
+
 		// then
 		require.NoError(t, err)
 		assert.True(t, changed)
-		o, err := st.GetCharacterNotification(ctx, c.ID, 42)
-		require.NoError(t, err)
-		assert.True(t, o.IsRead.ValueOrZero())
-		xassert.Equal(t, 42, o.NotificationID)
-		xassert.Equal(t, sender, o.Sender)
-		xassert.Equal(t, app.InsurancePayoutMsg, o.Type)
-		xassert.Equal(t, text, o.Text.ValueOrZero())
-		xassert.Equal(t, time.Date(2017, 8, 16, 10, 8, 0, 0, time.UTC), o.Timestamp)
+
 		ids, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, set.Of(42, n1.NotificationID), ids)
+		xassert.Equal(t, set.Of(newNotificationID, n1.NotificationID), ids)
+
+		o, err := st.GetCharacterNotification(ctx, c.ID, newNotificationID)
+		require.NoError(t, err)
+		xassert.Equal(t, newNotificationID, o.NotificationID)
+		assert.False(t, o.IsRead.ValueOrZero())
+		xassert.Equal(t, sender, o.Sender)
+		xassert.Equal(t, app.CorpNoLongerWarEligible, o.Type)
+		xassert.Empty(t, o.Text)
+		xassert.Equal(t, timestamp, o.Timestamp)
+		xassert.Equal(t, c.EveCharacter.Corporation.ID, o.Recipient.ValueOrZero().ID) // this is a corp notification
 	})
+
 	t.Run("should update isRead for existing notification", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)

--- a/internal/app/storage/characternotification.go
+++ b/internal/app/storage/characternotification.go
@@ -348,6 +348,13 @@ func (st *Storage) CreateCharacterNotification(ctx context.Context, arg CreateCh
 	return nil
 }
 
+func (st *Storage) DeleteCharacterNotifications(ctx context.Context, characterID int64, notificationIDs set.Set[int64]) error {
+	return st.qRW.DeleteCharacterNotifications(ctx, queries.DeleteCharacterNotificationsParams{
+		CharacterID:     characterID,
+		NotificationIds: slices.Collect(notificationIDs.All()),
+	})
+}
+
 func (st *Storage) GetCharacterNotification(ctx context.Context, characterID int64, notificationID int64) (*app.CharacterNotification, error) {
 	arg := queries.GetCharacterNotificationParams{
 		CharacterID:    characterID,

--- a/internal/app/storage/characternotification_test.go
+++ b/internal/app/storage/characternotification_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -38,9 +39,7 @@ func TestCharacterNotification(t *testing.T) {
 		// when
 		err := st.CreateCharacterNotification(ctx, arg)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, c.ID, 42)
 		if assert.NoError(t, err) {
 			xassert.Equal(t, c.ID, o.CharacterID)
@@ -109,9 +108,7 @@ func TestCharacterNotification(t *testing.T) {
 		// when
 		err := st.CreateCharacterNotification(ctx, arg)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, c.ID, 42)
 		if assert.NoError(t, err) {
 			xassert.Equal(t, app.UnknownNotification, o.Type)
@@ -127,9 +124,7 @@ func TestCharacterNotification(t *testing.T) {
 			IsRead: optional.New(true),
 		})
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, n.CharacterID, n.ID)
 		if assert.NoError(t, err) {
 			assert.True(t, o.IsRead.ValueOrZero())
@@ -146,9 +141,7 @@ func TestCharacterNotification(t *testing.T) {
 			ID: n.ID,
 		})
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, n.CharacterID, n.ID)
 		if assert.NoError(t, err) {
 			assert.False(t, o.IsRead.ValueOrZero())
@@ -164,9 +157,7 @@ func TestCharacterNotification(t *testing.T) {
 			Title: optional.New("title"),
 		})
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, n.CharacterID, n.ID)
 		if assert.NoError(t, err) {
 			xassert.Equal(t, "title", o.Title.ValueOrZero())
@@ -182,9 +173,7 @@ func TestCharacterNotification(t *testing.T) {
 			Body: optional.New("body"),
 		})
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		o, err := st.GetCharacterNotification(ctx, n.CharacterID, n.ID)
 		if assert.NoError(t, err) {
 			xassert.Equal(t, "body", o.Body.ValueOrZero())
@@ -209,13 +198,9 @@ func TestCharacterNotification(t *testing.T) {
 		// when
 		err := st.UpdateCharacterNotificationsSetProcessed(ctx, 42)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		ee, err := st.ListCharacterNotificationsUnprocessed(ctx, c1.ID, time.Now().Add(-24*time.Hour))
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))
@@ -243,14 +228,29 @@ func TestCharacterNotification(t *testing.T) {
 		// when
 		x, err := st.CountCharacterNotifications(ctx, c.ID)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		want := map[app.EveNotificationType][]int{
 			app.StructureUnderAttack: {2, 1},
 			app.StructureDestroyed:   {1, 1},
 		}
 		xassert.Equal(t, want, x)
+	})
+
+	t.Run("can delete notifications", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		e1 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
+		e2 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
+		e3 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
+		// when
+		err := st.DeleteCharacterNotifications(ctx, c.ID, set.Of(e1.NotificationID, e2.NotificationID))
+		// then
+		require.NoError(t, err)
+		got, err := st.ListCharacterNotificationIDs(ctx, c.ID)
+		require.NoError(t, err)
+		want := set.Of(e3.NotificationID)
+		xassert.Equal(t, want, got)
 	})
 }
 
@@ -268,9 +268,7 @@ func TestCharacterNotification_List(t *testing.T) {
 		// when
 		got, err := st.ListCharacterNotificationIDs(ctx, c.ID)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		want := set.Of(e1.NotificationID, e2.NotificationID, e3.NotificationID)
 		xassert.Equal(t, want, got)
 	})
@@ -293,9 +291,7 @@ func TestCharacterNotification_List(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsForTypes(ctx, c.ID, set.Of(app.StructureDestroyed))
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		want := set.Of(n1.NotificationID, n2.NotificationID)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.NotificationID
@@ -322,9 +318,7 @@ func TestCharacterNotification_List(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsUnread(ctx, c.ID)
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))
@@ -360,9 +354,7 @@ func TestCharacterNotification_ListUnprocessed(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsUnprocessed(ctx, c.ID, now.Add(-24*time.Hour))
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))
@@ -391,9 +383,7 @@ func TestCharacterNotification_ListUnprocessed(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsUnprocessed(ctx, c.ID, now.Add(-24*time.Hour))
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))
@@ -427,9 +417,7 @@ func TestCharacterNotification_ListUnprocessed(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsUnprocessed(ctx, c.ID, now.Add(-24*time.Hour))
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))
@@ -467,9 +455,7 @@ func TestCharacterNotification_ListUnprocessed(t *testing.T) {
 		// when
 		ee, err := st.ListCharacterNotificationsUnprocessed(ctx, c.ID, now.Add(-24*time.Hour))
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(ee, func(x *app.CharacterNotification) int64 {
 			return x.ID
 		}))

--- a/internal/app/storage/corporationindustryjob_test.go
+++ b/internal/app/storage/corporationindustryjob_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -316,13 +317,9 @@ func TestCorporationIndustryJob(t *testing.T) {
 			Status:        app.JobUnknown,
 		})
 		// then
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		j2, err := st.GetCorporationIndustryJob(ctx, j1.CorporationID, j1.JobID)
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		xassert.Equal(t, app.JobUnknown, j2.Status)
 	})
 }

--- a/internal/app/storage/queries/character_notifications.sql
+++ b/internal/app/storage/queries/character_notifications.sql
@@ -31,6 +31,12 @@ INSERT INTO
 VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+-- name: DeleteCharacterNotifications :exec
+DELETE FROM character_notifications
+WHERE
+    character_id = ?
+    AND notification_id IN (sqlc.slice('notification_ids'));
+
 -- name: GetCharacterNotification :one
 SELECT
     sqlc.embed(cn),

--- a/internal/app/storage/queries/character_notifications.sql.go
+++ b/internal/app/storage/queries/character_notifications.sql.go
@@ -129,6 +129,34 @@ func (q *Queries) CreateNotificationType(ctx context.Context, name string) (int6
 	return id, err
 }
 
+const deleteCharacterNotifications = `-- name: DeleteCharacterNotifications :exec
+DELETE FROM character_notifications
+WHERE
+    character_id = ?
+    AND notification_id IN (/*SLICE:notification_ids*/?)
+`
+
+type DeleteCharacterNotificationsParams struct {
+	CharacterID     int64
+	NotificationIds []int64
+}
+
+func (q *Queries) DeleteCharacterNotifications(ctx context.Context, arg DeleteCharacterNotificationsParams) error {
+	query := deleteCharacterNotifications
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	if len(arg.NotificationIds) > 0 {
+		for _, v := range arg.NotificationIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:notification_ids*/?", strings.Repeat(",?", len(arg.NotificationIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:notification_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
 const getCharacterNotification = `-- name: GetCharacterNotification :one
 SELECT
     cn.id, cn.body, cn.character_id, cn.is_processed, cn.is_read, cn.notification_id, cn.sender_id, cn.text, cn.timestamp, cn.title, cn.type_id, cn.recipient_id,

--- a/internal/xgoesi/ratelimit_test.go
+++ b/internal/xgoesi/ratelimit_test.go
@@ -36,9 +36,7 @@ func TestRateLimiter_RateLimited(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 		require.NoError(t, err)
 		resp, err := client.Do(req)
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 	t.Run("should limit subsequent requests to the same bucket", func(t *testing.T) {


### PR DESCRIPTION
Communications that were deleted in the game are now also removed from EVE Buddy.

Fixes #425 