### PR TITLE
feat: add wealth overview & improve wealth calculation

### DIFF
--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -30,6 +30,7 @@ type Character struct {
 	OrderItemsValue    optional.Optional[float64]
 	OrdersEscrow       optional.Optional[float64]
 	Ship               optional.Optional[*EveType]
+	SkillPointsValue   optional.Optional[float64]
 	TrainedSP          optional.Optional[int64]
 	UnallocatedSP      optional.Optional[int64]
 	WalletBalance      optional.Optional[float64]

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -60,7 +60,7 @@ func (c *Character) NameOrZero() string {
 // Blueprints do not count towards a character‘s Total Net Worth.
 // Source: Total Net Worth of a character as defined by CCP.
 func (c *Character) CombinedAssetsValue() optional.Optional[float64] {
-	return optional.Sum(c.AssetValue, c.ContractItemsValue, c.OrderItemsValue)
+	return optional.SumNonEmpty(c.AssetValue, c.ContractItemsValue, c.OrderItemsValue)
 }
 
 type CharacterAttributes struct {

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -60,7 +60,7 @@ func (c *Character) NameOrZero() string {
 // Blueprints do not count towards a character‘s Total Net Worth.
 // Source: Total Net Worth of a character as defined by CCP.
 func (c *Character) CombinedAssetsValue() optional.Optional[float64] {
-	return optional.SumNonEmpty(c.AssetValue, c.ContractItemsValue, c.OrderItemsValue)
+	return optional.Sum(c.AssetValue, c.ContractItemsValue, c.OrderItemsValue)
 }
 
 type CharacterAttributes struct {

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -18,6 +18,7 @@ import (
 // Character is an EVE Online character owned by the user.
 type Character struct {
 	AssetValue        optional.Optional[float64]
+	ContractEscrow    optional.Optional[float64]
 	EveCharacter      *EveCharacter
 	Home              optional.Optional[*EveLocation]
 	ID                int64
@@ -25,6 +26,7 @@ type Character struct {
 	LastCloneJumpAt   optional.Optional[time.Time]
 	LastLoginAt       optional.Optional[time.Time]
 	Location          optional.Optional[*EveLocation]
+	MarketEscrow      optional.Optional[float64]
 	Ship              optional.Optional[*EveType]
 	TrainedSP         optional.Optional[int64]
 	UnallocatedSP     optional.Optional[int64]
@@ -415,11 +417,4 @@ func SearchCategories() []SearchCategory {
 		SearchStation,
 		SearchType,
 	}
-}
-
-type CharacterWealth struct {
-	Assets      optional.Optional[float64]
-	CharacterID int64
-	Total       optional.Optional[float64]
-	Wallet      optional.Optional[float64]
 }

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -17,20 +17,22 @@ import (
 
 // Character is an EVE Online character owned by the user.
 type Character struct {
-	AssetValue        optional.Optional[float64]
-	ContractEscrow    optional.Optional[float64]
-	EveCharacter      *EveCharacter
-	Home              optional.Optional[*EveLocation]
-	ID                int64
-	IsTrainingWatched bool
-	LastCloneJumpAt   optional.Optional[time.Time]
-	LastLoginAt       optional.Optional[time.Time]
-	Location          optional.Optional[*EveLocation]
-	MarketEscrow      optional.Optional[float64]
-	Ship              optional.Optional[*EveType]
-	TrainedSP         optional.Optional[int64]
-	UnallocatedSP     optional.Optional[int64]
-	WalletBalance     optional.Optional[float64]
+	AssetValue         optional.Optional[float64] // value of character assets
+	ContractItemsValue optional.Optional[float64]
+	ContractsEscrow    optional.Optional[float64]
+	EveCharacter       *EveCharacter
+	Home               optional.Optional[*EveLocation]
+	ID                 int64
+	IsTrainingWatched  bool
+	LastCloneJumpAt    optional.Optional[time.Time]
+	LastLoginAt        optional.Optional[time.Time]
+	Location           optional.Optional[*EveLocation]
+	OrderItemsValue    optional.Optional[float64]
+	OrdersEscrow       optional.Optional[float64]
+	Ship               optional.Optional[*EveType]
+	TrainedSP          optional.Optional[int64]
+	UnallocatedSP      optional.Optional[int64]
+	WalletBalance      optional.Optional[float64]
 	// Calculated fields
 	NextCloneJump optional.Optional[time.Time] // zero time == now
 }
@@ -47,6 +49,18 @@ func (c *Character) NameOrZero() string {
 		return ""
 	}
 	return c.EveCharacter.Name
+}
+
+// CombinedAssetsValue returns the combined assets estimated value.
+//
+// This is the total sum of the estimated market price of a character's assets.
+// This includes any items that the player owns in Stations or Upwell Structures,
+// items located in outstanding sell orders on the market or contracts,
+// and those in a character's Asset Safety.
+// Blueprints do not count towards a character‘s Total Net Worth.
+// Source: Total Net Worth of a character as defined by CCP.
+func (c *Character) CombinedAssetsValue() optional.Optional[float64] {
+	return optional.Sum(c.AssetValue, c.ContractItemsValue, c.OrderItemsValue)
 }
 
 type CharacterAttributes struct {

--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -416,3 +416,10 @@ func SearchCategories() []SearchCategory {
 		SearchType,
 	}
 }
+
+type CharacterWealth struct {
+	Assets      optional.Optional[float64]
+	CharacterID int64
+	Total       optional.Optional[float64]
+	Wallet      optional.Optional[float64]
+}

--- a/internal/app/characterservice/assets.go
+++ b/internal/app/characterservice/assets.go
@@ -208,7 +208,7 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 				} else {
 					err := s.st.CreateCharacterAsset(ctx, storage.CreateCharacterAssetParams{
 						CharacterID:     characterID,
-						EveTypeID:       a.TypeId,
+						TypeID:          a.TypeId,
 						IsBlueprintCopy: optional.FromPtr(a.IsBlueprintCopy),
 						IsSingleton:     a.IsSingleton,
 						ItemID:          a.ItemId,
@@ -231,9 +231,6 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 					return false, err
 				}
 				slog.Info("Deleted obsolete character assets", "characterID", characterID, "count", ids.Size())
-			}
-			if _, err := s.UpdateAssetTotalValue(ctx, characterID); err != nil {
-				return false, err
 			}
 
 			// update names
@@ -265,6 +262,10 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 				if err != nil {
 					return false, err
 				}
+			}
+
+			if err := s.updateAssetValue(ctx, characterID); err != nil {
+				return false, err
 			}
 
 			return true, nil
@@ -300,13 +301,13 @@ func (s *CharacterService) fetchAssetNamesESI(ctx context.Context, characterID i
 	return m, !hasError
 }
 
-func (s *CharacterService) UpdateAssetTotalValue(ctx context.Context, characterID int64) (float64, error) {
+func (s *CharacterService) updateAssetValue(ctx context.Context, characterID int64) error {
 	v, err := s.st.CalculateCharacterAssetTotalValue(ctx, characterID)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	if err := s.st.UpdateCharacterAssetValue(ctx, characterID, optional.New(v)); err != nil {
-		return 0, err
+		return err
 	}
-	return v, nil
+	return nil
 }

--- a/internal/app/characterservice/assets.go
+++ b/internal/app/characterservice/assets.go
@@ -135,7 +135,7 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 	if arg.section != app.SectionCharacterAssets {
 		return false, fmt.Errorf("wrong section for update %s: %w", arg.section, app.ErrInvalid)
 	}
-	return s.updateSectionIfChanged(
+	changed, err := s.updateSectionIfChanged(
 		ctx, arg, false,
 		func(ctx context.Context, characterID int64) (any, error) {
 			ctx = xgoesi.NewContextWithOperationID(ctx, "GetCharactersCharacterIdAssets")
@@ -264,14 +264,24 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 				}
 			}
 
-			// update calculated values
-			if err := s.updateAssetValue(ctx, characterID); err != nil {
-				return false, err
-			}
-
 			return true, nil
 		},
 	)
+	if err != nil {
+		return false, err
+	}
+
+	// update calculated values
+	c, err := s.st.GetCharacter(ctx, arg.characterID)
+	if err != nil {
+		return false, err
+	}
+	if arg.forceUpdate || changed || c.AssetValue.IsEmpty() {
+		if err := s.updateAssetValue(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+	return changed, nil
 }
 
 func (s *CharacterService) fetchAssetNamesESI(ctx context.Context, characterID int64, ids []int64) (map[int64]string, bool) {

--- a/internal/app/characterservice/assets.go
+++ b/internal/app/characterservice/assets.go
@@ -264,6 +264,7 @@ func (s *CharacterService) updateAssetsESI(ctx context.Context, arg characterSec
 				}
 			}
 
+			// update calculated values
 			if err := s.updateAssetValue(ctx, characterID); err != nil {
 				return false, err
 			}

--- a/internal/app/characterservice/assets_internal_test.go
+++ b/internal/app/characterservice/assets_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
@@ -251,4 +252,42 @@ func TestUpdateCharacterAssetsESI(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, "", x.Name)
 	})
+}
+
+func TestUpdateAssetValue(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can calculate total asset value for character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		ca1 := factory.CreateCharacterAsset(storage.CreateCharacterAssetParams{
+			CharacterID: c.ID,
+			Quantity:    1,
+		})
+		ca2 := factory.CreateCharacterAsset(storage.CreateCharacterAssetParams{
+			CharacterID: c.ID,
+			Quantity:    2,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       ca1.Type.ID,
+			AveragePrice: optional.New(100.1),
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       ca2.Type.ID,
+			AveragePrice: optional.New(200.2),
+		})
+
+		// when
+		err := s.updateAssetValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(t.Context(), c.ID)
+		require.NoError(t, err)
+		got := c2.AssetValue
+		assert.Equal(t, optional.New(500.5), got)
+	})
+
 }

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -174,7 +174,3 @@ func (s *CharacterService) UpdateOrCreateCharacterFromSSO(ctx context.Context, s
 	}
 	return c, nil
 }
-
-func (s *CharacterService) ListWealthValues(ctx context.Context) ([]*app.CharacterWealth, error) {
-	return s.st.ListCharacterWealthValues(ctx)
-}

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -175,7 +175,7 @@ func (s *CharacterService) UpdateOrCreateCharacterFromSSO(ctx context.Context, s
 	return c, nil
 }
 
-func (s *CharacterService) UpdateTotalNetWorth(ctx context.Context, characterID int64) error {
+func (s *CharacterService) UpdateCalculatedValues(ctx context.Context, characterID int64) error {
 	if err := s.updateAssetValue(ctx, characterID); err != nil {
 		return err
 	}
@@ -189,6 +189,9 @@ func (s *CharacterService) UpdateTotalNetWorth(ctx context.Context, characterID 
 		return err
 	}
 	if err := s.updateOrderItemValue(ctx, characterID); err != nil {
+		return err
+	}
+	if err := s.updateSkillPointValue(ctx, characterID); err != nil {
 		return err
 	}
 	return nil

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -174,3 +174,7 @@ func (s *CharacterService) UpdateOrCreateCharacterFromSSO(ctx context.Context, s
 	}
 	return c, nil
 }
+
+func (s *CharacterService) ListWealthValues(ctx context.Context) ([]*app.CharacterWealth, error) {
+	return s.st.ListCharacterWealthValues(ctx)
+}

--- a/internal/app/characterservice/character.go
+++ b/internal/app/characterservice/character.go
@@ -174,3 +174,22 @@ func (s *CharacterService) UpdateOrCreateCharacterFromSSO(ctx context.Context, s
 	}
 	return c, nil
 }
+
+func (s *CharacterService) UpdateTotalNetWorth(ctx context.Context, characterID int64) error {
+	if err := s.updateAssetValue(ctx, characterID); err != nil {
+		return err
+	}
+	if err := s.updateContractItemsValue(ctx, characterID); err != nil {
+		return err
+	}
+	if err := s.updateContractsEscrow(ctx, characterID); err != nil {
+		return err
+	}
+	if err := s.updateOrdersEscrow(ctx, characterID); err != nil {
+		return err
+	}
+	if err := s.updateOrderItemValue(ctx, characterID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -448,28 +448,11 @@ func (s *CharacterService) updateContractsEscrow(ctx context.Context, characterI
 	wrapErr := func(err error) error {
 		return fmt.Errorf("updateContractsEscrow: %d: %w", characterID, err)
 	}
-	if characterID == 0 {
-		wrapErr(app.ErrInvalid)
-	}
-	oo, err := s.st.ListCharacterContracts(ctx, characterID)
+	v1, err := s.st.CalculateCharacterContractsCourierEscrow(ctx, characterID)
 	if err != nil {
 		wrapErr(err)
 	}
-	var escrow float64
-	for _, o := range oo {
-		switch o.Type {
-		case app.ContractTypeCourier:
-			if !o.Status.IsActive() {
-				break
-			}
-			if v, ok := o.Acceptor.Value(); ok && v.ID == characterID {
-				if v, ok := o.Collateral.Value(); ok {
-					escrow += v
-				}
-			}
-		}
-	}
-	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(escrow))
+	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(v1))
 	if err != nil {
 		wrapErr(err)
 	}

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -252,6 +252,11 @@ func (s *CharacterService) updateContractsESI(ctx context.Context, arg character
 			if err := s.st.DeleteCharacterContracts(ctx, characterID, staleIDs); err != nil {
 				return false, err
 			}
+
+			// update escrow
+			if err := s.updateContractsEscrow(ctx, characterID); err != nil {
+				return false, err
+			}
 			return true, nil
 		})
 }
@@ -414,5 +419,37 @@ func (s *CharacterService) updateContractBids(ctx context.Context, characterID, 
 		}
 	}
 	slog.Info("created contract bids", "characterID", characterID, "contract", contractID, "count", len(newBids))
+	return nil
+}
+
+func (s *CharacterService) updateContractsEscrow(ctx context.Context, characterID int64) error {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("updateContractsEscrow: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		wrapErr(app.ErrInvalid)
+	}
+	oo, err := s.st.ListCharacterContracts(ctx, characterID)
+	if err != nil {
+		wrapErr(err)
+	}
+	var escrow float64
+	for _, o := range oo {
+		switch o.Type {
+		case app.ContractTypeCourier:
+			if !o.Status.IsActive() {
+				break
+			}
+			if v, ok := o.Acceptor.Value(); ok && v.ID == characterID {
+				if v, ok := o.Collateral.Value(); ok {
+					escrow += v
+				}
+			}
+		}
+	}
+	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(escrow))
+	if err != nil {
+		wrapErr(err)
+	}
 	return nil
 }

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -444,15 +444,15 @@ func (s *CharacterService) updateContractItemsValue(ctx context.Context, charact
 		return fmt.Errorf("updateContractItemsValue: %d: %w", characterID, err)
 	}
 	if characterID == 0 {
-		wrapErr(app.ErrInvalid)
+		return wrapErr(app.ErrInvalid)
 	}
 	v, err := s.st.CalculateCharacterContractItemsValue(ctx, characterID)
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	err = s.st.UpdateCharacterContractItemsValue(ctx, characterID, optional.New(v))
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	return nil
 }
@@ -463,15 +463,15 @@ func (s *CharacterService) updateContractsEscrow(ctx context.Context, characterI
 	}
 	v1, err := s.st.CalculateCharacterContractsCourierEscrow(ctx, characterID)
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	v2, err := s.st.CalculateCharacterContractsAuctionEscrow(ctx, characterID)
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(v1+v2))
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	return nil
 }

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -253,10 +253,14 @@ func (s *CharacterService) updateContractsESI(ctx context.Context, arg character
 				return false, err
 			}
 
-			// update escrow
+			// update calculated values
+			if err := s.updateContractItemsValue(ctx, characterID); err != nil {
+				return false, err
+			}
 			if err := s.updateContractsEscrow(ctx, characterID); err != nil {
 				return false, err
 			}
+
 			return true, nil
 		})
 }
@@ -419,6 +423,24 @@ func (s *CharacterService) updateContractBids(ctx context.Context, characterID, 
 		}
 	}
 	slog.Info("created contract bids", "characterID", characterID, "contract", contractID, "count", len(newBids))
+	return nil
+}
+
+func (s *CharacterService) updateContractItemsValue(ctx context.Context, characterID int64) error {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("updateContractItemsValue: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		wrapErr(app.ErrInvalid)
+	}
+	v, err := s.st.CalculateCharacterContractItemsValue(ctx, characterID)
+	if err != nil {
+		wrapErr(err)
+	}
+	err = s.st.UpdateCharacterContractItemsValue(ctx, characterID, optional.New(v))
+	if err != nil {
+		wrapErr(err)
+	}
 	return nil
 }
 

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -150,7 +150,7 @@ func (s *CharacterService) updateContractsESI(ctx context.Context, arg character
 	if arg.section != app.SectionCharacterContracts {
 		return false, fmt.Errorf("wrong section for update %s: %w", arg.section, app.ErrInvalid)
 	}
-	return s.updateSectionIfChanged(
+	changed, err := s.updateSectionIfChanged(
 		ctx, arg, false,
 		func(ctx context.Context, characterID int64) (any, error) {
 			ctx = xgoesi.NewContextWithOperationID(ctx, "GetCharactersCharacterIdContracts")
@@ -253,16 +253,29 @@ func (s *CharacterService) updateContractsESI(ctx context.Context, arg character
 				return false, err
 			}
 
-			// update calculated values
-			if err := s.updateContractItemsValue(ctx, characterID); err != nil {
-				return false, err
-			}
-			if err := s.updateContractsEscrow(ctx, characterID); err != nil {
-				return false, err
-			}
-
 			return true, nil
-		})
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	// update calculated values
+	c, err := s.st.GetCharacter(ctx, arg.characterID)
+	if err != nil {
+		return false, err
+	}
+	if arg.forceUpdate || changed || c.ContractItemsValue.IsEmpty() {
+		if err := s.updateContractItemsValue(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+	if arg.forceUpdate || changed || c.ContractsEscrow.IsEmpty() {
+		if err := s.updateContractsEscrow(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+	return changed, nil
 }
 
 func (s *CharacterService) createNewContract(ctx context.Context, characterID int64, c esi.CharactersCharacterIdContractsGetInner) error {

--- a/internal/app/characterservice/contracts.go
+++ b/internal/app/characterservice/contracts.go
@@ -452,7 +452,11 @@ func (s *CharacterService) updateContractsEscrow(ctx context.Context, characterI
 	if err != nil {
 		wrapErr(err)
 	}
-	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(v1))
+	v2, err := s.st.CalculateCharacterContractsAuctionEscrow(ctx, characterID)
+	if err != nil {
+		wrapErr(err)
+	}
+	err = s.st.UpdateCharacterContractsEscrow(ctx, characterID, optional.New(v1+v2))
 	if err != nil {
 		wrapErr(err)
 	}

--- a/internal/app/characterservice/contracts_internal_test.go
+++ b/internal/app/characterservice/contracts_internal_test.go
@@ -501,47 +501,29 @@ func TestUpdateContractsEscrow(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	s := NewFake(Params{Storage: st})
+	c := factory.CreateCharacter()
+	factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		CharacterID: c.ID,
+		AcceptorID:  c.ID,
+		Collateral:  optional.New(100.0),
+		Type:        app.ContractTypeCourier,
+		Status:      app.ContractStatusInProgress,
+	})
+	factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		CharacterID: c.ID,
+		AcceptorID:  c.ID,
+		Collateral:  optional.New(200.0),
+		Type:        app.ContractTypeCourier,
+		Status:      app.ContractStatusInProgress,
+	})
 
-	characterID := int64(42)
+	// when
+	err := s.updateContractsEscrow(t.Context(), c.ID)
 
-	cases := []struct {
-		name string
-
-		acceptorID   int64
-		contractType app.ContractType
-		collateral   optional.Optional[float64]
-		want         optional.Optional[float64]
-	}{
-		{"accepted courier contract", characterID, app.ContractTypeCourier, optional.New(123.0), optional.New(123.0)},
-		{"courier contract accepted by other", 0, app.ContractTypeCourier, optional.New(123.0), optional.New(0.0)},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// given
-			testutil.MustTruncateTables(db)
-			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
-				ID: characterID,
-			})
-			c := factory.CreateCharacter(storage.CreateCharacterParams{
-				ID: ec.ID,
-			})
-			factory.CreateCharacterContract(storage.CreateCharacterContractParams{
-				CharacterID: c.ID,
-				AcceptorID:  tc.acceptorID,
-				Collateral:  tc.collateral,
-				Type:        tc.contractType,
-			})
-			factory.CreateCharacterContract() // should be ignored
-
-			// when
-			err := s.updateContractsEscrow(t.Context(), c.ID)
-
-			// then
-			require.NoError(t, err)
-			c2, err := st.GetCharacter(t.Context(), c.ID)
-			require.NoError(t, err)
-			got := c2.ContractsEscrow
-			assert.Equal(t, tc.want, got)
-		})
-	}
+	// then
+	require.NoError(t, err)
+	c2, err := st.GetCharacter(t.Context(), c.ID)
+	require.NoError(t, err)
+	got := c2.ContractsEscrow
+	assert.Equal(t, optional.New(300.0), got)
 }

--- a/internal/app/characterservice/contracts_internal_test.go
+++ b/internal/app/characterservice/contracts_internal_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
@@ -491,4 +493,55 @@ func TestUpdateContractESI(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, set.Of(o1.ContractID, o2.ContractID, o3.ContractID), ids)
 	})
+}
+
+func TestUpdateContractsEscrow(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := NewFake(Params{Storage: st})
+
+	characterID := int64(42)
+
+	cases := []struct {
+		name string
+
+		acceptorID   int64
+		contractType app.ContractType
+		collateral   optional.Optional[float64]
+		want         optional.Optional[float64]
+	}{
+		{"accepted courier contract", characterID, app.ContractTypeCourier, optional.New(123.0), optional.New(123.0)},
+		{"courier contract accepted by other", 0, app.ContractTypeCourier, optional.New(123.0), optional.New(0.0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+				ID: characterID,
+			})
+			c := factory.CreateCharacter(storage.CreateCharacterParams{
+				ID: ec.ID,
+			})
+			factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+				CharacterID: c.ID,
+				AcceptorID:  tc.acceptorID,
+				Collateral:  tc.collateral,
+				Type:        tc.contractType,
+			})
+			factory.CreateCharacterContract() // should be ignored
+
+			// when
+			err := s.updateContractsEscrow(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			c2, err := st.GetCharacter(t.Context(), c.ID)
+			require.NoError(t, err)
+			got := c2.ContractsEscrow
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/app/characterservice/contracts_internal_test.go
+++ b/internal/app/characterservice/contracts_internal_test.go
@@ -516,6 +516,16 @@ func TestUpdateContractsEscrow(t *testing.T) {
 		Type:        app.ContractTypeCourier,
 		Status:      app.ContractStatusInProgress,
 	})
+	o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		CharacterID: c.ID,
+		Type:        app.ContractTypeAuction,
+		Status:      app.ContractStatusInProgress,
+	})
+	factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+		Amount:     12.3,
+		BidderID:   c.ID,
+		ContractID: o.ID,
+	})
 
 	// when
 	err := s.updateContractsEscrow(t.Context(), c.ID)
@@ -525,5 +535,5 @@ func TestUpdateContractsEscrow(t *testing.T) {
 	c2, err := st.GetCharacter(t.Context(), c.ID)
 	require.NoError(t, err)
 	got := c2.ContractsEscrow
-	assert.Equal(t, optional.New(300.0), got)
+	assert.Equal(t, optional.New(312.3), got)
 }

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -200,16 +200,32 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 			if err := s.updateOrdersEscrow(ctx, characterID); err != nil {
 				return false, err
 			}
+			if err := s.updateOrderItemValue(ctx, characterID); err != nil {
+				return false, err
+			}
+
 			return true, nil
 		})
 }
 
+func (s *CharacterService) updateOrderItemValue(ctx context.Context, characterID int64) error {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("updateOrderItemValue: %d: %w", characterID, err)
+	}
+	v, err := s.st.CalculateCharacterOrderItemsValue(ctx, characterID)
+	if err != nil {
+		return wrapErr(err)
+	}
+	err = s.st.UpdateCharacterOrderItemsValue(ctx, characterID, optional.New(v))
+	if err != nil {
+		wrapErr(err)
+	}
+	return nil
+}
+
 func (s *CharacterService) updateOrdersEscrow(ctx context.Context, characterID int64) error {
 	wrapErr := func(err error) error {
-		return fmt.Errorf("calculateMarketEscrow: %d: %w", characterID, err)
-	}
-	if characterID == 0 {
-		return wrapErr(app.ErrInvalid)
+		return fmt.Errorf("updateOrdersEscrow: %d: %w", characterID, err)
 	}
 	oo, err := s.st.ListCharacterMarketOrders(ctx, characterID)
 	if err != nil {

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -27,7 +27,7 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 		return false, fmt.Errorf("wrong section for update %s: %w", arg.section, app.ErrInvalid)
 	}
 	const openState = "open"
-	return s.updateSectionIfChanged(
+	changed, err := s.updateSectionIfChanged(
 		ctx, arg, false,
 		func(ctx context.Context, characterID int64) (any, error) {
 			ctx = xgoesi.NewContextWithOperationID(ctx, "GetCharactersCharacterIdOrders")
@@ -197,16 +197,29 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 				slog.Info("Deleted stale market orders", "characterID", characterID, "count", stale.Size())
 			}
 
-			// update calculated values
-			if err := s.updateOrdersEscrow(ctx, characterID); err != nil {
-				return false, err
-			}
-			if err := s.updateOrderItemValue(ctx, characterID); err != nil {
-				return false, err
-			}
-
 			return true, nil
-		})
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	// update calculated values
+	c, err := s.st.GetCharacter(ctx, arg.characterID)
+	if err != nil {
+		return false, err
+	}
+	if arg.forceUpdate || changed || c.OrdersEscrow.IsEmpty() {
+		if err := s.updateOrdersEscrow(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+	if arg.forceUpdate || changed || c.OrderItemsValue.IsEmpty() {
+		if err := s.updateOrderItemValue(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+	return changed, nil
 }
 
 func (s *CharacterService) updateOrderItemValue(ctx context.Context, characterID int64) error {

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -197,6 +197,7 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 				slog.Info("Deleted stale market orders", "characterID", characterID, "count", stale.Size())
 			}
 
+			// update calculated values
 			if err := s.updateOrdersEscrow(ctx, characterID); err != nil {
 				return false, err
 			}

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -228,20 +228,11 @@ func (s *CharacterService) updateOrdersEscrow(ctx context.Context, characterID i
 	wrapErr := func(err error) error {
 		return fmt.Errorf("updateOrdersEscrow: %d: %w", characterID, err)
 	}
-	oo, err := s.st.ListCharacterMarketOrders(ctx, characterID)
+	v, err := s.st.CalculateCharacterOrdersEscrow(ctx, characterID)
 	if err != nil {
-		return wrapErr(err)
+		wrapErr(err)
 	}
-	var escrow float64
-	for _, o := range oo {
-		if v, ok := o.IsBuyOrder.Value(); !ok || !v {
-			continue
-		}
-		if v, ok := o.Escrow.Value(); ok {
-			escrow += v
-		}
-	}
-	err = s.st.UpdateCharacterOrdersEscrow(ctx, characterID, optional.New(escrow))
+	err = s.st.UpdateCharacterOrdersEscrow(ctx, characterID, optional.New(v))
 	if err != nil {
 		wrapErr(err)
 	}

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -232,7 +232,7 @@ func (s *CharacterService) updateOrderItemValue(ctx context.Context, characterID
 	}
 	err = s.st.UpdateCharacterOrderItemsValue(ctx, characterID, optional.New(v))
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	return nil
 }
@@ -243,11 +243,11 @@ func (s *CharacterService) updateOrdersEscrow(ctx context.Context, characterID i
 	}
 	v, err := s.st.CalculateCharacterOrdersEscrow(ctx, characterID)
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	err = s.st.UpdateCharacterOrdersEscrow(ctx, characterID, optional.New(v))
 	if err != nil {
-		wrapErr(err)
+		return wrapErr(err)
 	}
 	return nil
 }

--- a/internal/app/characterservice/market.go
+++ b/internal/app/characterservice/market.go
@@ -121,7 +121,7 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 				} else {
 					ownerID = characterID
 				}
-				arg := storage.UpdateOrCreateCharacterMarketOrderParams{
+				err := s.st.UpdateOrCreateCharacterMarketOrder(ctx, storage.UpdateOrCreateCharacterMarketOrderParams{
 					CharacterID:   characterID,
 					Duration:      o.Duration,
 					IsBuyOrder:    optional.FromPtr(o.IsBuyOrder),
@@ -139,8 +139,8 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 					VolumeTotal:   o.VolumeTotal,
 					Escrow:        optional.FromPtr(o.Escrow),
 					MinVolume:     optional.FromPtr(o.MinVolume),
-				}
-				if err := s.st.UpdateOrCreateCharacterMarketOrder(ctx, arg); err != nil {
+				})
+				if err != nil {
 					return false, err
 				}
 			}
@@ -196,6 +196,37 @@ func (s *CharacterService) updateMarketOrdersESI(ctx context.Context, arg charac
 				}
 				slog.Info("Deleted stale market orders", "characterID", characterID, "count", stale.Size())
 			}
+
+			if err := s.updateOrdersEscrow(ctx, characterID); err != nil {
+				return false, err
+			}
 			return true, nil
 		})
+}
+
+func (s *CharacterService) updateOrdersEscrow(ctx context.Context, characterID int64) error {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("calculateMarketEscrow: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return wrapErr(app.ErrInvalid)
+	}
+	oo, err := s.st.ListCharacterMarketOrders(ctx, characterID)
+	if err != nil {
+		return wrapErr(err)
+	}
+	var escrow float64
+	for _, o := range oo {
+		if v, ok := o.IsBuyOrder.Value(); !ok || !v {
+			continue
+		}
+		if v, ok := o.Escrow.Value(); ok {
+			escrow += v
+		}
+	}
+	err = s.st.UpdateCharacterOrdersEscrow(ctx, characterID, optional.New(escrow))
+	if err != nil {
+		wrapErr(err)
+	}
+	return nil
 }

--- a/internal/app/characterservice/market_internal_test.go
+++ b/internal/app/characterservice/market_internal_test.go
@@ -345,8 +345,6 @@ func TestUpdateCharacterMarketOrdersESI(t *testing.T) {
 func TestUpdateOrdersEscrow(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	s := NewFake(Params{Storage: st})
 
 	cases := []struct {
@@ -388,4 +386,42 @@ func TestUpdateOrdersEscrow(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestUpdateOrderItemValue(t *testing.T) {
+	// given
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	c := factory.CreateCharacter()
+	o1 := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+		CharacterID:   c.ID,
+		IsBuyOrder:    optional.New(false),
+		State:         app.OrderOpen,
+		VolumeRemains: 1,
+	})
+	o2 := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+		CharacterID:   c.ID,
+		IsBuyOrder:    optional.New(false),
+		State:         app.OrderOpen,
+		VolumeRemains: 2,
+	})
+	factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+		TypeID:       o1.Type.ID,
+		AveragePrice: optional.New(100.1),
+	})
+	factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+		TypeID:       o2.Type.ID,
+		AveragePrice: optional.New(200.2),
+	})
+
+	// when
+	err := s.updateOrderItemValue(t.Context(), c.ID)
+
+	// then
+	require.NoError(t, err)
+	c2, err := st.GetCharacter(t.Context(), c.ID)
+	require.NoError(t, err)
+	got := c2.OrderItemsValue
+	assert.Equal(t, optional.New(500.5), got)
 }

--- a/internal/app/characterservice/market_internal_test.go
+++ b/internal/app/characterservice/market_internal_test.go
@@ -342,52 +342,6 @@ func TestUpdateCharacterMarketOrdersESI(t *testing.T) {
 	})
 }
 
-func TestUpdateOrdersEscrow(t *testing.T) {
-	db, st, factory := testutil.NewDBOnDisk(t)
-	defer db.Close()
-	s := NewFake(Params{Storage: st})
-
-	cases := []struct {
-		name             string
-		firstIsBuyOrder  optional.Optional[bool]
-		firstEscrow      optional.Optional[float64]
-		secondIsBuyOrder optional.Optional[bool]
-		secondEscrow     optional.Optional[float64]
-		want             optional.Optional[float64]
-	}{
-		{"normal", optional.New(true), optional.New(12.3), optional.New(true), optional.New(10.0), optional.New(22.3)},
-		{"buy order without escrow", optional.New(true), optional.Optional[float64]{}, optional.New(true), optional.New(10.0), optional.New(10.0)},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// given
-			testutil.MustTruncateTables(db)
-			c := factory.CreateCharacter()
-			factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
-				CharacterID: c.ID,
-				IsBuyOrder:  tc.firstIsBuyOrder,
-				Escrow:      tc.firstEscrow,
-			})
-			factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
-				CharacterID: c.ID,
-				IsBuyOrder:  tc.secondIsBuyOrder,
-				Escrow:      tc.secondEscrow,
-			})
-			factory.CreateCharacterMarketOrder() // should be ignored
-
-			// when
-			err := s.updateOrdersEscrow(t.Context(), c.ID)
-
-			// then
-			require.NoError(t, err)
-			c2, err := st.GetCharacter(t.Context(), c.ID)
-			require.NoError(t, err)
-			got := c2.OrdersEscrow
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func TestUpdateOrderItemValue(t *testing.T) {
 	// given
 	db, st, factory := testutil.NewDBOnDisk(t)
@@ -424,4 +378,33 @@ func TestUpdateOrderItemValue(t *testing.T) {
 	require.NoError(t, err)
 	got := c2.OrderItemsValue
 	assert.Equal(t, optional.New(500.5), got)
+}
+
+func TestUpdateOrdersEscrow(t *testing.T) {
+	// given
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	c := factory.CreateCharacter()
+	factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+		CharacterID: c.ID,
+		IsBuyOrder:  optional.New(true),
+		Escrow:      optional.New(10.2),
+	})
+	factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+		CharacterID: c.ID,
+		IsBuyOrder:  optional.New(true),
+		Escrow:      optional.New(5.0),
+	})
+	factory.CreateCharacterMarketOrder() // should be ignored
+
+	// when
+	err := s.updateOrdersEscrow(t.Context(), c.ID)
+
+	// then
+	require.NoError(t, err)
+	c2, err := st.GetCharacter(t.Context(), c.ID)
+	require.NoError(t, err)
+	got := c2.OrdersEscrow
+	assert.Equal(t, optional.New(15.2), got)
 }

--- a/internal/app/characterservice/market_internal_test.go
+++ b/internal/app/characterservice/market_internal_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/go-set"
 
@@ -339,4 +340,52 @@ func TestUpdateCharacterMarketOrdersESI(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestUpdateOrdersEscrow(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := NewFake(Params{Storage: st})
+
+	cases := []struct {
+		name             string
+		firstIsBuyOrder  optional.Optional[bool]
+		firstEscrow      optional.Optional[float64]
+		secondIsBuyOrder optional.Optional[bool]
+		secondEscrow     optional.Optional[float64]
+		want             optional.Optional[float64]
+	}{
+		{"normal", optional.New(true), optional.New(12.3), optional.New(true), optional.New(10.0), optional.New(22.3)},
+		{"buy order without escrow", optional.New(true), optional.Optional[float64]{}, optional.New(true), optional.New(10.0), optional.New(10.0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			c := factory.CreateCharacter()
+			factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+				CharacterID: c.ID,
+				IsBuyOrder:  tc.firstIsBuyOrder,
+				Escrow:      tc.firstEscrow,
+			})
+			factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+				CharacterID: c.ID,
+				IsBuyOrder:  tc.secondIsBuyOrder,
+				Escrow:      tc.secondEscrow,
+			})
+			factory.CreateCharacterMarketOrder() // should be ignored
+
+			// when
+			err := s.updateOrdersEscrow(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			c2, err := st.GetCharacter(t.Context(), c.ID)
+			require.NoError(t, err)
+			got := c2.OrdersEscrow
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/app/characterservice/section.go
+++ b/internal/app/characterservice/section.go
@@ -182,8 +182,6 @@ func (s *CharacterService) UpdateCharacterAndRefreshIfNeeded(ctx context.Context
 	slog.Debug("Started updating character", "characterID", characterID, "sections", sections, "forceUpdate", forceUpdate)
 	wg.Wait()
 
-	// Update calculated values
-
 	slog.Debug("Finished updating character", "characterID", characterID, "sections", sections, "forceUpdate", forceUpdate)
 }
 

--- a/internal/app/characterservice/section.go
+++ b/internal/app/characterservice/section.go
@@ -181,6 +181,9 @@ func (s *CharacterService) UpdateCharacterAndRefreshIfNeeded(ctx context.Context
 	}
 	slog.Debug("Started updating character", "characterID", characterID, "sections", sections, "forceUpdate", forceUpdate)
 	wg.Wait()
+
+	// Update calculated values
+
 	slog.Debug("Finished updating character", "characterID", characterID, "sections", sections, "forceUpdate", forceUpdate)
 }
 

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -357,7 +357,7 @@ func (s *CharacterService) updateSkillqueueESI(ctx context.Context, arg characte
 	if arg.section != app.SectionCharacterSkillqueue {
 		return false, fmt.Errorf("wrong section for update %s: %w", arg.section, app.ErrInvalid)
 	}
-	return s.updateSectionIfChanged(
+	changed, err := s.updateSectionIfChanged(
 		ctx, arg, false,
 		func(ctx context.Context, characterID int64) (any, error) {
 			ctx = xgoesi.NewContextWithOperationID(ctx, "GetCharactersCharacterIdSkillqueue")
@@ -395,6 +395,64 @@ func (s *CharacterService) updateSkillqueueESI(ctx context.Context, arg characte
 			}
 			slog.Info("Stored updated skillqueue items", "characterID", characterID, "count", len(items))
 			return true, nil
-		})
+		},
+	)
+	if err != nil {
+		return false, err
+	}
 
+	// update calculated values
+	c, err := s.st.GetCharacter(ctx, arg.characterID)
+	if err != nil {
+		return false, err
+	}
+	if arg.forceUpdate || changed || c.SkillPointsValue.IsEmpty() {
+		if err := s.updateSkillPointValue(ctx, arg.characterID); err != nil {
+			return false, err
+		}
+	}
+
+	return changed, nil
+}
+
+func (s *CharacterService) updateSkillPointValue(ctx context.Context, characterID int64) error {
+	const (
+		spLowerThreshold         = 5_500_000
+		spPerLargeSkillExtractor = 500_000
+	)
+	wrapErr := func(err error) error {
+		return fmt.Errorf("updateSkillPointValue: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return wrapErr(app.ErrInvalid)
+	}
+	o, err := s.st.GetCharacter(ctx, characterID)
+	if err != nil {
+		return wrapErr(err)
+	}
+	extractorPrice, err := s.eus.MarketPrice(ctx, app.EveTypeSkillExtractor)
+	if err != nil {
+		return wrapErr(err)
+	}
+	injectorPrice, err := s.eus.MarketPrice(ctx, app.EveTypeLargeSkillInjector)
+	if err != nil {
+		return wrapErr(err)
+	}
+	var value optional.Optional[float64]
+	if extractor, ok := extractorPrice.Value(); ok {
+		if injector, ok := injectorPrice.Value(); ok {
+			if trainedSP, ok := o.TrainedSP.Value(); ok {
+				if unallocatedSP, ok := o.UnallocatedSP.Value(); ok {
+					totalSP := float64(trainedSP + unallocatedSP)
+					v := (injector - extractor) * (max(0, totalSP-spLowerThreshold) / spPerLargeSkillExtractor)
+					value.Set(v)
+				}
+			}
+		}
+	}
+	err = s.st.UpdateCharacterSkillPointsValue(ctx, characterID, value)
+	if err != nil {
+		return wrapErr(err)
+	}
+	return nil
 }

--- a/internal/app/characterservice/skills_internal_test.go
+++ b/internal/app/characterservice/skills_internal_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/ErikKalkoken/go-set"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
@@ -159,11 +161,11 @@ func TestUpdateCharacterSkillsESI(t *testing.T) {
 		factory.CreateEveType(storage.CreateEveTypeParams{ID: 42})
 		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID: c.ID,
-			TypeID:   41,
+			TypeID:      41,
 		})
 		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID: c.ID,
-			TypeID:   42,
+			TypeID:      42,
 		})
 		data := map[string]any{
 			"skills": []map[string]any{
@@ -273,5 +275,42 @@ func TestUpdateSkillqueueESI(t *testing.T) {
 				assert.Len(t, ii, 3)
 			}
 		}
+	})
+}
+
+func TestUpdateSkllPointsValue(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("should create new queue", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacterFull(storage.CreateCharacterParams{
+			TotalSP:       optional.New(9_000_000),
+			UnallocatedSP: optional.New(1_500_000),
+		})
+		injectorType := factory.CreateEveType(storage.CreateEveTypeParams{
+			ID: app.EveTypeLargeSkillInjector,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       injectorType.ID,
+			AveragePrice: optional.New(110_000.0),
+		})
+		extractorType := factory.CreateEveType(storage.CreateEveTypeParams{
+			ID: app.EveTypeSkillExtractor,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       extractorType.ID,
+			AveragePrice: optional.New(10_000.0),
+		})
+
+		// when
+		err := s.updateSkillPointValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(t.Context(), c.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, 1_000_000, c2.SkillPointsValue.ValueOrZero())
 	})
 }

--- a/internal/app/corporationservice/wallet.go
+++ b/internal/app/corporationservice/wallet.go
@@ -125,7 +125,7 @@ func (s *CorporationService) GetWalletBalancesTotal(ctx context.Context, corpora
 		return b, nil
 	}
 	for _, o := range oo {
-		b = optional.Sum(b, optional.New(o.Balance))
+		b = optional.SumNonEmpty(b, optional.New(o.Balance))
 	}
 	return b, nil
 }

--- a/internal/app/evetype.go
+++ b/internal/app/evetype.go
@@ -82,10 +82,12 @@ const (
 	EveTypeInfomorphSynchronizing      = 33399
 	EveTypeInterplanetaryConsolidation = 2495
 	EveTypeLaboratoryOperation         = 3406
+	EveTypeLargeSkillInjector          = 40520
 	EveTypeMassProduction              = 3387
 	EveTypeMassReactions               = 45748
 	EveTypeOffice                      = 27
 	EveTypePlanetTemperate             = 11
+	EveTypeSkillExtractor              = 40519
 	EveTypeSolarSystem                 = 5
 	EveTypeTCU                         = 32226
 )

--- a/internal/app/signals.go
+++ b/internal/app/signals.go
@@ -32,6 +32,9 @@ type EveUniverseSectionUpdated struct {
 // Signals represents the app's event signals.
 // It is safe for concurrent use.
 type Signals struct {
+	// The app is initialized
+	AppInit signals.Signal[struct{}]
+
 	// A character was added.
 	CharacterAdded signals.Signal[*Character]
 
@@ -85,6 +88,7 @@ type Signals struct {
 
 func NewSignals() *Signals {
 	s := &Signals{
+		AppInit:                     signals.New[struct{}](),
 		CharacterAdded:              signals.New[*Character](),
 		CharacterChanged:            signals.New[int64](),
 		CharacterRemoved:            signals.New[*EntityShort](),

--- a/internal/app/signals.go
+++ b/internal/app/signals.go
@@ -38,6 +38,9 @@ type Signals struct {
 	// A character was added.
 	CharacterAdded signals.Signal[*Character]
 
+	// A Character field has changed (e.g. number of unread messages).
+	CharacterChanged signals.Signal[int64]
+
 	// A character was removed.
 	CharacterRemoved signals.Signal[*EntityShort]
 
@@ -73,9 +76,6 @@ type Signals struct {
 
 	// A tag as been added, removed or renamed.
 	TagsChanged signals.Signal[struct{}]
-
-	// A Character has changed [only: trainingWatcher].
-	CharacterChanged signals.Signal[int64]
 
 	// A section update has started.
 	UpdateStarted signals.Signal[string]

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -17,32 +17,34 @@ import (
 )
 
 type CreateCharacterParams struct {
-	AssetValue        optional.Optional[float64]
-	ContractEscrow    optional.Optional[float64]
-	HomeID            optional.Optional[int64]
-	ID                int64
-	IsTrainingWatched bool
-	LastCloneJumpAt   optional.Optional[time.Time]
-	LastLoginAt       optional.Optional[time.Time]
-	LocationID        optional.Optional[int64]
-	MarketEscrow      optional.Optional[float64]
-	ShipID            optional.Optional[int64]
-	TotalSP           optional.Optional[int]
-	UnallocatedSP     optional.Optional[int]
-	WalletBalance     optional.Optional[float64]
+	AssetValue         optional.Optional[float64]
+	ContractItemsValue optional.Optional[float64]
+	ContractsEscrow    optional.Optional[float64]
+	HomeID             optional.Optional[int64]
+	ID                 int64
+	IsTrainingWatched  bool
+	LastCloneJumpAt    optional.Optional[time.Time]
+	LastLoginAt        optional.Optional[time.Time]
+	LocationID         optional.Optional[int64]
+	OrderItemsValue    optional.Optional[float64]
+	OrdersEscrow       optional.Optional[float64]
+	ShipID             optional.Optional[int64]
+	TotalSP            optional.Optional[int]
+	UnallocatedSP      optional.Optional[int]
+	WalletBalance      optional.Optional[float64]
 }
 
 func (st *Storage) CreateCharacter(ctx context.Context, arg CreateCharacterParams) error {
 	err := st.qRW.CreateCharacter(ctx, queries.CreateCharacterParams{
 		ID:                arg.ID,
 		AssetValue:        optional.ToNullFloat64(arg.AssetValue),
-		ContractEscrow:    optional.ToNullFloat64(arg.ContractEscrow),
-		MarketEscrow:      optional.ToNullFloat64(arg.MarketEscrow),
-		IsTrainingWatched: arg.IsTrainingWatched,
+		ContractsEscrow:   optional.ToNullFloat64(arg.ContractsEscrow),
 		HomeID:            optional.ToNullInt64(arg.HomeID),
+		IsTrainingWatched: arg.IsTrainingWatched,
 		LastCloneJumpAt:   optional.ToNullTime(arg.LastCloneJumpAt),
 		LastLoginAt:       optional.ToNullTime(arg.LastLoginAt),
 		LocationID:        optional.ToNullInt64(arg.LocationID),
+		OrdersEscrow:      optional.ToNullFloat64(arg.OrdersEscrow),
 		ShipID:            optional.ToNullInt64(arg.ShipID),
 		TotalSp:           optional.ToNullInt64(arg.TotalSP),
 		UnallocatedSp:     optional.ToNullInt64(arg.UnallocatedSP),
@@ -229,121 +231,144 @@ func (st *Storage) listCharacterIDs(ctx context.Context, q *queries.Queries) (se
 }
 
 func (st *Storage) UpdateCharacterAssetValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
-	arg := queries.UpdateCharacterAssetValueParams{
+	err := st.qRW.UpdateCharacterAssetValue(ctx, queries.UpdateCharacterAssetValueParams{
 		ID:         characterID,
 		AssetValue: optional.ToNullFloat64(v),
-	}
-	if err := st.qRW.UpdateCharacterAssetValue(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update asset value for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterHome(ctx context.Context, characterID int64, homeID optional.Optional[int64]) error {
-	arg := queries.UpdateCharacterHomeIdParams{
+	err := st.qRW.UpdateCharacterHomeId(ctx, queries.UpdateCharacterHomeIdParams{
 		ID:     characterID,
 		HomeID: optional.ToNullInt64(homeID),
-	}
-	if err := st.qRW.UpdateCharacterHomeId(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update home for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterIsTrainingWatched(ctx context.Context, characterID int64, isWatched bool) error {
-	arg := queries.UpdateCharacterIsTrainingWatchedParams{
+	err := st.qRW.UpdateCharacterIsTrainingWatched(ctx, queries.UpdateCharacterIsTrainingWatchedParams{
 		ID:                characterID,
 		IsTrainingWatched: isWatched,
-	}
-	if err := st.qRW.UpdateCharacterIsTrainingWatched(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update is training watched for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterLastCloneJump(ctx context.Context, characterID int64, v optional.Optional[time.Time]) error {
-	arg := queries.UpdateCharacterLastCloneJumpParams{
+	err := st.qRW.UpdateCharacterLastCloneJump(ctx, queries.UpdateCharacterLastCloneJumpParams{
 		ID:              characterID,
 		LastCloneJumpAt: optional.ToNullTime(v),
-	}
-	if err := st.qRW.UpdateCharacterLastCloneJump(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update last clone jump for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterLastLoginAt(ctx context.Context, characterID int64, v optional.Optional[time.Time]) error {
-	arg := queries.UpdateCharacterLastLoginAtParams{
+	err := st.qRW.UpdateCharacterLastLoginAt(ctx, queries.UpdateCharacterLastLoginAtParams{
 		ID:          characterID,
 		LastLoginAt: optional.ToNullTime(v),
-	}
-	if err := st.qRW.UpdateCharacterLastLoginAt(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update last login for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterLocation(ctx context.Context, characterID int64, locationID optional.Optional[int64]) error {
-	arg := queries.UpdateCharacterLocationIDParams{
+	err := st.qRW.UpdateCharacterLocationID(ctx, queries.UpdateCharacterLocationIDParams{
 		ID:         characterID,
 		LocationID: optional.ToNullInt64(locationID),
-	}
-	if err := st.qRW.UpdateCharacterLocationID(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update location for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
-func (st *Storage) UpdateCharacterContractEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
-	arg := queries.UpdateCharacterContractEscrowParams{
-		ID:             characterID,
-		ContractEscrow: optional.ToNullFloat64(v),
-	}
-	if err := st.qRW.UpdateCharacterContractEscrow(ctx, arg); err != nil {
-		return fmt.Errorf("UpdateCharacterMarketEscrow for character %d: %w", characterID, err)
+func (st *Storage) UpdateCharacterContractsEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	err := st.qRW.UpdateCharacterContractsEscrow(ctx, queries.UpdateCharacterContractsEscrowParams{
+		ID:              characterID,
+		ContractsEscrow: optional.ToNullFloat64(v),
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateCharacterOrdersEscrow for character %d: %w", characterID, err)
 	}
 	return nil
 }
-func (st *Storage) UpdateCharacterMarketEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
-	arg := queries.UpdateCharacterMarketEscrowParams{
-		ID:           characterID,
-		MarketEscrow: optional.ToNullFloat64(v),
+
+func (st *Storage) UpdateCharacterContractItemsValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	err := st.qRW.UpdateCharacterContractItemsValue(ctx, queries.UpdateCharacterContractItemsValueParams{
+		ID:                 characterID,
+		ContractItemsValue: optional.ToNullFloat64(v),
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateCharacterContractItemsValue for character %d: %w", characterID, err)
 	}
-	if err := st.qRW.UpdateCharacterMarketEscrow(ctx, arg); err != nil {
-		return fmt.Errorf("UpdateCharacterMarketEscrow for character %d: %w", characterID, err)
+	return nil
+}
+
+func (st *Storage) UpdateCharacterOrdersEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	err := st.qRW.UpdateCharacterOrdersEscrow(ctx, queries.UpdateCharacterOrdersEscrowParams{
+		ID:           characterID,
+		OrdersEscrow: optional.ToNullFloat64(v),
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateCharacterOrdersEscrow for character %d: %w", characterID, err)
+	}
+	return nil
+}
+
+func (st *Storage) UpdateCharacterOrderItemsValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	err := st.qRW.UpdateCharacterOrderItemsValue(ctx, queries.UpdateCharacterOrderItemsValueParams{
+		ID:              characterID,
+		OrderItemsValue: optional.ToNullFloat64(v),
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateCharacterOrderItemsValue for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterShip(ctx context.Context, characterID int64, shipID optional.Optional[int64]) error {
-	arg := queries.UpdateCharacterShipIDParams{
+	err := st.qRW.UpdateCharacterShipID(ctx, queries.UpdateCharacterShipIDParams{
 		ID:     characterID,
 		ShipID: optional.ToNullInt64(shipID),
-	}
-	if err := st.qRW.UpdateCharacterShipID(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update ship for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterSkillPoints(ctx context.Context, characterID int64, totalSP, unallocatedSP optional.Optional[int64]) error {
-	arg := queries.UpdateCharacterSPParams{
+	err := st.qRW.UpdateCharacterSP(ctx, queries.UpdateCharacterSPParams{
 		ID:            characterID,
 		TotalSp:       optional.ToNullInt64(totalSP),
 		UnallocatedSp: optional.ToNullInt64(unallocatedSP),
-	}
-	if err := st.qRW.UpdateCharacterSP(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update sp for character %d: %w", characterID, err)
 	}
 	return nil
 }
 
 func (st *Storage) UpdateCharacterWalletBalance(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
-	arg := queries.UpdateCharacterWalletBalanceParams{
+	err := st.qRW.UpdateCharacterWalletBalance(ctx, queries.UpdateCharacterWalletBalanceParams{
 		ID:            characterID,
 		WalletBalance: optional.ToNullFloat64(v),
-	}
-	if err := st.qRW.UpdateCharacterWalletBalance(ctx, arg); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("update wallet balance for character %d: %w", characterID, err)
 	}
 	return nil
@@ -364,17 +389,19 @@ func (st *Storage) characterFromDBModel(
 	shipID sql.NullInt64,
 ) (*app.Character, error) {
 	o := app.Character{
-		AssetValue:        optional.FromNullFloat64(character.AssetValue),
-		ContractEscrow:    optional.FromNullFloat64(character.ContractEscrow),
-		EveCharacter:      eveCharacterFromDBModel(eveCharacter, corporation, race, alliance, faction),
-		ID:                character.ID,
-		IsTrainingWatched: character.IsTrainingWatched,
-		LastCloneJumpAt:   optional.FromNullTime(character.LastCloneJumpAt),
-		LastLoginAt:       optional.FromNullTime(character.LastLoginAt),
-		MarketEscrow:      optional.FromNullFloat64(character.MarketEscrow),
-		TrainedSP:         optional.FromNullInt64(character.TotalSp),
-		UnallocatedSP:     optional.FromNullInt64(character.UnallocatedSp),
-		WalletBalance:     optional.FromNullFloat64(character.WalletBalance),
+		AssetValue:         optional.FromNullFloat64(character.AssetValue),
+		ContractItemsValue: optional.FromNullFloat64(character.ContractItemsValue),
+		ContractsEscrow:    optional.FromNullFloat64(character.ContractsEscrow),
+		EveCharacter:       eveCharacterFromDBModel(eveCharacter, corporation, race, alliance, faction),
+		ID:                 character.ID,
+		IsTrainingWatched:  character.IsTrainingWatched,
+		LastCloneJumpAt:    optional.FromNullTime(character.LastCloneJumpAt),
+		LastLoginAt:        optional.FromNullTime(character.LastLoginAt),
+		OrderItemsValue:    optional.FromNullFloat64(character.OrderItemsValue),
+		OrdersEscrow:       optional.FromNullFloat64(character.OrdersEscrow),
+		TrainedSP:          optional.FromNullInt64(character.TotalSp),
+		UnallocatedSP:      optional.FromNullInt64(character.UnallocatedSp),
+		WalletBalance:      optional.FromNullFloat64(character.WalletBalance),
 	}
 	if homeID.Valid {
 		x, err := st.GetLocation(ctx, homeID.Int64)

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -335,7 +335,7 @@ func (st *Storage) characterFromDBModel(
 		IsTrainingWatched: character.IsTrainingWatched,
 		LastCloneJumpAt:   optional.FromNullTime(character.LastCloneJumpAt),
 		LastLoginAt:       optional.FromNullTime(character.LastLoginAt),
-		TrainedSP:           optional.FromNullInt64(character.TotalSp),
+		TrainedSP:         optional.FromNullInt64(character.TotalSp),
 		UnallocatedSP:     optional.FromNullInt64(character.UnallocatedSp),
 		WalletBalance:     optional.FromNullFloat64(character.WalletBalance),
 	}
@@ -369,4 +369,30 @@ func (st *Storage) GetCharacterAssetValue(ctx context.Context, id int64) (option
 		return optional.Optional[float64]{}, fmt.Errorf("get asset value for character %d: %w", id, convertGetError(err))
 	}
 	return optional.FromNullFloat64(v), nil
+}
+
+func (st *Storage) ListCharacterWealthValues(ctx context.Context) ([]*app.CharacterWealth, error) {
+	rows, err := st.qRO.ListCharacterWealthValues(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ListCharacterWealthValues: %w", err)
+
+	}
+	var oo []*app.CharacterWealth
+	for _, r := range rows {
+		assets := optional.FromNullFloat64(r.AssetValue)
+		wallets := optional.FromNullFloat64(r.WalletBalance)
+		var total optional.Optional[float64]
+		if v1, ok := assets.Value(); ok {
+			if v2, ok := wallets.Value(); ok {
+				total.Set(v1 + v2)
+			}
+		}
+		oo = append(oo, &app.CharacterWealth{
+			Assets:      assets,
+			CharacterID: r.ID,
+			Total:       total,
+			Wallet:      wallets,
+		})
+	}
+	return oo, nil
 }

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -18,12 +18,14 @@ import (
 
 type CreateCharacterParams struct {
 	AssetValue        optional.Optional[float64]
+	ContractEscrow    optional.Optional[float64]
+	HomeID            optional.Optional[int64]
 	ID                int64
 	IsTrainingWatched bool
-	HomeID            optional.Optional[int64]
 	LastCloneJumpAt   optional.Optional[time.Time]
 	LastLoginAt       optional.Optional[time.Time]
 	LocationID        optional.Optional[int64]
+	MarketEscrow      optional.Optional[float64]
 	ShipID            optional.Optional[int64]
 	TotalSP           optional.Optional[int]
 	UnallocatedSP     optional.Optional[int]
@@ -34,6 +36,8 @@ func (st *Storage) CreateCharacter(ctx context.Context, arg CreateCharacterParam
 	err := st.qRW.CreateCharacter(ctx, queries.CreateCharacterParams{
 		ID:                arg.ID,
 		AssetValue:        optional.ToNullFloat64(arg.AssetValue),
+		ContractEscrow:    optional.ToNullFloat64(arg.ContractEscrow),
+		MarketEscrow:      optional.ToNullFloat64(arg.MarketEscrow),
 		IsTrainingWatched: arg.IsTrainingWatched,
 		HomeID:            optional.ToNullInt64(arg.HomeID),
 		LastCloneJumpAt:   optional.ToNullTime(arg.LastCloneJumpAt),
@@ -132,6 +136,14 @@ func (st *Storage) GetAnyCharacter(ctx context.Context) (*app.Character, error) 
 	return o, nil
 }
 
+func (st *Storage) GetCharacterAssetValue(ctx context.Context, id int64) (optional.Optional[float64], error) {
+	v, err := st.qRO.GetCharacterAssetValue(ctx, id)
+	if err != nil {
+		return optional.Optional[float64]{}, fmt.Errorf("get asset value for character %d: %w", id, convertGetError(err))
+	}
+	return optional.FromNullFloat64(v), nil
+}
+
 func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error) {
 	rows, err := st.qRO.ListCharacters(ctx)
 	if err != nil {
@@ -216,6 +228,17 @@ func (st *Storage) listCharacterIDs(ctx context.Context, q *queries.Queries) (se
 	return ids2, nil
 }
 
+func (st *Storage) UpdateCharacterAssetValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	arg := queries.UpdateCharacterAssetValueParams{
+		ID:         characterID,
+		AssetValue: optional.ToNullFloat64(v),
+	}
+	if err := st.qRW.UpdateCharacterAssetValue(ctx, arg); err != nil {
+		return fmt.Errorf("update asset value for character %d: %w", characterID, err)
+	}
+	return nil
+}
+
 func (st *Storage) UpdateCharacterHome(ctx context.Context, characterID int64, homeID optional.Optional[int64]) error {
 	arg := queries.UpdateCharacterHomeIdParams{
 		ID:     characterID,
@@ -271,6 +294,27 @@ func (st *Storage) UpdateCharacterLocation(ctx context.Context, characterID int6
 	return nil
 }
 
+func (st *Storage) UpdateCharacterContractEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	arg := queries.UpdateCharacterContractEscrowParams{
+		ID:             characterID,
+		ContractEscrow: optional.ToNullFloat64(v),
+	}
+	if err := st.qRW.UpdateCharacterContractEscrow(ctx, arg); err != nil {
+		return fmt.Errorf("UpdateCharacterMarketEscrow for character %d: %w", characterID, err)
+	}
+	return nil
+}
+func (st *Storage) UpdateCharacterMarketEscrow(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	arg := queries.UpdateCharacterMarketEscrowParams{
+		ID:           characterID,
+		MarketEscrow: optional.ToNullFloat64(v),
+	}
+	if err := st.qRW.UpdateCharacterMarketEscrow(ctx, arg); err != nil {
+		return fmt.Errorf("UpdateCharacterMarketEscrow for character %d: %w", characterID, err)
+	}
+	return nil
+}
+
 func (st *Storage) UpdateCharacterShip(ctx context.Context, characterID int64, shipID optional.Optional[int64]) error {
 	arg := queries.UpdateCharacterShipIDParams{
 		ID:     characterID,
@@ -305,16 +349,7 @@ func (st *Storage) UpdateCharacterWalletBalance(ctx context.Context, characterID
 	return nil
 }
 
-func (st *Storage) UpdateCharacterAssetValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
-	arg := queries.UpdateCharacterAssetValueParams{
-		ID:         characterID,
-		AssetValue: optional.ToNullFloat64(v),
-	}
-	if err := st.qRW.UpdateCharacterAssetValue(ctx, arg); err != nil {
-		return fmt.Errorf("update asset value for character %d: %w", characterID, err)
-	}
-	return nil
-}
+// TODO: Optimize so additional queries are not needed
 
 func (st *Storage) characterFromDBModel(
 	ctx context.Context,
@@ -330,11 +365,13 @@ func (st *Storage) characterFromDBModel(
 ) (*app.Character, error) {
 	o := app.Character{
 		AssetValue:        optional.FromNullFloat64(character.AssetValue),
+		ContractEscrow:    optional.FromNullFloat64(character.ContractEscrow),
 		EveCharacter:      eveCharacterFromDBModel(eveCharacter, corporation, race, alliance, faction),
 		ID:                character.ID,
 		IsTrainingWatched: character.IsTrainingWatched,
 		LastCloneJumpAt:   optional.FromNullTime(character.LastCloneJumpAt),
 		LastLoginAt:       optional.FromNullTime(character.LastLoginAt),
+		MarketEscrow:      optional.FromNullFloat64(character.MarketEscrow),
 		TrainedSP:         optional.FromNullInt64(character.TotalSp),
 		UnallocatedSP:     optional.FromNullInt64(character.UnallocatedSp),
 		WalletBalance:     optional.FromNullFloat64(character.WalletBalance),
@@ -361,38 +398,4 @@ func (st *Storage) characterFromDBModel(
 		o.Ship = optional.New(x)
 	}
 	return &o, nil
-}
-
-func (st *Storage) GetCharacterAssetValue(ctx context.Context, id int64) (optional.Optional[float64], error) {
-	v, err := st.qRO.GetCharacterAssetValue(ctx, id)
-	if err != nil {
-		return optional.Optional[float64]{}, fmt.Errorf("get asset value for character %d: %w", id, convertGetError(err))
-	}
-	return optional.FromNullFloat64(v), nil
-}
-
-func (st *Storage) ListCharacterWealthValues(ctx context.Context) ([]*app.CharacterWealth, error) {
-	rows, err := st.qRO.ListCharacterWealthValues(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("ListCharacterWealthValues: %w", err)
-
-	}
-	var oo []*app.CharacterWealth
-	for _, r := range rows {
-		assets := optional.FromNullFloat64(r.AssetValue)
-		wallets := optional.FromNullFloat64(r.WalletBalance)
-		var total optional.Optional[float64]
-		if v1, ok := assets.Value(); ok {
-			if v2, ok := wallets.Value(); ok {
-				total.Set(v1 + v2)
-			}
-		}
-		oo = append(oo, &app.CharacterWealth{
-			Assets:      assets,
-			CharacterID: r.ID,
-			Total:       total,
-			Wallet:      wallets,
-		})
-	}
-	return oo, nil
 }

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -29,6 +29,7 @@ type CreateCharacterParams struct {
 	OrderItemsValue    optional.Optional[float64]
 	OrdersEscrow       optional.Optional[float64]
 	ShipID             optional.Optional[int64]
+	SkillPointsValue   optional.Optional[float64]
 	TotalSP            optional.Optional[int]
 	UnallocatedSP      optional.Optional[int]
 	WalletBalance      optional.Optional[float64]
@@ -36,19 +37,22 @@ type CreateCharacterParams struct {
 
 func (st *Storage) CreateCharacter(ctx context.Context, arg CreateCharacterParams) error {
 	err := st.qRW.CreateCharacter(ctx, queries.CreateCharacterParams{
-		ID:                arg.ID,
-		AssetValue:        optional.ToNullFloat64(arg.AssetValue),
-		ContractsEscrow:   optional.ToNullFloat64(arg.ContractsEscrow),
-		HomeID:            optional.ToNullInt64(arg.HomeID),
-		IsTrainingWatched: arg.IsTrainingWatched,
-		LastCloneJumpAt:   optional.ToNullTime(arg.LastCloneJumpAt),
-		LastLoginAt:       optional.ToNullTime(arg.LastLoginAt),
-		LocationID:        optional.ToNullInt64(arg.LocationID),
-		OrdersEscrow:      optional.ToNullFloat64(arg.OrdersEscrow),
-		ShipID:            optional.ToNullInt64(arg.ShipID),
-		TotalSp:           optional.ToNullInt64(arg.TotalSP),
-		UnallocatedSp:     optional.ToNullInt64(arg.UnallocatedSP),
-		WalletBalance:     optional.ToNullFloat64(arg.WalletBalance),
+		AssetValue:         optional.ToNullFloat64(arg.AssetValue),
+		ContractItemsValue: optional.ToNullFloat64(arg.ContractItemsValue),
+		ContractsEscrow:    optional.ToNullFloat64(arg.ContractsEscrow),
+		HomeID:             optional.ToNullInt64(arg.HomeID),
+		ID:                 arg.ID,
+		IsTrainingWatched:  arg.IsTrainingWatched,
+		LastCloneJumpAt:    optional.ToNullTime(arg.LastCloneJumpAt),
+		LastLoginAt:        optional.ToNullTime(arg.LastLoginAt),
+		LocationID:         optional.ToNullInt64(arg.LocationID),
+		OrderItemsValue:    optional.ToNullFloat64(arg.OrderItemsValue),
+		OrdersEscrow:       optional.ToNullFloat64(arg.OrdersEscrow),
+		ShipID:             optional.ToNullInt64(arg.ShipID),
+		SkillPointsValue:   optional.ToNullFloat64(arg.SkillPointsValue),
+		TotalSp:            optional.ToNullInt64(arg.TotalSP),
+		UnallocatedSp:      optional.ToNullInt64(arg.UnallocatedSP),
+		WalletBalance:      optional.ToNullFloat64(arg.WalletBalance),
 	})
 	if err != nil {
 		if sqliteErr, ok := err.(sqlite3.Error); ok {
@@ -363,6 +367,17 @@ func (st *Storage) UpdateCharacterSkillPoints(ctx context.Context, characterID i
 	return nil
 }
 
+func (st *Storage) UpdateCharacterSkillPointsValue(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
+	err := st.qRW.UpdateCharacterSkillPointsValue(ctx, queries.UpdateCharacterSkillPointsValueParams{
+		ID:               characterID,
+		SkillPointsValue: optional.ToNullFloat64(v),
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateCharacterSkillPointsValue for character %d: %w", characterID, err)
+	}
+	return nil
+}
+
 func (st *Storage) UpdateCharacterWalletBalance(ctx context.Context, characterID int64, v optional.Optional[float64]) error {
 	err := st.qRW.UpdateCharacterWalletBalance(ctx, queries.UpdateCharacterWalletBalanceParams{
 		ID:            characterID,
@@ -399,6 +414,7 @@ func (st *Storage) characterFromDBModel(
 		LastLoginAt:        optional.FromNullTime(character.LastLoginAt),
 		OrderItemsValue:    optional.FromNullFloat64(character.OrderItemsValue),
 		OrdersEscrow:       optional.FromNullFloat64(character.OrdersEscrow),
+		SkillPointsValue:   optional.FromNullFloat64(character.SkillPointsValue),
 		TrainedSP:          optional.FromNullInt64(character.TotalSp),
 		UnallocatedSP:      optional.FromNullInt64(character.UnallocatedSp),
 		WalletBalance:      optional.FromNullFloat64(character.WalletBalance),

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -547,5 +548,54 @@ func TestCharacterAssetValue(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.True(t, got.IsEmpty())
 		}
+	})
+}
+
+func TestCharacterWealth(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	// given
+	cases := []struct {
+		name      string
+		assets    optional.Optional[float64]
+		wallet    optional.Optional[float64]
+		totalWant optional.Optional[float64]
+	}{
+		{"all values exist", optional.New(1.0), optional.New(2.0), optional.New(3.0)},
+		{"missing wallet", optional.New(1.0), optional.Optional[float64]{}, optional.Optional[float64]{}},
+		{"missing assets", optional.Optional[float64]{}, optional.New(1.0), optional.Optional[float64]{}},
+		{"no values", optional.Optional[float64]{}, optional.Optional[float64]{}, optional.Optional[float64]{}},
+	}
+
+	for _, tc := range cases {
+		t.Run("can list when all value exist", func(t *testing.T) {
+			testutil.MustTruncateTables(db)
+			c := factory.CreateCharacter(storage.CreateCharacterParams{
+				AssetValue:    tc.assets,
+				WalletBalance: tc.wallet,
+			})
+			// when
+			oo, err := st.ListCharacterWealthValues(t.Context())
+			// then
+			require.NoError(t, err)
+			require.Len(t, oo, 1)
+			o := oo[0]
+			assert.Equal(t, c.ID, o.CharacterID)
+			assert.Equal(t, tc.assets, o.Assets)
+			assert.Equal(t, tc.wallet, o.Wallet)
+			assert.Equal(t, tc.totalWant, o.Total)
+		})
+	}
+
+	t.Run("can list characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterFull()
+		factory.CreateCharacterFull()
+		// when
+		oo, err := st.ListCharacterWealthValues(t.Context())
+		// then
+		require.NoError(t, err)
+		require.Len(t, oo, 2)
 	})
 }

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -279,6 +279,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
+
 	t.Run("can update home", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -292,6 +293,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, home, c2.Home.MustValue())
 	})
+
 	t.Run("can update last clone jump with a time", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -305,6 +307,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, x.UTC(), c2.LastCloneJumpAt.ValueOrZero().UTC())
 	})
+
 	t.Run("can update last clone jump with zero time", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -318,6 +321,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, x, c2.LastCloneJumpAt.MustValue())
 	})
+
 	t.Run("should return empty when last clone jump not updated", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -327,6 +331,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, c2.LastCloneJumpAt.IsEmpty())
 	})
+
 	t.Run("can update last login", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -339,8 +344,8 @@ func TestUpdateCharacterFields(t *testing.T) {
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, x.UTC(), c2.LastLoginAt.ValueOrZero().UTC())
-
 	})
+
 	t.Run("can update location", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -354,6 +359,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, location, c2.Location.MustValue())
 	})
+
 	t.Run("can update ship", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -367,6 +373,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, x, c2.Ship.MustValue())
 	})
+
 	t.Run("can update is training watched", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -379,6 +386,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, c2.IsTrainingWatched)
 	})
+
 	t.Run("can update is training watched 2", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -394,6 +402,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, c2.IsTrainingWatched)
 	})
+
 	t.Run("can update skill points", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -409,6 +418,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		xassert.Equal(t, totalSP, c2.TrainedSP)
 		xassert.Equal(t, unallocatedSP, c2.UnallocatedSP)
 	})
+
 	t.Run("can update wallet balance", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -422,6 +432,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, x, c2.WalletBalance.ValueOrZero())
 	})
+
 	t.Run("can disable all training watchers", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -442,31 +453,61 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, c2.IsTrainingWatched)
 	})
+
 	t.Run("can update contract escrow", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		c1 := factory.CreateCharacterFull()
 		x := rand.Float64() * 100_000_000
 		// when
-		err := st.UpdateCharacterContractEscrow(ctx, c1.ID, optional.New(x))
+		err := st.UpdateCharacterContractsEscrow(ctx, c1.ID, optional.New(x))
 		// then
 		require.NoError(t, err)
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, x, c2.ContractEscrow.ValueOrZero())
+		xassert.Equal(t, x, c2.ContractsEscrow.ValueOrZero())
 	})
+
 	t.Run("can update market escrow", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		c1 := factory.CreateCharacterFull()
 		x := rand.Float64() * 100_000_000
 		// when
-		err := st.UpdateCharacterMarketEscrow(ctx, c1.ID, optional.New(x))
+		err := st.UpdateCharacterOrdersEscrow(ctx, c1.ID, optional.New(x))
 		// then
 		require.NoError(t, err)
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, x, c2.MarketEscrow.ValueOrZero())
+		xassert.Equal(t, x, c2.OrdersEscrow.ValueOrZero())
+	})
+
+	t.Run("can update contract items value", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		x := rand.Float64() * 100_000_000
+		// when
+		err := st.UpdateCharacterContractItemsValue(ctx, c1.ID, optional.New(x))
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.ContractItemsValue.ValueOrZero())
+	})
+
+	t.Run("can update order items value", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		x := rand.Float64() * 100_000_000
+		// when
+		err := st.UpdateCharacterOrderItemsValue(ctx, c1.ID, optional.New(x))
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.OrderItemsValue.ValueOrZero())
 	})
 }
 

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -22,7 +22,7 @@ func TestCharacter(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
-	t.Run("can get with all dependencies", func(t *testing.T) {
+	t.Run("can get", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		a := factory.CreateEveEntityAlliance()
@@ -38,13 +38,18 @@ func TestCharacter(t *testing.T) {
 		require.NoError(t, err)
 		xassert.Equal(t, c1.ID, c2.ID)
 		xassert.Equal(t, c1.AssetValue, c2.AssetValue)
+		xassert.Equal(t, c1.ContractItemsValue, c2.ContractItemsValue)
+		xassert.Equal(t, c1.ContractsEscrow, c2.ContractsEscrow)
 		xassert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
 		xassert.Equal(t, c1.Home, c2.Home)
 		xassert.Equal(t, c1.IsTrainingWatched, c2.IsTrainingWatched)
 		xassert.Equal(t, c1.LastCloneJumpAt, c2.LastCloneJumpAt)
 		xassert.Equal(t, c1.LastLoginAt, c2.LastLoginAt)
 		xassert.Equal(t, c1.Location, c2.Location)
+		xassert.Equal(t, c1.OrderItemsValue, c2.OrderItemsValue)
+		xassert.Equal(t, c1.OrdersEscrow, c2.OrdersEscrow)
 		xassert.Equal(t, c1.Ship, c2.Ship)
+		xassert.Equal(t, c1.SkillPointsValue, c2.SkillPointsValue)
 		xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
 		xassert.Equal(t, c1.UnallocatedSP, c2.UnallocatedSP)
 		xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
@@ -81,7 +86,7 @@ func TestCharacter(t *testing.T) {
 	})
 }
 
-func TestGetAnyCharacter(t *testing.T) {
+func TestCharacter_GetAny(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
@@ -106,7 +111,7 @@ func TestGetAnyCharacter(t *testing.T) {
 	})
 }
 
-func TestCharacterCreate(t *testing.T) {
+func TestCharacter_Create(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	ctx := context.Background()
@@ -135,15 +140,22 @@ func TestCharacterCreate(t *testing.T) {
 		login := time.Now()
 		cloneJump := time.Now()
 		arg := storage.CreateCharacterParams{
-			ID:              character.ID,
-			AssetValue:      optional.New(3.4),
-			HomeID:          optional.New(home.ID),
-			LastCloneJumpAt: optional.New(cloneJump),
-			LastLoginAt:     optional.New(login),
-			LocationID:      optional.New(location.ID),
-			ShipID:          optional.New(ship.ID),
-			TotalSP:         optional.New(123),
-			WalletBalance:   optional.New(1.2),
+			AssetValue:         optional.New(3.4),
+			ContractItemsValue: optional.New(2.0),
+			ContractsEscrow:    optional.New(3.0),
+			HomeID:             optional.New(home.ID),
+			ID:                 character.ID,
+			IsTrainingWatched:  true,
+			LastCloneJumpAt:    optional.New(cloneJump),
+			LastLoginAt:        optional.New(login),
+			LocationID:         optional.New(location.ID),
+			OrderItemsValue:    optional.New(4.0),
+			OrdersEscrow:       optional.New(5.0),
+			ShipID:             optional.New(ship.ID),
+			SkillPointsValue:   optional.New(6.0),
+			TotalSP:            optional.New(123),
+			UnallocatedSP:      optional.New(42),
+			WalletBalance:      optional.New(1.2),
 		}
 		// when
 		err := st.CreateCharacter(ctx, arg)
@@ -151,14 +163,21 @@ func TestCharacterCreate(t *testing.T) {
 		require.NoError(t, err)
 		r, err := st.GetCharacter(ctx, arg.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, home, r.Home.MustValue())
-		xassert.Equal(t, cloneJump.UTC(), r.LastCloneJumpAt.ValueOrZero().UTC())
-		xassert.Equal(t, login.UTC(), r.LastLoginAt.ValueOrZero().UTC())
-		xassert.Equal(t, location, r.Location.MustValue())
-		xassert.Equal(t, ship, r.Ship.MustValue())
-		xassert.Equal(t, 123, r.TrainedSP.ValueOrZero())
 		xassert.Equal(t, 1.2, r.WalletBalance.ValueOrZero())
+		xassert.Equal(t, 123, r.TrainedSP.ValueOrZero())
+		xassert.Equal(t, 2.0, r.ContractItemsValue.ValueOrZero())
+		xassert.Equal(t, 3.0, r.ContractsEscrow.ValueOrZero())
 		xassert.Equal(t, 3.4, r.AssetValue.ValueOrZero())
+		xassert.Equal(t, 4.0, r.OrderItemsValue.ValueOrZero())
+		xassert.Equal(t, 42, r.UnallocatedSP.ValueOrZero())
+		xassert.Equal(t, 5.0, r.OrdersEscrow.ValueOrZero())
+		xassert.Equal(t, 6.0, r.SkillPointsValue.ValueOrZero())
+		xassert.Equal(t, cloneJump, r.LastCloneJumpAt.ValueOrZero())
+		xassert.Equal(t, home, r.Home.MustValue())
+		xassert.Equal(t, location, r.Location.MustValue())
+		xassert.Equal(t, login, r.LastLoginAt.ValueOrZero())
+		xassert.Equal(t, ship, r.Ship.MustValue())
+		xassert.Equal(t, true, r.IsTrainingWatched)
 	})
 	t.Run("report error when character already exists", func(t *testing.T) {
 		// given
@@ -508,6 +527,20 @@ func TestUpdateCharacterFields(t *testing.T) {
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, x, c2.OrderItemsValue.ValueOrZero())
+	})
+
+	t.Run("can update skill points value", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		x := rand.Float64() * 100_000_000
+		// when
+		err := st.UpdateCharacterSkillPointsValue(ctx, c1.ID, optional.New(x))
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.SkillPointsValue.ValueOrZero())
 	})
 }
 

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -35,20 +35,19 @@ func TestCharacter(t *testing.T) {
 		// when
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		// then
-		if assert.NoError(t, err) {
-			xassert.Equal(t, c1.ID, c2.ID)
-			xassert.Equal(t, c1.AssetValue, c2.AssetValue)
-			xassert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
-			xassert.Equal(t, c1.Home, c2.Home)
-			xassert.Equal(t, c1.IsTrainingWatched, c2.IsTrainingWatched)
-			xassert.Equal(t, c1.LastCloneJumpAt, c2.LastCloneJumpAt)
-			xassert.Equal(t, c1.LastLoginAt, c2.LastLoginAt)
-			xassert.Equal(t, c1.Location, c2.Location)
-			xassert.Equal(t, c1.Ship, c2.Ship)
-			xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
-			xassert.Equal(t, c1.UnallocatedSP, c2.UnallocatedSP)
-			xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
-		}
+		require.NoError(t, err)
+		xassert.Equal(t, c1.ID, c2.ID)
+		xassert.Equal(t, c1.AssetValue, c2.AssetValue)
+		xassert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
+		xassert.Equal(t, c1.Home, c2.Home)
+		xassert.Equal(t, c1.IsTrainingWatched, c2.IsTrainingWatched)
+		xassert.Equal(t, c1.LastCloneJumpAt, c2.LastCloneJumpAt)
+		xassert.Equal(t, c1.LastLoginAt, c2.LastLoginAt)
+		xassert.Equal(t, c1.Location, c2.Location)
+		xassert.Equal(t, c1.Ship, c2.Ship)
+		xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
+		xassert.Equal(t, c1.UnallocatedSP, c2.UnallocatedSP)
+		xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
 	})
 	t.Run("can delete", func(t *testing.T) {
 		// given
@@ -57,10 +56,9 @@ func TestCharacter(t *testing.T) {
 		// when
 		err := st.DeleteCharacter(ctx, c.ID)
 		// then
-		if assert.NoError(t, err) {
-			_, err := st.GetCharacter(ctx, c.ID)
-			assert.ErrorIs(t, err, app.ErrNotFound)
-		}
+		require.NoError(t, err)
+		_, err = st.GetCharacter(ctx, c.ID)
+		assert.ErrorIs(t, err, app.ErrNotFound)
 	})
 	t.Run("should return correct error when not found", func(t *testing.T) {
 		// given
@@ -77,10 +75,9 @@ func TestCharacter(t *testing.T) {
 		// when
 		c2, err := st.GetCharacter(ctx, c1.ID)
 		// then
-		if assert.NoError(t, err) {
-			xassert.Equal(t, c1.ID, c2.ID)
-			xassert.Equal(t, c1.Location, c2.Location)
-		}
+		require.NoError(t, err)
+		xassert.Equal(t, c1.ID, c2.ID)
+		xassert.Equal(t, c1.Location, c2.Location)
 	})
 }
 
@@ -96,9 +93,8 @@ func TestGetAnyCharacter(t *testing.T) {
 		// when
 		c, err := st.GetAnyCharacter(ctx)
 		// then
-		if assert.NoError(t, err) {
-			assert.Contains(t, []int64{c1.ID, c2.ID}, c.ID)
-		}
+		require.NoError(t, err)
+		assert.Contains(t, []int64{c1.ID, c2.ID}, c.ID)
 	})
 	t.Run("should return correct error when not found", func(t *testing.T) {
 		// given
@@ -124,12 +120,10 @@ func TestCharacterCreate(t *testing.T) {
 		// when
 		err := st.CreateCharacter(ctx, arg)
 		// then
-		if assert.NoError(t, err) {
-			r, err := st.GetCharacter(ctx, arg.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, character.ID, r.ID)
-			}
-		}
+		require.NoError(t, err)
+		r, err := st.GetCharacter(ctx, arg.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, character.ID, r.ID)
 	})
 	t.Run("can create new full", func(t *testing.T) {
 		// given
@@ -154,19 +148,17 @@ func TestCharacterCreate(t *testing.T) {
 		// when
 		err := st.CreateCharacter(ctx, arg)
 		// then
-		if assert.NoError(t, err) {
-			r, err := st.GetCharacter(ctx, arg.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, home, r.Home.MustValue())
-				xassert.Equal(t, cloneJump.UTC(), r.LastCloneJumpAt.ValueOrZero().UTC())
-				xassert.Equal(t, login.UTC(), r.LastLoginAt.ValueOrZero().UTC())
-				xassert.Equal(t, location, r.Location.MustValue())
-				xassert.Equal(t, ship, r.Ship.MustValue())
-				xassert.Equal(t, 123, r.TrainedSP.ValueOrZero())
-				xassert.Equal(t, 1.2, r.WalletBalance.ValueOrZero())
-				xassert.Equal(t, 3.4, r.AssetValue.ValueOrZero())
-			}
-		}
+		require.NoError(t, err)
+		r, err := st.GetCharacter(ctx, arg.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, home, r.Home.MustValue())
+		xassert.Equal(t, cloneJump.UTC(), r.LastCloneJumpAt.ValueOrZero().UTC())
+		xassert.Equal(t, login.UTC(), r.LastLoginAt.ValueOrZero().UTC())
+		xassert.Equal(t, location, r.Location.MustValue())
+		xassert.Equal(t, ship, r.Ship.MustValue())
+		xassert.Equal(t, 123, r.TrainedSP.ValueOrZero())
+		xassert.Equal(t, 1.2, r.WalletBalance.ValueOrZero())
+		xassert.Equal(t, 3.4, r.AssetValue.ValueOrZero())
 	})
 	t.Run("report error when character already exists", func(t *testing.T) {
 		// given
@@ -191,11 +183,10 @@ func TestListCharactersShort(t *testing.T) {
 		// when
 		cc, err := st.ListCharactersShort(ctx)
 		// then
-		if assert.NoError(t, err) {
-			c2 := cc[0]
-			assert.Len(t, cc, 1)
-			xassert.Equal(t, c1.ID, c2.ID)
-		}
+		require.NoError(t, err)
+		c2 := cc[0]
+		assert.Len(t, cc, 1)
+		xassert.Equal(t, c1.ID, c2.ID)
 	})
 	t.Run("can list characters", func(t *testing.T) {
 		// given
@@ -205,11 +196,9 @@ func TestListCharactersShort(t *testing.T) {
 		// when
 		cc, err := st.ListCharactersShort(ctx)
 		// then
-		if assert.NoError(t, err) {
-			assert.Len(t, cc, 2)
-		}
+		require.NoError(t, err)
+		assert.Len(t, cc, 2)
 	})
-
 }
 
 func TestListCharacters(t *testing.T) {
@@ -223,20 +212,19 @@ func TestListCharacters(t *testing.T) {
 		// when
 		cc, err := st.ListCharacters(ctx)
 		// then
-		if assert.NoError(t, err) {
-			c2 := cc[0]
-			if assert.NotNil(t, c2) {
-				assert.Len(t, cc, 1)
-				xassert.Equal(t, c1.ID, c2.ID)
-				xassert.Equal(t, c1.LastLoginAt.ValueOrZero().UTC(), c2.LastLoginAt.ValueOrZero().UTC())
-				xassert.Equal(t, c1.Ship, c2.Ship)
-				xassert.Equal(t, c1.Location, c2.Location)
-				xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
-				xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
-				xassert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
-				xassert.Equal(t, c1.EveCharacter.Alliance, c2.EveCharacter.Alliance)
-				xassert.Equal(t, c1.EveCharacter.Faction, c2.EveCharacter.Faction)
-			}
+		require.NoError(t, err)
+		c2 := cc[0]
+		if assert.NotNil(t, c2) {
+			assert.Len(t, cc, 1)
+			xassert.Equal(t, c1.ID, c2.ID)
+			xassert.Equal(t, c1.LastLoginAt.ValueOrZero().UTC(), c2.LastLoginAt.ValueOrZero().UTC())
+			xassert.Equal(t, c1.Ship, c2.Ship)
+			xassert.Equal(t, c1.Location, c2.Location)
+			xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
+			xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
+			xassert.Equal(t, c1.EveCharacter.ID, c2.EveCharacter.ID)
+			xassert.Equal(t, c1.EveCharacter.Alliance, c2.EveCharacter.Alliance)
+			xassert.Equal(t, c1.EveCharacter.Faction, c2.EveCharacter.Faction)
 		}
 	})
 	t.Run("can list character IDs", func(t *testing.T) {
@@ -247,10 +235,9 @@ func TestListCharacters(t *testing.T) {
 		// when
 		got, err := st.ListCharacterIDs(ctx)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(c1.ID, c2.ID)
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(c1.ID, c2.ID)
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can list character corporations", func(t *testing.T) {
 		// given
@@ -264,13 +251,12 @@ func TestListCharacters(t *testing.T) {
 		// when
 		cc, err := st.ListCharacterCorporations(ctx)
 		// then
-		if assert.NoError(t, err) {
-			got := set.Collect(xiter.MapSlice(cc, func(x *app.EntityShort) int64 {
-				return x.ID
-			}))
-			want := set.Of(ec1.Corporation.ID)
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		got := set.Collect(xiter.MapSlice(cc, func(x *app.EntityShort) int64 {
+			return x.ID
+		}))
+		want := set.Of(ec1.Corporation.ID)
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can list character corporation IDs", func(t *testing.T) {
 		// given
@@ -283,10 +269,9 @@ func TestListCharacters(t *testing.T) {
 		// when
 		got, err := st.ListCharacterCorporationIDs(ctx)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(c1.EveCharacter.Corporation.ID, c2.EveCharacter.Corporation.ID)
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(c1.EveCharacter.Corporation.ID, c2.EveCharacter.Corporation.ID)
+		xassert.Equal(t, want, got)
 	})
 }
 
@@ -302,13 +287,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterHome(ctx, c1.ID, optional.New(home.ID))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, home, c2.Home.MustValue())
-			}
-		}
-
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, home, c2.Home.MustValue())
 	})
 	t.Run("can update last clone jump with a time", func(t *testing.T) {
 		// given
@@ -318,12 +300,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterLastCloneJump(ctx, c1.ID, optional.New(x))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, x.UTC(), c2.LastCloneJumpAt.ValueOrZero().UTC())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x.UTC(), c2.LastCloneJumpAt.ValueOrZero().UTC())
 	})
 	t.Run("can update last clone jump with zero time", func(t *testing.T) {
 		// given
@@ -333,12 +313,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterLastCloneJump(ctx, c1.ID, optional.New(x))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, x, c2.LastCloneJumpAt.MustValue())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.LastCloneJumpAt.MustValue())
 	})
 	t.Run("should return empty when last clone jump not updated", func(t *testing.T) {
 		// given
@@ -346,9 +324,8 @@ func TestUpdateCharacterFields(t *testing.T) {
 		c1 := factory.CreateCharacter()
 		// when
 		c2, err := st.GetCharacter(ctx, c1.ID)
-		if assert.NoError(t, err) {
-			assert.True(t, c2.LastCloneJumpAt.IsEmpty())
-		}
+		require.NoError(t, err)
+		assert.True(t, c2.LastCloneJumpAt.IsEmpty())
 	})
 	t.Run("can update last login", func(t *testing.T) {
 		// given
@@ -358,12 +335,11 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterLastLoginAt(ctx, c1.ID, optional.New(x))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, x.UTC(), c2.LastLoginAt.ValueOrZero().UTC())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x.UTC(), c2.LastLoginAt.ValueOrZero().UTC())
+
 	})
 	t.Run("can update location", func(t *testing.T) {
 		// given
@@ -373,12 +349,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterLocation(ctx, c1.ID, optional.New(location.ID))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, location, c2.Location.MustValue())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, location, c2.Location.MustValue())
 	})
 	t.Run("can update ship", func(t *testing.T) {
 		// given
@@ -388,12 +362,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterShip(ctx, c1.ID, optional.New(x.ID))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, x, c2.Ship.MustValue())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.Ship.MustValue())
 	})
 	t.Run("can update is training watched", func(t *testing.T) {
 		// given
@@ -402,30 +374,25 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterIsTrainingWatched(ctx, c1.ID, true)
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				assert.True(t, c2.IsTrainingWatched)
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		assert.True(t, c2.IsTrainingWatched)
 	})
 	t.Run("can update is training watched 2", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		c1 := factory.CreateCharacterFull(storage.CreateCharacterParams{IsTrainingWatched: true})
 		c2, err := st.GetCharacter(ctx, c1.ID)
-		if assert.NoError(t, err) {
-			assert.True(t, c2.IsTrainingWatched)
-		}
+		require.NoError(t, err)
+		assert.True(t, c2.IsTrainingWatched)
 		// when
 		err = st.UpdateCharacterIsTrainingWatched(ctx, c1.ID, false)
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				assert.False(t, c2.IsTrainingWatched)
-			}
-		}
+		require.NoError(t, err)
+		c2, err = st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		assert.False(t, c2.IsTrainingWatched)
 	})
 	t.Run("can update skill points", func(t *testing.T) {
 		// given
@@ -436,13 +403,11 @@ func TestUpdateCharacterFields(t *testing.T) {
 		unallocatedSP := optional.New(rand.Int64N(10_000_000))
 		err := st.UpdateCharacterSkillPoints(ctx, c1.ID, totalSP, unallocatedSP)
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, totalSP, c2.TrainedSP)
-				xassert.Equal(t, unallocatedSP, c2.UnallocatedSP)
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, totalSP, c2.TrainedSP)
+		xassert.Equal(t, unallocatedSP, c2.UnallocatedSP)
 	})
 	t.Run("can update wallet balance", func(t *testing.T) {
 		// given
@@ -452,12 +417,10 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.UpdateCharacterWalletBalance(ctx, c1.ID, optional.New(x))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, x, c2.WalletBalance.ValueOrZero())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.WalletBalance.ValueOrZero())
 	})
 	t.Run("can disable all training watchers", func(t *testing.T) {
 		// given
@@ -471,16 +434,39 @@ func TestUpdateCharacterFields(t *testing.T) {
 		// when
 		err := st.DisableAllTrainingWatchers(ctx)
 		// then
-		if assert.NoError(t, err) {
-			c1, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				assert.False(t, c1.IsTrainingWatched)
-			}
-			c2, err := st.GetCharacter(ctx, c2.ID)
-			if assert.NoError(t, err) {
-				assert.False(t, c2.IsTrainingWatched)
-			}
-		}
+		require.NoError(t, err)
+		c1, err = st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		assert.False(t, c1.IsTrainingWatched)
+		c2, err = st.GetCharacter(ctx, c2.ID)
+		require.NoError(t, err)
+		assert.False(t, c2.IsTrainingWatched)
+	})
+	t.Run("can update contract escrow", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		x := rand.Float64() * 100_000_000
+		// when
+		err := st.UpdateCharacterContractEscrow(ctx, c1.ID, optional.New(x))
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.ContractEscrow.ValueOrZero())
+	})
+	t.Run("can update market escrow", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		x := rand.Float64() * 100_000_000
+		// when
+		err := st.UpdateCharacterMarketEscrow(ctx, c1.ID, optional.New(x))
+		// then
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, x, c2.MarketEscrow.ValueOrZero())
 	})
 }
 
@@ -498,12 +484,10 @@ func TestCharacterAssetValue(t *testing.T) {
 		// when
 		err := st.UpdateCharacterAssetValue(ctx, c1.ID, optional.New(v))
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, v, c2.AssetValue.ValueOrZero())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, v, c2.AssetValue.ValueOrZero())
 	})
 	t.Run("can reset", func(t *testing.T) {
 		// given
@@ -514,12 +498,10 @@ func TestCharacterAssetValue(t *testing.T) {
 		// when
 		err := st.UpdateCharacterAssetValue(ctx, c1.ID, optional.Optional[float64]{})
 		// then
-		if assert.NoError(t, err) {
-			c2, err := st.GetCharacter(ctx, c1.ID)
-			if assert.NoError(t, err) {
-				assert.True(t, c2.AssetValue.IsEmpty())
-			}
-		}
+		require.NoError(t, err)
+		c2, err := st.GetCharacter(ctx, c1.ID)
+		require.NoError(t, err)
+		assert.True(t, c2.AssetValue.IsEmpty())
 	})
 	t.Run("can get set value", func(t *testing.T) {
 		// given
@@ -531,9 +513,8 @@ func TestCharacterAssetValue(t *testing.T) {
 		// when
 		got, err := st.GetCharacterAssetValue(ctx, c1.ID)
 		// then
-		if assert.NoError(t, err) {
-			xassert.Equal(t, v, got.ValueOrZero())
-		}
+		require.NoError(t, err)
+		xassert.Equal(t, v, got.ValueOrZero())
 	})
 	t.Run("can get empty value", func(t *testing.T) {
 		// given
@@ -545,57 +526,7 @@ func TestCharacterAssetValue(t *testing.T) {
 		// when
 		got, err := st.GetCharacterAssetValue(ctx, c1.ID)
 		// then
-		if assert.NoError(t, err) {
-			assert.True(t, got.IsEmpty())
-		}
-	})
-}
-
-func TestCharacterWealth(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
-	defer db.Close()
-	// given
-	cases := []struct {
-		name      string
-		assets    optional.Optional[float64]
-		wallet    optional.Optional[float64]
-		totalWant optional.Optional[float64]
-	}{
-		{"all values exist", optional.New(1.0), optional.New(2.0), optional.New(3.0)},
-		{"missing wallet", optional.New(1.0), optional.Optional[float64]{}, optional.Optional[float64]{}},
-		{"missing assets", optional.Optional[float64]{}, optional.New(1.0), optional.Optional[float64]{}},
-		{"no values", optional.Optional[float64]{}, optional.Optional[float64]{}, optional.Optional[float64]{}},
-	}
-
-	for _, tc := range cases {
-		t.Run("can list when all value exist", func(t *testing.T) {
-			testutil.MustTruncateTables(db)
-			c := factory.CreateCharacter(storage.CreateCharacterParams{
-				AssetValue:    tc.assets,
-				WalletBalance: tc.wallet,
-			})
-			// when
-			oo, err := st.ListCharacterWealthValues(t.Context())
-			// then
-			require.NoError(t, err)
-			require.Len(t, oo, 1)
-			o := oo[0]
-			assert.Equal(t, c.ID, o.CharacterID)
-			assert.Equal(t, tc.assets, o.Assets)
-			assert.Equal(t, tc.wallet, o.Wallet)
-			assert.Equal(t, tc.totalWant, o.Total)
-		})
-	}
-
-	t.Run("can list characters", func(t *testing.T) {
-		// given
-		testutil.MustTruncateTables(db)
-		factory.CreateCharacterFull()
-		factory.CreateCharacterFull()
-		// when
-		oo, err := st.ListCharacterWealthValues(t.Context())
-		// then
 		require.NoError(t, err)
-		require.Len(t, oo, 2)
+		assert.True(t, got.IsEmpty())
 	})
 }

--- a/internal/app/storage/characterasset.go
+++ b/internal/app/storage/characterasset.go
@@ -128,9 +128,25 @@ func init() {
 	}
 }
 
+func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterAssetTotalValue: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterAssetTotalValue(ctx, queries.CalculateCharacterAssetTotalValueParams{
+		EveCategoryID: app.EveCategoryBlueprint,
+		CharacterID:   characterID,
+	})
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	return v.Float64, nil
+}
+
 type CreateCharacterAssetParams struct {
 	CharacterID     int64
-	EveTypeID       int64
 	IsBlueprintCopy optional.Optional[bool]
 	IsSingleton     bool
 	ItemID          int64
@@ -139,6 +155,7 @@ type CreateCharacterAssetParams struct {
 	LocationType    app.LocationType
 	Name            string
 	Quantity        int64
+	TypeID          int64
 }
 
 func (st *Storage) CreateCharacterAsset(ctx context.Context, arg CreateCharacterAssetParams) error {
@@ -146,12 +163,12 @@ func (st *Storage) CreateCharacterAsset(ctx context.Context, arg CreateCharacter
 		return fmt.Errorf("CreateCharacterAsset: %+v: %w", arg, err)
 
 	}
-	if arg.CharacterID == 0 || arg.EveTypeID == 0 || arg.ItemID == 0 {
+	if arg.CharacterID == 0 || arg.TypeID == 0 || arg.ItemID == 0 {
 		return wrapErr(app.ErrInvalid)
 	}
 	if err := st.qRW.CreateCharacterAsset(ctx, queries.CreateCharacterAssetParams{
 		CharacterID:     arg.CharacterID,
-		EveTypeID:       arg.EveTypeID,
+		EveTypeID:       arg.TypeID,
 		IsBlueprintCopy: arg.IsBlueprintCopy.ValueOrZero(),
 		IsSingleton:     arg.IsSingleton,
 		ItemID:          arg.ItemID,
@@ -183,14 +200,6 @@ func (st *Storage) GetCharacterAsset(ctx context.Context, characterID int64, ite
 	}
 	o := characterAssetFromDBModel(r.CharacterAsset, r.EveType, r.EveGroup, r.EveCategory, r.Price)
 	return o, nil
-}
-
-func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, characterID int64) (float64, error) {
-	v, err := st.qRO.CalculateCharacterAssetTotalValue(ctx, characterID)
-	if err != nil {
-		return 0, fmt.Errorf("calculate character asset for character %d: %w", characterID, err)
-	}
-	return v.Float64, nil
 }
 
 func (st *Storage) ListCharacterAssetIDs(ctx context.Context, characterID int64) (set.Set[int64], error) {

--- a/internal/app/storage/characterasset.go
+++ b/internal/app/storage/characterasset.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -139,6 +140,9 @@ func (st *Storage) CalculateCharacterAssetTotalValue(ctx context.Context, charac
 		EveCategoryID: app.EveCategoryBlueprint,
 		CharacterID:   characterID,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, wrapErr(err)
 	}

--- a/internal/app/storage/characterasset_test.go
+++ b/internal/app/storage/characterasset_test.go
@@ -31,7 +31,7 @@ func TestCharacterAsset(t *testing.T) {
 		// when
 		err := st.CreateCharacterAsset(ctx, storage.CreateCharacterAssetParams{
 			CharacterID:  c.ID,
-			EveTypeID:    eveType.ID,
+			TypeID:       eveType.ID,
 			IsSingleton:  true,
 			ItemID:       42,
 			LocationFlag: app.FlagHangar,
@@ -137,10 +137,11 @@ func TestCharacterAsset(t *testing.T) {
 		want := []*app.CharacterAsset{ca1, ca2}
 		assert.ElementsMatch(t, want, got)
 	})
+
 	t.Run("can calculate total asset value for character", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
+		c := factory.CreateCharacter()
 		ca1 := factory.CreateCharacterAsset(storage.CreateCharacterAssetParams{
 			CharacterID: c.ID,
 			Quantity:    1,
@@ -157,12 +158,34 @@ func TestCharacterAsset(t *testing.T) {
 			TypeID:       ca2.Type.ID,
 			AveragePrice: optional.New(200.2),
 		})
+		blueprintCategory := factory.CreateEveCategory(storage.CreateEveCategoryParams{
+			ID:   app.EveCategoryBlueprint,
+			Name: "Blueprint",
+		})
+		blueprintGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{
+			CategoryID: blueprintCategory.ID,
+		})
+		blueprintType := factory.CreateEveType(storage.CreateEveTypeParams{
+			GroupID: blueprintGroup.ID,
+		})
+		factory.CreateCharacterAsset(storage.CreateCharacterAssetParams{
+			CharacterID: c.ID,
+			Quantity:    1,
+			TypeID:      blueprintType.ID,
+		}) // blueprints must be excluded
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       blueprintType.ID,
+			AveragePrice: optional.New(66.6),
+		})
+
 		// when
 		got, err := st.CalculateCharacterAssetTotalValue(ctx, c.ID)
+
 		// then
 		require.NoError(t, err)
 		assert.InDelta(t, 500.5, got, 0.1)
 	})
+
 	t.Run("returns not found error", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -63,6 +63,31 @@ func init() {
 	}
 }
 
+func (st *Storage) CalculateCharacterContractItemsValue(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterContractItemsValue: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterContractItemsValue(ctx, queries.CalculateCharacterContractItemsValueParams{
+		CharacterID:   characterID,
+		EveCategoryID: app.EveCategoryBlueprint,
+		Status: []string{
+			characterContractStatusToDBValue[app.ContractStatusOutstanding],
+			characterContractStatusToDBValue[app.ContractStatusInProgress],
+		},
+		Types: []string{
+			characterContractTypeToDBValue[app.ContractTypeAuction],
+			characterContractTypeToDBValue[app.ContractTypeCourier],
+		},
+	})
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	return v.Float64, nil
+}
+
 type CreateCharacterContractParams struct {
 	AcceptorID          int64
 	AssigneeID          int64

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -88,6 +88,27 @@ func (st *Storage) CalculateCharacterContractItemsValue(ctx context.Context, cha
 	return v.Float64, nil
 }
 
+func (st *Storage) CalculateCharacterContractsCourierEscrow(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterContractsCourierEscrow: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterContractsCourierEscrow(ctx, queries.CalculateCharacterContractsCourierEscrowParams{
+		CharacterID: characterID,
+		Type:        characterContractTypeToDBValue[app.ContractTypeCourier],
+		Status: []string{
+			characterContractStatusToDBValue[app.ContractStatusOutstanding],
+			characterContractStatusToDBValue[app.ContractStatusInProgress],
+		},
+	})
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	return v.Float64, nil
+}
+
 type CreateCharacterContractParams struct {
 	AcceptorID          int64
 	AssigneeID          int64

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -82,10 +83,14 @@ func (st *Storage) CalculateCharacterContractItemsValue(ctx context.Context, cha
 			characterContractTypeToDBValue[app.ContractTypeCourier],
 		},
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, wrapErr(err)
 	}
-	return v.Float64, nil
+	v2 := optional.FromNullFloat64(v)
+	return v2.ValueOrZero(), nil
 }
 
 func (st *Storage) CalculateCharacterContractsCourierEscrow(ctx context.Context, characterID int64) (float64, error) {
@@ -103,10 +108,37 @@ func (st *Storage) CalculateCharacterContractsCourierEscrow(ctx context.Context,
 			characterContractStatusToDBValue[app.ContractStatusInProgress],
 		},
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, wrapErr(err)
 	}
-	return v.Float64, nil
+	v2 := optional.FromNullFloat64(v)
+	return v2.ValueOrZero(), nil
+}
+
+func (st *Storage) CalculateCharacterContractsAuctionEscrow(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterContractsAuctionEscrow: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterContractsAuctionEscrow(ctx, queries.CalculateCharacterContractsAuctionEscrowParams{
+		CharacterID: characterID,
+		Status: []string{
+			characterContractStatusToDBValue[app.ContractStatusInProgress],
+		},
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	v2 := optional.FromNullFloat64(v.TotalWinningBids)
+	return v2.ValueOrZero(), nil
 }
 
 type CreateCharacterContractParams struct {

--- a/internal/app/storage/charactercontract_test.go
+++ b/internal/app/storage/charactercontract_test.go
@@ -465,3 +465,76 @@ func TestCalculateCharacterContractItemsValue(t *testing.T) {
 		assert.Equal(t, 0.0, got)
 	})
 }
+
+func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+
+	characterID := int64(42)
+
+	cases := []struct {
+		name string
+
+		acceptorID   int64
+		contractType app.ContractType
+		collateral   optional.Optional[float64]
+		want         float64
+	}{
+		{"should include courier contract accepted by character", characterID, app.ContractTypeCourier, optional.New(123.0), 123.0},
+		{"should not include courier contract accepted by other", 0, app.ContractTypeCourier, optional.New(123.0), 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+				ID: characterID,
+			})
+			c := factory.CreateCharacter(storage.CreateCharacterParams{
+				ID: ec.ID,
+			})
+			factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+				CharacterID: c.ID,
+				AcceptorID:  tc.acceptorID,
+				Collateral:  tc.collateral,
+				Type:        tc.contractType,
+			})
+			factory.CreateCharacterContract() // should be ignored
+
+			// when
+			got, err := st.CalculateCharacterContractsCourierEscrow(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("should sum over multiple courier contracts", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			AcceptorID:  c.ID,
+			Collateral:  optional.New(100.0),
+			Type:        app.ContractTypeCourier,
+			Status:      app.ContractStatusInProgress,
+		})
+		factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			AcceptorID:  c.ID,
+			Collateral:  optional.New(200.0),
+			Type:        app.ContractTypeCourier,
+			Status:      app.ContractStatusInProgress,
+		})
+		factory.CreateCharacterContract() // should be ignored
+
+		// when
+		got, err := st.CalculateCharacterContractsCourierEscrow(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 300.0, got)
+	})
+}

--- a/internal/app/storage/charactercontract_test.go
+++ b/internal/app/storage/charactercontract_test.go
@@ -310,3 +310,158 @@ func TestCharacterContractItem(t *testing.T) {
 		xassert.Equal(t, want, got)
 	})
 }
+
+func TestCalculateCharacterContractItemsValue(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+
+	const characterID = 42
+
+	cases := []struct {
+		name         string
+		contractType app.ContractType
+		status       app.ContractStatus
+		price        float64
+		want         float64
+	}{
+		{
+			name:         "should include courier outstanding contract",
+			contractType: app.ContractTypeCourier,
+			status:       app.ContractStatusOutstanding,
+			price:        10.0,
+			want:         10.0,
+		},
+		{
+			name:         "should include in progress courier contract",
+			contractType: app.ContractTypeCourier,
+			status:       app.ContractStatusInProgress,
+			price:        10.0,
+			want:         10.0,
+		},
+		{
+			name:         "should include outstanding auction contract",
+			contractType: app.ContractTypeAuction,
+			status:       app.ContractStatusOutstanding,
+			price:        10.0,
+			want:         10.0,
+		},
+		{
+			name:         "should exclude finished courier contract",
+			contractType: app.ContractTypeCourier,
+			status:       app.ContractStatusFinished,
+			price:        10.0,
+			want:         0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+				ID: characterID,
+			})
+			c := factory.CreateCharacter(storage.CreateCharacterParams{
+				ID: ec.ID,
+			})
+			o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+				CharacterID: c.ID,
+				Status:      tc.status,
+				Type:        tc.contractType,
+			})
+			u := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+				ContractID: o.ID,
+				IsIncluded: true,
+				Quantity:   1,
+			})
+			factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+				TypeID:       u.Type.ID,
+				AveragePrice: optional.New(tc.price),
+			})
+
+			// when
+			got, err := st.CalculateCharacterContractItemsValue(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("can calculate items value for multiple contracts", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			Status:      app.ContractStatusOutstanding,
+			Type:        app.ContractTypeAuction,
+		})
+		u1 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+			ContractID: o1.ID,
+			IsIncluded: true,
+			Quantity:   1,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       u1.Type.ID,
+			AveragePrice: optional.New(100.1),
+		})
+		o2 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			Status:      app.ContractStatusOutstanding,
+			Type:        app.ContractTypeAuction,
+		})
+		u2 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+			ContractID: o2.ID,
+			IsIncluded: true,
+			Quantity:   2,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       u2.Type.ID,
+			AveragePrice: optional.New(200.2),
+		})
+
+		// when
+		got, err := st.CalculateCharacterContractItemsValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 500.5, got)
+	})
+
+	t.Run("should ignore blueprints", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		blueprintCategory := factory.CreateEveCategory(storage.CreateEveCategoryParams{
+			ID:   app.EveCategoryBlueprint,
+			Name: "Blueprint",
+		})
+		blueprintGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{
+			CategoryID: blueprintCategory.ID,
+		})
+		blueprintType := factory.CreateEveType(storage.CreateEveTypeParams{
+			GroupID: blueprintGroup.ID,
+		})
+		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			Status:      app.ContractStatusOutstanding,
+			Type:        app.ContractTypeAuction,
+		})
+		factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+			ContractID: o1.ID,
+			IsIncluded: true,
+			Quantity:   1,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       blueprintType.ID,
+			AveragePrice: optional.New(66.6),
+		})
+
+		// when
+		got, err := st.CalculateCharacterOrderItemsValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 0.0, got)
+	})
+}

--- a/internal/app/storage/charactercontract_test.go
+++ b/internal/app/storage/charactercontract_test.go
@@ -538,3 +538,62 @@ func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
 		assert.Equal(t, 300.0, got)
 	})
 }
+
+func TestCalculateCharacterContractsAuctionEscrow(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+
+	t.Run("should include when own bid is highest", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			Type:        app.ContractTypeAuction,
+			Status:      app.ContractStatusInProgress,
+		})
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+			Amount:     12.3,
+			BidderID:   c.ID,
+			ContractID: o.ID,
+		})
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+			Amount:     3,
+			ContractID: o.ID,
+		})
+
+		// when
+		got, err := st.CalculateCharacterContractsAuctionEscrow(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 12.3, got)
+	})
+
+	t.Run("should not include when own bid is not highest", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			CharacterID: c.ID,
+			Type:        app.ContractTypeAuction,
+			Status:      app.ContractStatusInProgress,
+		})
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+			Amount:     12.3,
+			BidderID:   c.ID,
+			ContractID: o.ID,
+		})
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+			Amount:     15,
+			ContractID: o.ID,
+		})
+
+		// when
+		got, err := st.CalculateCharacterContractsAuctionEscrow(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 0.0, got)
+	})
+}

--- a/internal/app/storage/charactermarketorder.go
+++ b/internal/app/storage/charactermarketorder.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -46,6 +47,9 @@ func (st *Storage) CalculateCharacterOrderItemsValue(ctx context.Context, charac
 			orderStatusToDBValue[app.OrderExpired],
 		},
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, wrapErr(err)
 	}
@@ -66,6 +70,9 @@ func (st *Storage) CalculateCharacterOrdersEscrow(ctx context.Context, character
 		},
 		CharacterID: characterID,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, wrapErr(err)
 	}

--- a/internal/app/storage/charactermarketorder.go
+++ b/internal/app/storage/charactermarketorder.go
@@ -31,6 +31,27 @@ func init() {
 	}
 }
 
+func (st *Storage) CalculateCharacterOrderItemsValue(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterOrderItemsValue: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterOrderItemsValue(ctx, queries.CalculateCharacterOrderItemsValueParams{
+		EveCategoryID: app.EveCategoryBlueprint,
+		States: []string{
+			orderStatusToDBValue[app.OrderOpen],
+			orderStatusToDBValue[app.OrderExpired],
+		},
+		CharacterID: characterID,
+	})
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	return v.Float64, nil
+}
+
 func (st *Storage) DeleteCharacterMarketOrders(ctx context.Context, characterID int64, orderIDs set.Set[int64]) error {
 	wrapErr := func(err error) error {
 		return fmt.Errorf("DeleteCharacterMarketOrdersByID for character %d and job IDs: %v: %w", characterID, orderIDs, err)

--- a/internal/app/storage/charactermarketorder.go
+++ b/internal/app/storage/charactermarketorder.go
@@ -39,7 +39,27 @@ func (st *Storage) CalculateCharacterOrderItemsValue(ctx context.Context, charac
 		return 0, wrapErr(app.ErrInvalid)
 	}
 	v, err := st.qRO.CalculateCharacterOrderItemsValue(ctx, queries.CalculateCharacterOrderItemsValueParams{
+		CharacterID:   characterID,
 		EveCategoryID: app.EveCategoryBlueprint,
+		States: []string{
+			orderStatusToDBValue[app.OrderOpen],
+			orderStatusToDBValue[app.OrderExpired],
+		},
+	})
+	if err != nil {
+		return 0, wrapErr(err)
+	}
+	return v.Float64, nil
+}
+
+func (st *Storage) CalculateCharacterOrdersEscrow(ctx context.Context, characterID int64) (float64, error) {
+	wrapErr := func(err error) error {
+		return fmt.Errorf("CalculateCharacterOrdersEscrow: %d: %w", characterID, err)
+	}
+	if characterID == 0 {
+		return 0, wrapErr(app.ErrInvalid)
+	}
+	v, err := st.qRO.CalculateCharacterOrdersEscrow(ctx, queries.CalculateCharacterOrdersEscrowParams{
 		States: []string{
 			orderStatusToDBValue[app.OrderOpen],
 			orderStatusToDBValue[app.OrderExpired],
@@ -51,7 +71,6 @@ func (st *Storage) CalculateCharacterOrderItemsValue(ctx context.Context, charac
 	}
 	return v.Float64, nil
 }
-
 func (st *Storage) DeleteCharacterMarketOrders(ctx context.Context, characterID int64, orderIDs set.Set[int64]) error {
 	wrapErr := func(err error) error {
 		return fmt.Errorf("DeleteCharacterMarketOrdersByID for character %d and job IDs: %v: %w", characterID, orderIDs, err)

--- a/internal/app/storage/charactermarketorder_test.go
+++ b/internal/app/storage/charactermarketorder_test.go
@@ -381,3 +381,62 @@ func TestCalculateCharacterOrderItemsValue(t *testing.T) {
 		assert.Equal(t, 0.0, got)
 	})
 }
+
+func TestCalcOrdersEscrow(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+
+	cases := []struct {
+		name       string
+		isBuyOrder optional.Optional[bool]
+		escrow     optional.Optional[float64]
+		want       float64
+	}{
+		{"should include open buy order with escrow", optional.New(true), optional.New(12.3), 12.3},
+		{"should not include buy order without escrow", optional.New(true), optional.Optional[float64]{}, 0.0},
+		{"should not include sell order", optional.New(false), optional.New(12.3), 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			c := factory.CreateCharacter()
+			factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+				CharacterID: c.ID,
+				IsBuyOrder:  tc.isBuyOrder,
+				Escrow:      tc.escrow,
+			})
+
+			// when
+			got, err := st.CalculateCharacterOrdersEscrow(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("should sum buy orders owner by character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+			CharacterID: c.ID,
+			IsBuyOrder:  optional.New(true),
+			Escrow:      optional.New(12.3),
+		})
+		factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+			CharacterID: c.ID,
+			IsBuyOrder:  optional.New(true),
+			Escrow:      optional.New(10.1),
+		})
+		factory.CreateCharacterMarketOrder() // should be ignored
+
+		// when
+		got, err := st.CalculateCharacterOrdersEscrow(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 22.4, got)
+	})
+}

--- a/internal/app/storage/charactermarketorder_test.go
+++ b/internal/app/storage/charactermarketorder_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -50,28 +51,26 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		err := st.UpdateOrCreateCharacterMarketOrder(ctx, arg)
 		// then
-		if assert.NoError(t, err) {
-			o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, 3, o.Duration)
-				assert.True(t, o.Escrow.IsEmpty())
-				xassert.Equal(t, true, o.IsBuyOrder.ValueOrZero())
-				xassert.Equal(t, true, o.IsCorporation)
-				assert.True(t, issued.Equal(o.Issued), "got %q, wanted %q", issued, o.Issued)
-				xassert.Equal(t, location.ID, o.Location.ID)
-				xassert.Equal(t, location.Name, o.Location.Name.ValueOrZero())
-				assert.True(t, o.MinVolume.IsEmpty())
-				xassert.Equal(t, 123.45, o.Price)
-				xassert.Equal(t, "station", o.Range)
-				xassert.Equal(t, region.ID, o.Region.ID)
-				xassert.Equal(t, region.Name, o.Region.Name)
-				xassert.Equal(t, app.OrderOpen, o.State)
-				xassert.Equal(t, itemType.ID, o.Type.ID)
-				xassert.Equal(t, itemType.Name, o.Type.Name)
-				xassert.Equal(t, 5, o.VolumeRemains)
-				xassert.Equal(t, 10, o.VolumeTotal)
-			}
-		}
+		require.NoError(t, err)
+		o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
+		require.NoError(t, err)
+		xassert.Equal(t, 3, o.Duration)
+		assert.True(t, o.Escrow.IsEmpty())
+		xassert.Equal(t, true, o.IsBuyOrder.ValueOrZero())
+		xassert.Equal(t, true, o.IsCorporation)
+		assert.True(t, issued.Equal(o.Issued), "got %q, wanted %q", issued, o.Issued)
+		xassert.Equal(t, location.ID, o.Location.ID)
+		xassert.Equal(t, location.Name, o.Location.Name.ValueOrZero())
+		assert.True(t, o.MinVolume.IsEmpty())
+		xassert.Equal(t, 123.45, o.Price)
+		xassert.Equal(t, "station", o.Range)
+		xassert.Equal(t, region.ID, o.Region.ID)
+		xassert.Equal(t, region.Name, o.Region.Name)
+		xassert.Equal(t, app.OrderOpen, o.State)
+		xassert.Equal(t, itemType.ID, o.Type.ID)
+		xassert.Equal(t, itemType.Name, o.Type.Name)
+		xassert.Equal(t, 5, o.VolumeRemains)
+		xassert.Equal(t, 10, o.VolumeTotal)
 	})
 	t.Run("can create new full", func(t *testing.T) {
 		// given
@@ -104,13 +103,11 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		err := st.UpdateOrCreateCharacterMarketOrder(ctx, arg)
 		// then
-		if assert.NoError(t, err) {
-			o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, 234.56, o.Escrow.MustValue())
-				xassert.Equal(t, 3, o.MinVolume.MustValue())
-			}
-		}
+		require.NoError(t, err)
+		o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
+		require.NoError(t, err)
+		xassert.Equal(t, 234.56, o.Escrow.MustValue())
+		xassert.Equal(t, 3, o.MinVolume.MustValue())
 	})
 	t.Run("can update existing", func(t *testing.T) {
 		// given
@@ -143,15 +140,13 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		err := st.UpdateOrCreateCharacterMarketOrder(ctx, arg)
 		// then
-		if assert.NoError(t, err) {
-			o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, escrow, o.Escrow.ValueOrZero())
-				xassert.Equal(t, price, o.Price)
-				xassert.Equal(t, remains, o.VolumeRemains)
-				xassert.Equal(t, app.OrderExpired, o.State)
-			}
-		}
+		require.NoError(t, err)
+		o, err := st.GetCharacterMarketOrder(ctx, arg.CharacterID, arg.OrderID)
+		require.NoError(t, err)
+		xassert.Equal(t, escrow, o.Escrow.ValueOrZero())
+		xassert.Equal(t, price, o.Price)
+		xassert.Equal(t, remains, o.VolumeRemains)
+		xassert.Equal(t, app.OrderExpired, o.State)
 	})
 	t.Run("can list orders for a character", func(t *testing.T) {
 		// given
@@ -167,13 +162,12 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		s, err := st.ListCharacterMarketOrders(ctx, c.ID)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(o1.OrderID, o2.OrderID)
-			got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
-				return x.OrderID
-			}))
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(o1.OrderID, o2.OrderID)
+		got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
+			return x.OrderID
+		}))
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can list order IDs for a character", func(t *testing.T) {
 		// given
@@ -189,10 +183,9 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		got, err := st.ListCharacterMarketOrderIDs(ctx, c.ID)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(o1.OrderID, o2.OrderID)
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(o1.OrderID, o2.OrderID)
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can list all buy orders", func(t *testing.T) {
 		// given
@@ -207,13 +200,12 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		s, err := st.ListAllCharacterMarketOrders(ctx, true)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(o1.OrderID, o2.OrderID)
-			got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
-				return x.OrderID
-			}))
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(o1.OrderID, o2.OrderID)
+		got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
+			return x.OrderID
+		}))
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can list all sell orders", func(t *testing.T) {
 		// given
@@ -226,13 +218,12 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		s, err := st.ListAllCharacterMarketOrders(ctx, false)
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(o1.OrderID, o2.OrderID)
-			got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
-				return x.OrderID
-			}))
-			xassert.Equal(t, want, got)
-		}
+		require.NoError(t, err)
+		want := set.Of(o1.OrderID, o2.OrderID)
+		got := set.Collect(xiter.Map(slices.Values(s), func(x *app.CharacterMarketOrder) int64 {
+			return x.OrderID
+		}))
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can delete orders for a character by ID", func(t *testing.T) {
 		// given
@@ -247,13 +238,11 @@ func TestCharacterMarketOrder(t *testing.T) {
 		// when
 		err := st.DeleteCharacterMarketOrders(ctx, c.ID, set.Of(o2.OrderID))
 		// then
-		if assert.NoError(t, err) {
-			want := set.Of(o1.OrderID)
-			got, err := st.ListCharacterMarketOrderIDs(ctx, c.ID)
-			if assert.NoError(t, err) {
-				xassert.Equal(t, want, got)
-			}
-		}
+		require.NoError(t, err)
+		want := set.Of(o1.OrderID)
+		got, err := st.ListCharacterMarketOrderIDs(ctx, c.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, want, got)
 	})
 	t.Run("can update order status", func(t *testing.T) {
 		// given
@@ -270,15 +259,9 @@ func TestCharacterMarketOrder(t *testing.T) {
 			State:       app.OrderUnknown,
 		})
 		// then
-		failOnError(t, err)
+		require.NoError(t, err)
 		o2, err := st.GetCharacterMarketOrder(ctx, c.ID, o1.OrderID)
-		failOnError(t, err)
+		require.NoError(t, err)
 		xassert.Equal(t, app.OrderUnknown, o2.State)
 	})
-}
-
-func failOnError(t *testing.T, err error) {
-	if err != nil {
-		t.Fatal("Error occured", err)
-	}
 }

--- a/internal/app/storage/charactermarketorder_test.go
+++ b/internal/app/storage/charactermarketorder_test.go
@@ -265,3 +265,119 @@ func TestCharacterMarketOrder(t *testing.T) {
 		xassert.Equal(t, app.OrderUnknown, o2.State)
 	})
 }
+
+func TestCalculateCharacterOrderItemsValue(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+
+	const characterID = 42
+
+	cases := []struct {
+		name       string
+		isBuyOrder bool
+		state      app.MarketOrderState
+		price      float64
+		want       float64
+	}{
+		{"should include open sell order", false, app.OrderOpen, 10.0, 10.0},
+		{"should include expired sell order", false, app.OrderExpired, 10.0, 10.0},
+		{"should ignore buy orders", true, app.OrderOpen, 0, 0},
+		{"should ignore cancelled orders", false, app.OrderCancelled, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			testutil.MustTruncateTables(db)
+			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+				ID: characterID,
+			})
+			c := factory.CreateCharacter(storage.CreateCharacterParams{
+				ID: ec.ID,
+			})
+			o := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+				CharacterID:   c.ID,
+				IsBuyOrder:    optional.New(tc.isBuyOrder),
+				State:         tc.state,
+				VolumeRemains: 1,
+			})
+			factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+				TypeID:       o.Type.ID,
+				AveragePrice: optional.New(tc.price),
+			})
+
+			// when
+			got, err := st.CalculateCharacterOrderItemsValue(t.Context(), c.ID)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("can calculate items value for multiple orders", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		o1 := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+			CharacterID:   c.ID,
+			IsBuyOrder:    optional.New(false),
+			State:         app.OrderOpen,
+			VolumeRemains: 1,
+		})
+		o2 := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+			CharacterID:   c.ID,
+			IsBuyOrder:    optional.New(false),
+			State:         app.OrderOpen,
+			VolumeRemains: 2,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       o1.Type.ID,
+			AveragePrice: optional.New(100.1),
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       o2.Type.ID,
+			AveragePrice: optional.New(200.2),
+		})
+
+		// when
+		got, err := st.CalculateCharacterOrderItemsValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 500.5, got)
+	})
+
+	t.Run("should ignore blueprints", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		blueprintCategory := factory.CreateEveCategory(storage.CreateEveCategoryParams{
+			ID:   app.EveCategoryBlueprint,
+			Name: "Blueprint",
+		})
+		blueprintGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{
+			CategoryID: blueprintCategory.ID,
+		})
+		blueprintType := factory.CreateEveType(storage.CreateEveTypeParams{
+			GroupID: blueprintGroup.ID,
+		})
+		factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{
+			CharacterID:   c.ID,
+			IsBuyOrder:    optional.New(false),
+			State:         app.OrderOpen,
+			TypeID:        blueprintType.ID,
+			VolumeRemains: 1,
+		})
+		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			TypeID:       blueprintType.ID,
+			AveragePrice: optional.New(66.6),
+		})
+
+		// when
+		got, err := st.CalculateCharacterOrderItemsValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 0.0, got)
+	})
+}

--- a/internal/app/storage/migrations/0020_add_character_wealth.sql
+++ b/internal/app/storage/migrations/0020_add_character_wealth.sql
@@ -9,3 +9,6 @@ ADD COLUMN orders_escrow REAL;
 
 ALTER TABLE characters
 ADD COLUMN order_items_value REAL;
+
+ALTER TABLE characters
+ADD COLUMN skill_points_value REAL;

--- a/internal/app/storage/migrations/0020_add_character_wealth.sql
+++ b/internal/app/storage/migrations/0020_add_character_wealth.sql
@@ -1,0 +1,5 @@
+ALTER TABLE characters
+ADD COLUMN contract_escrow REAL;
+
+ALTER TABLE characters
+ADD COLUMN market_escrow REAL;

--- a/internal/app/storage/migrations/0020_add_character_wealth.sql
+++ b/internal/app/storage/migrations/0020_add_character_wealth.sql
@@ -1,5 +1,11 @@
 ALTER TABLE characters
-ADD COLUMN contract_escrow REAL;
+ADD COLUMN contracts_escrow REAL;
 
 ALTER TABLE characters
-ADD COLUMN market_escrow REAL;
+ADD COLUMN contract_items_value REAL;
+
+ALTER TABLE characters
+ADD COLUMN orders_escrow REAL;
+
+ALTER TABLE characters
+ADD COLUMN order_items_value REAL;

--- a/internal/app/storage/queries/character_assets.sql
+++ b/internal/app/storage/queries/character_assets.sql
@@ -1,24 +1,25 @@
 -- name: CreateCharacterAsset :exec
-INSERT INTO character_assets (
-    character_id,
-    eve_type_id,
-    is_blueprint_copy,
-    is_singleton,
-    item_id,
-    location_flag,
-    location_id,
-    location_type,
-    name,
-    quantity
-)
-VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-);
+INSERT INTO
+    character_assets (
+        character_id,
+        eve_type_id,
+        is_blueprint_copy,
+        is_singleton,
+        item_id,
+        location_flag,
+        location_id,
+        location_type,
+        name,
+        quantity
+    )
+VALUES
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: DeleteCharacterAssets :exec
 DELETE FROM character_assets
-WHERE character_id = ?
-AND item_id IN (sqlc.slice('item_ids'));
+WHERE
+    character_id = ?
+    AND item_id IN (sqlc.slice('item_ids'));
 
 -- name: GetCharacterAsset :one
 SELECT
@@ -27,18 +28,24 @@ SELECT
     sqlc.embed(eg),
     sqlc.embed(ec),
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE
-WHERE character_id = ?
-AND item_id = ?;
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE
+WHERE
+    character_id = ?
+    AND item_id = ?;
 
 -- name: ListCharacterAssetIDs :many
-SELECT item_id
-FROM character_assets
-WHERE character_id = ?;
+SELECT
+    item_id
+FROM
+    character_assets
+WHERE
+    character_id = ?;
 
 -- name: ListAllCharacterAssets :many
 SELECT
@@ -47,11 +54,13 @@ SELECT
     sqlc.embed(eg),
     sqlc.embed(ec),
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE;
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE;
 
 -- name: ListCharacterAssets :many
 SELECT
@@ -60,18 +69,27 @@ SELECT
     sqlc.embed(eg),
     sqlc.embed(ec),
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE
-WHERE character_id = ?;
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE
+WHERE
+    character_id = ?;
 
 -- name: CalculateCharacterAssetTotalValue :one
-SELECT SUM(IFNULL(emp.average_price, 0) * quantity * IIF(ca.is_blueprint_copy IS TRUE, 0, 1)) as total
-FROM character_assets ca
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
-WHERE character_id = ?;
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * quantity)
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = ca.eve_type_id
+WHERE
+    character_id = ?
+    AND eg.eve_category_id <> ?;
 
 -- name: UpdateCharacterAsset :exec
 UPDATE character_assets
@@ -80,12 +98,14 @@ SET
     location_id = ?,
     location_type = ?,
     quantity = ?
-WHERE character_id = ?
-AND item_id = ?;
+WHERE
+    character_id = ?
+    AND item_id = ?;
 
 -- name: UpdateCharacterAssetName :exec
 UPDATE character_assets
 SET
     name = ?
-WHERE character_id = ?
-AND item_id = ?;
+WHERE
+    character_id = ?
+    AND item_id = ?;

--- a/internal/app/storage/queries/character_assets.sql.go
+++ b/internal/app/storage/queries/character_assets.sql.go
@@ -12,35 +12,46 @@ import (
 )
 
 const calculateCharacterAssetTotalValue = `-- name: CalculateCharacterAssetTotalValue :one
-SELECT SUM(IFNULL(emp.average_price, 0) * quantity * IIF(ca.is_blueprint_copy IS TRUE, 0, 1)) as total
-FROM character_assets ca
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
-WHERE character_id = ?
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * quantity)
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = ca.eve_type_id
+WHERE
+    character_id = ?
+    AND eg.eve_category_id <> ?
 `
 
-func (q *Queries) CalculateCharacterAssetTotalValue(ctx context.Context, characterID int64) (sql.NullFloat64, error) {
-	row := q.db.QueryRowContext(ctx, calculateCharacterAssetTotalValue, characterID)
-	var total sql.NullFloat64
-	err := row.Scan(&total)
-	return total, err
+type CalculateCharacterAssetTotalValueParams struct {
+	CharacterID   int64
+	EveCategoryID int64
+}
+
+func (q *Queries) CalculateCharacterAssetTotalValue(ctx context.Context, arg CalculateCharacterAssetTotalValueParams) (sql.NullFloat64, error) {
+	row := q.db.QueryRowContext(ctx, calculateCharacterAssetTotalValue, arg.CharacterID, arg.EveCategoryID)
+	var sum sql.NullFloat64
+	err := row.Scan(&sum)
+	return sum, err
 }
 
 const createCharacterAsset = `-- name: CreateCharacterAsset :exec
-INSERT INTO character_assets (
-    character_id,
-    eve_type_id,
-    is_blueprint_copy,
-    is_singleton,
-    item_id,
-    location_flag,
-    location_id,
-    location_type,
-    name,
-    quantity
-)
-VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-)
+INSERT INTO
+    character_assets (
+        character_id,
+        eve_type_id,
+        is_blueprint_copy,
+        is_singleton,
+        item_id,
+        location_flag,
+        location_id,
+        location_type,
+        name,
+        quantity
+    )
+VALUES
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateCharacterAssetParams struct {
@@ -74,8 +85,9 @@ func (q *Queries) CreateCharacterAsset(ctx context.Context, arg CreateCharacterA
 
 const deleteCharacterAssets = `-- name: DeleteCharacterAssets :exec
 DELETE FROM character_assets
-WHERE character_id = ?
-AND item_id IN (/*SLICE:item_ids*/?)
+WHERE
+    character_id = ?
+    AND item_id IN (/*SLICE:item_ids*/?)
 `
 
 type DeleteCharacterAssetsParams struct {
@@ -106,13 +118,16 @@ SELECT
     eg.id, eg.eve_category_id, eg.name, eg.is_published,
     ec.id, ec.name, ec.is_published,
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE
-WHERE character_id = ?
-AND item_id = ?
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE
+WHERE
+    character_id = ?
+    AND item_id = ?
 `
 
 type GetCharacterAssetParams struct {
@@ -176,11 +191,13 @@ SELECT
     eg.id, eg.eve_category_id, eg.name, eg.is_published,
     ec.id, ec.name, ec.is_published,
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE
 `
 
 type ListAllCharacterAssetsRow struct {
@@ -249,9 +266,12 @@ func (q *Queries) ListAllCharacterAssets(ctx context.Context) ([]ListAllCharacte
 }
 
 const listCharacterAssetIDs = `-- name: ListCharacterAssetIDs :many
-SELECT item_id
-FROM character_assets
-WHERE character_id = ?
+SELECT
+    item_id
+FROM
+    character_assets
+WHERE
+    character_id = ?
 `
 
 func (q *Queries) ListCharacterAssetIDs(ctx context.Context, characterID int64) ([]int64, error) {
@@ -284,12 +304,15 @@ SELECT
     eg.id, eg.eve_category_id, eg.name, eg.is_published,
     ec.id, ec.name, ec.is_published,
     average_price as price
-FROM character_assets ca
-JOIN eve_types et ON et.id = ca.eve_type_id
-JOIN eve_groups eg ON eg.id = et.eve_group_id
-JOIN eve_categories ec ON ec.id = eg.eve_category_id
-LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id AND ca.is_blueprint_copy IS FALSE
-WHERE character_id = ?
+FROM
+    character_assets ca
+    JOIN eve_types et ON et.id = ca.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+    LEFT JOIN eve_market_prices emp ON emp.type_id = ca.eve_type_id
+    AND ca.is_blueprint_copy IS FALSE
+WHERE
+    character_id = ?
 `
 
 type ListCharacterAssetsRow struct {
@@ -364,8 +387,9 @@ SET
     location_id = ?,
     location_type = ?,
     quantity = ?
-WHERE character_id = ?
-AND item_id = ?
+WHERE
+    character_id = ?
+    AND item_id = ?
 `
 
 type UpdateCharacterAssetParams struct {
@@ -393,8 +417,9 @@ const updateCharacterAssetName = `-- name: UpdateCharacterAssetName :exec
 UPDATE character_assets
 SET
     name = ?
-WHERE character_id = ?
-AND item_id = ?
+WHERE
+    character_id = ?
+    AND item_id = ?
 `
 
 type UpdateCharacterAssetNameParams struct {

--- a/internal/app/storage/queries/character_contracts.sql
+++ b/internal/app/storage/queries/character_contracts.sql
@@ -25,6 +25,22 @@ WHERE
     AND type = ?
     AND status IN (sqlc.slice('status'));
 
+-- name: CalculateCharacterContractsAuctionEscrow :one
+SELECT
+    bidder_id,
+    SUM(amount) AS total_winning_bids
+FROM character_contract_bids AS main_bids
+JOIN character_contracts cc ON cc.id = main_bids.contract_id
+WHERE amount = (
+    SELECT MAX(amount)
+    FROM character_contract_bids
+    WHERE contract_id = main_bids.contract_id
+)
+AND main_bids.bidder_id = cc.character_id
+AND cc.character_id = ?
+AND cc.status IN (sqlc.slice('status'))
+GROUP BY main_bids.bidder_id;
+
 -- name: CreateCharacterContract :one
 INSERT INTO
     character_contracts (

--- a/internal/app/storage/queries/character_contracts.sql
+++ b/internal/app/storage/queries/character_contracts.sql
@@ -1,3 +1,19 @@
+-- name: CalculateCharacterContractItemsValue :one
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * cci.quantity)
+FROM
+    character_contract_items cci
+    JOIN character_contracts cc ON cc.id = cci.contract_id
+    JOIN eve_types et ON et.id = cci.type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = cci.type_id
+WHERE
+    character_id = ?
+    AND cc.status IN (sqlc.slice('status'))
+    AND cc.type IN (sqlc.slice('types'))
+    AND cci.is_included IS TRUE
+    AND eg.eve_category_id <> ?;
+
 -- name: CreateCharacterContract :one
 INSERT INTO
     character_contracts (
@@ -60,8 +76,9 @@ RETURNING
 
 -- name: DeleteCharacterContracts :exec
 DELETE FROM character_contracts
-WHERE character_id = ?
-AND contract_id IN (sqlc.slice('contract_ids'));
+WHERE
+    character_id = ?
+    AND contract_id IN (sqlc.slice('contract_ids'));
 
 -- name: GetCharacterContract :one
 SELECT

--- a/internal/app/storage/queries/character_contracts.sql
+++ b/internal/app/storage/queries/character_contracts.sql
@@ -14,6 +14,17 @@ WHERE
     AND cci.is_included IS TRUE
     AND eg.eve_category_id <> ?;
 
+-- name: CalculateCharacterContractsCourierEscrow :one
+SELECT
+    SUM(collateral)
+FROM
+    character_contracts
+WHERE
+    character_id = ?
+    AND acceptor_id == character_id
+    AND type = ?
+    AND status IN (sqlc.slice('status'));
+
 -- name: CreateCharacterContract :one
 INSERT INTO
     character_contracts (

--- a/internal/app/storage/queries/character_contracts.sql.go
+++ b/internal/app/storage/queries/character_contracts.sql.go
@@ -12,6 +12,57 @@ import (
 	"time"
 )
 
+const calculateCharacterContractItemsValue = `-- name: CalculateCharacterContractItemsValue :one
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * cci.quantity)
+FROM
+    character_contract_items cci
+    JOIN character_contracts cc ON cc.id = cci.contract_id
+    JOIN eve_types et ON et.id = cci.type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = cci.type_id
+WHERE
+    character_id = ?
+    AND cc.status IN (/*SLICE:status*/?)
+    AND cc.type IN (/*SLICE:types*/?)
+    AND cci.is_included IS TRUE
+    AND eg.eve_category_id <> ?
+`
+
+type CalculateCharacterContractItemsValueParams struct {
+	CharacterID   int64
+	Status        []string
+	Types         []string
+	EveCategoryID int64
+}
+
+func (q *Queries) CalculateCharacterContractItemsValue(ctx context.Context, arg CalculateCharacterContractItemsValueParams) (sql.NullFloat64, error) {
+	query := calculateCharacterContractItemsValue
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	if len(arg.Status) > 0 {
+		for _, v := range arg.Status {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:status*/?", strings.Repeat(",?", len(arg.Status))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:status*/?", "NULL", 1)
+	}
+	if len(arg.Types) > 0 {
+		for _, v := range arg.Types {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:types*/?", strings.Repeat(",?", len(arg.Types))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:types*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.EveCategoryID)
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
+	var sum sql.NullFloat64
+	err := row.Scan(&sum)
+	return sum, err
+}
+
 const createCharacterContract = `-- name: CreateCharacterContract :one
 INSERT INTO
     character_contracts (
@@ -200,8 +251,9 @@ func (q *Queries) CreateCharacterContractItem(ctx context.Context, arg CreateCha
 
 const deleteCharacterContracts = `-- name: DeleteCharacterContracts :exec
 DELETE FROM character_contracts
-WHERE character_id = ?
-AND contract_id IN (/*SLICE:contract_ids*/?)
+WHERE
+    character_id = ?
+    AND contract_id IN (/*SLICE:contract_ids*/?)
 `
 
 type DeleteCharacterContractsParams struct {

--- a/internal/app/storage/queries/character_contracts.sql.go
+++ b/internal/app/storage/queries/character_contracts.sql.go
@@ -63,6 +63,43 @@ func (q *Queries) CalculateCharacterContractItemsValue(ctx context.Context, arg 
 	return sum, err
 }
 
+const calculateCharacterContractsCourierEscrow = `-- name: CalculateCharacterContractsCourierEscrow :one
+SELECT
+    SUM(collateral)
+FROM
+    character_contracts
+WHERE
+    character_id = ?
+    AND acceptor_id == character_id
+    AND type = ?
+    AND status IN (/*SLICE:status*/?)
+`
+
+type CalculateCharacterContractsCourierEscrowParams struct {
+	CharacterID int64
+	Type        string
+	Status      []string
+}
+
+func (q *Queries) CalculateCharacterContractsCourierEscrow(ctx context.Context, arg CalculateCharacterContractsCourierEscrowParams) (sql.NullFloat64, error) {
+	query := calculateCharacterContractsCourierEscrow
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	queryParams = append(queryParams, arg.Type)
+	if len(arg.Status) > 0 {
+		for _, v := range arg.Status {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:status*/?", strings.Repeat(",?", len(arg.Status))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:status*/?", "NULL", 1)
+	}
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
+	var sum sql.NullFloat64
+	err := row.Scan(&sum)
+	return sum, err
+}
+
 const createCharacterContract = `-- name: CreateCharacterContract :one
 INSERT INTO
     character_contracts (

--- a/internal/app/storage/queries/character_contracts.sql.go
+++ b/internal/app/storage/queries/character_contracts.sql.go
@@ -63,6 +63,51 @@ func (q *Queries) CalculateCharacterContractItemsValue(ctx context.Context, arg 
 	return sum, err
 }
 
+const calculateCharacterContractsAuctionEscrow = `-- name: CalculateCharacterContractsAuctionEscrow :one
+SELECT
+    bidder_id,
+    SUM(amount) AS total_winning_bids
+FROM character_contract_bids AS main_bids
+JOIN character_contracts cc ON cc.id = main_bids.contract_id
+WHERE amount = (
+    SELECT MAX(amount)
+    FROM character_contract_bids
+    WHERE contract_id = main_bids.contract_id
+)
+AND main_bids.bidder_id = cc.character_id
+AND cc.character_id = ?
+AND cc.status IN (/*SLICE:status*/?)
+GROUP BY main_bids.bidder_id
+`
+
+type CalculateCharacterContractsAuctionEscrowParams struct {
+	CharacterID int64
+	Status      []string
+}
+
+type CalculateCharacterContractsAuctionEscrowRow struct {
+	BidderID         int64
+	TotalWinningBids sql.NullFloat64
+}
+
+func (q *Queries) CalculateCharacterContractsAuctionEscrow(ctx context.Context, arg CalculateCharacterContractsAuctionEscrowParams) (CalculateCharacterContractsAuctionEscrowRow, error) {
+	query := calculateCharacterContractsAuctionEscrow
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	if len(arg.Status) > 0 {
+		for _, v := range arg.Status {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:status*/?", strings.Repeat(",?", len(arg.Status))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:status*/?", "NULL", 1)
+	}
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
+	var i CalculateCharacterContractsAuctionEscrowRow
+	err := row.Scan(&i.BidderID, &i.TotalWinningBids)
+	return i, err
+}
+
 const calculateCharacterContractsCourierEscrow = `-- name: CalculateCharacterContractsCourierEscrow :one
 SELECT
     SUM(collateral)

--- a/internal/app/storage/queries/character_market_orders.sql
+++ b/internal/app/storage/queries/character_market_orders.sql
@@ -1,3 +1,17 @@
+-- name: CalculateCharacterOrderItemsValue :one
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * volume_remains)
+FROM
+    character_market_orders cmo
+    JOIN eve_types et ON et.id = cmo.type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = cmo.type_id
+WHERE
+    character_id = ?
+    AND is_buy_order IS FALSE
+    AND state IN (sqlc.slice('states'))
+    AND eg.eve_category_id <> ?;
+
 -- name: DeleteCharacterMarketOrders :exec
 DELETE FROM character_market_orders
 WHERE

--- a/internal/app/storage/queries/character_market_orders.sql
+++ b/internal/app/storage/queries/character_market_orders.sql
@@ -12,6 +12,16 @@ WHERE
     AND state IN (sqlc.slice('states'))
     AND eg.eve_category_id <> ?;
 
+-- name: CalculateCharacterOrdersEscrow :one
+SELECT
+    SUM(escrow)
+FROM
+    character_market_orders cmo
+WHERE
+    character_id = ?
+    AND is_buy_order IS TRUE
+    AND state IN (sqlc.slice('states'));
+
 -- name: DeleteCharacterMarketOrders :exec
 DELETE FROM character_market_orders
 WHERE

--- a/internal/app/storage/queries/character_market_orders.sql.go
+++ b/internal/app/storage/queries/character_market_orders.sql.go
@@ -12,6 +12,46 @@ import (
 	"time"
 )
 
+const calculateCharacterOrderItemsValue = `-- name: CalculateCharacterOrderItemsValue :one
+SELECT
+    SUM(IFNULL(mp.average_price, 0) * volume_remains)
+FROM
+    character_market_orders cmo
+    JOIN eve_types et ON et.id = cmo.type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    LEFT JOIN eve_market_prices mp ON mp.type_id = cmo.type_id
+WHERE
+    character_id = ?
+    AND is_buy_order IS FALSE
+    AND state IN (/*SLICE:states*/?)
+    AND eg.eve_category_id <> ?
+`
+
+type CalculateCharacterOrderItemsValueParams struct {
+	CharacterID   int64
+	States        []string
+	EveCategoryID int64
+}
+
+func (q *Queries) CalculateCharacterOrderItemsValue(ctx context.Context, arg CalculateCharacterOrderItemsValueParams) (sql.NullFloat64, error) {
+	query := calculateCharacterOrderItemsValue
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	if len(arg.States) > 0 {
+		for _, v := range arg.States {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:states*/?", strings.Repeat(",?", len(arg.States))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:states*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.EveCategoryID)
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
+	var sum sql.NullFloat64
+	err := row.Scan(&sum)
+	return sum, err
+}
+
 const deleteCharacterMarketOrders = `-- name: DeleteCharacterMarketOrders :exec
 DELETE FROM character_market_orders
 WHERE

--- a/internal/app/storage/queries/character_market_orders.sql.go
+++ b/internal/app/storage/queries/character_market_orders.sql.go
@@ -52,6 +52,40 @@ func (q *Queries) CalculateCharacterOrderItemsValue(ctx context.Context, arg Cal
 	return sum, err
 }
 
+const calculateCharacterOrdersEscrow = `-- name: CalculateCharacterOrdersEscrow :one
+SELECT
+    SUM(escrow)
+FROM
+    character_market_orders cmo
+WHERE
+    character_id = ?
+    AND is_buy_order IS TRUE
+    AND state IN (/*SLICE:states*/?)
+`
+
+type CalculateCharacterOrdersEscrowParams struct {
+	CharacterID int64
+	States      []string
+}
+
+func (q *Queries) CalculateCharacterOrdersEscrow(ctx context.Context, arg CalculateCharacterOrdersEscrowParams) (sql.NullFloat64, error) {
+	query := calculateCharacterOrdersEscrow
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.CharacterID)
+	if len(arg.States) > 0 {
+		for _, v := range arg.States {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:states*/?", strings.Repeat(",?", len(arg.States))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:states*/?", "NULL", 1)
+	}
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
+	var sum sql.NullFloat64
+	err := row.Scan(&sum)
+	return sum, err
+}
+
 const deleteCharacterMarketOrders = `-- name: DeleteCharacterMarketOrders :exec
 DELETE FROM character_market_orders
 WHERE

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -3,20 +3,22 @@ INSERT INTO
     characters (
         id,
         asset_value,
-        contract_escrow,
+        contracts_escrow,
+        contract_items_value,
         home_id,
         is_training_watched,
         last_clone_jump_at,
         last_login_at,
         location_id,
-        market_escrow,
+        orders_escrow,
+        order_items_value,
         ship_id,
         total_sp,
         unallocated_sp,
         wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: DeleteCharacter :exec
 DELETE FROM characters
@@ -124,7 +126,6 @@ SELECT
 FROM
     characters;
 
-
 -- name: UpdateCharacterAssetValue :exec
 UPDATE characters
 SET
@@ -132,10 +133,17 @@ SET
 WHERE
     id = ?;
 
--- name: UpdateCharacterContractEscrow :exec
+-- name: UpdateCharacterContractsEscrow :exec
 UPDATE characters
 SET
-    contract_escrow = ?
+    contracts_escrow = ?
+WHERE
+    id = ?;
+
+-- name: UpdateCharacterContractItemsValue :exec
+UPDATE characters
+SET
+    contract_items_value = ?
 WHERE
     id = ?;
 
@@ -174,13 +182,19 @@ SET
 WHERE
     id = ?;
 
--- name: UpdateCharacterMarketEscrow :exec
+-- name: UpdateCharacterOrdersEscrow :exec
 UPDATE characters
 SET
-    market_escrow = ?
+    orders_escrow = ?
 WHERE
     id = ?;
 
+-- name: UpdateCharacterOrderItemsValue :exec
+UPDATE characters
+SET
+    order_items_value = ?
+WHERE
+    id = ?;
 
 -- name: UpdateCharacterShipID :exec
 UPDATE characters

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -2,19 +2,21 @@
 INSERT INTO
     characters (
         id,
+        asset_value,
+        contract_escrow,
         home_id,
+        is_training_watched,
+        last_clone_jump_at,
         last_login_at,
         location_id,
+        market_escrow,
         ship_id,
         total_sp,
         unallocated_sp,
-        wallet_balance,
-        asset_value,
-        is_training_watched,
-        last_clone_jump_at
+        wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: DeleteCharacter :exec
 DELETE FROM characters
@@ -122,6 +124,21 @@ SELECT
 FROM
     characters;
 
+
+-- name: UpdateCharacterAssetValue :exec
+UPDATE characters
+SET
+    asset_value = ?
+WHERE
+    id = ?;
+
+-- name: UpdateCharacterContractEscrow :exec
+UPDATE characters
+SET
+    contract_escrow = ?
+WHERE
+    id = ?;
+
 -- name: UpdateCharacterLastCloneJump :exec
 UPDATE characters
 SET
@@ -157,6 +174,14 @@ SET
 WHERE
     id = ?;
 
+-- name: UpdateCharacterMarketEscrow :exec
+UPDATE characters
+SET
+    market_escrow = ?
+WHERE
+    id = ?;
+
+
 -- name: UpdateCharacterShipID :exec
 UPDATE characters
 SET
@@ -176,12 +201,5 @@ WHERE
 UPDATE characters
 SET
     wallet_balance = ?
-WHERE
-    id = ?;
-
--- name: UpdateCharacterAssetValue :exec
-UPDATE characters
-SET
-    asset_value = ?
 WHERE
     id = ?;

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -114,6 +114,14 @@ FROM
     JOIN eve_characters ec ON ec.id = ch.id
     JOIN eve_entities ee ON ee.id = ec.corporation_id;
 
+-- name: ListCharacterWealthValues :many
+SELECT
+    id,
+    asset_value,
+    wallet_balance
+FROM
+    characters;
+
 -- name: UpdateCharacterLastCloneJump :exec
 UPDATE characters
 SET

--- a/internal/app/storage/queries/characters.sql
+++ b/internal/app/storage/queries/characters.sql
@@ -3,22 +3,23 @@ INSERT INTO
     characters (
         id,
         asset_value,
-        contracts_escrow,
         contract_items_value,
+        contracts_escrow,
         home_id,
         is_training_watched,
         last_clone_jump_at,
         last_login_at,
         location_id,
-        orders_escrow,
         order_items_value,
+        orders_escrow,
         ship_id,
+        skill_points_value,
         total_sp,
         unallocated_sp,
         wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: DeleteCharacter :exec
 DELETE FROM characters
@@ -200,6 +201,13 @@ WHERE
 UPDATE characters
 SET
     ship_id = ?
+WHERE
+    id = ?;
+
+-- name: UpdateCharacterSkillPointsValue :exec
+UPDATE characters
+SET
+    skill_points_value = ?
 WHERE
     id = ?;
 

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -15,37 +15,39 @@ INSERT INTO
     characters (
         id,
         asset_value,
-        contracts_escrow,
         contract_items_value,
+        contracts_escrow,
         home_id,
         is_training_watched,
         last_clone_jump_at,
         last_login_at,
         location_id,
-        orders_escrow,
         order_items_value,
+        orders_escrow,
         ship_id,
+        skill_points_value,
         total_sp,
         unallocated_sp,
         wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateCharacterParams struct {
 	ID                 int64
 	AssetValue         sql.NullFloat64
-	ContractsEscrow    sql.NullFloat64
 	ContractItemsValue sql.NullFloat64
+	ContractsEscrow    sql.NullFloat64
 	HomeID             sql.NullInt64
 	IsTrainingWatched  bool
 	LastCloneJumpAt    sql.NullTime
 	LastLoginAt        sql.NullTime
 	LocationID         sql.NullInt64
-	OrdersEscrow       sql.NullFloat64
 	OrderItemsValue    sql.NullFloat64
+	OrdersEscrow       sql.NullFloat64
 	ShipID             sql.NullInt64
+	SkillPointsValue   sql.NullFloat64
 	TotalSp            sql.NullInt64
 	UnallocatedSp      sql.NullInt64
 	WalletBalance      sql.NullFloat64
@@ -55,16 +57,17 @@ func (q *Queries) CreateCharacter(ctx context.Context, arg CreateCharacterParams
 	_, err := q.db.ExecContext(ctx, createCharacter,
 		arg.ID,
 		arg.AssetValue,
-		arg.ContractsEscrow,
 		arg.ContractItemsValue,
+		arg.ContractsEscrow,
 		arg.HomeID,
 		arg.IsTrainingWatched,
 		arg.LastCloneJumpAt,
 		arg.LastLoginAt,
 		arg.LocationID,
-		arg.OrdersEscrow,
 		arg.OrderItemsValue,
+		arg.OrdersEscrow,
 		arg.ShipID,
+		arg.SkillPointsValue,
 		arg.TotalSp,
 		arg.UnallocatedSp,
 		arg.WalletBalance,
@@ -96,7 +99,7 @@ func (q *Queries) DisableAllTrainingWatchers(ctx context.Context) error {
 
 const getCharacter = `-- name: GetCharacter :one
 SELECT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value, cc.skill_points_value,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -151,6 +154,7 @@ func (q *Queries) GetCharacter(ctx context.Context, id int64) (GetCharacterRow, 
 		&i.Character.ContractItemsValue,
 		&i.Character.OrdersEscrow,
 		&i.Character.OrderItemsValue,
+		&i.Character.SkillPointsValue,
 		&i.EveCharacter.AllianceID,
 		&i.EveCharacter.Birthday,
 		&i.EveCharacter.CorporationID,
@@ -336,7 +340,7 @@ func (q *Queries) ListCharacterWealthValues(ctx context.Context) ([]ListCharacte
 
 const listCharacters = `-- name: ListCharacters :many
 SELECT DISTINCT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value, cc.skill_points_value,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -397,6 +401,7 @@ func (q *Queries) ListCharacters(ctx context.Context) ([]ListCharactersRow, erro
 			&i.Character.ContractItemsValue,
 			&i.Character.OrdersEscrow,
 			&i.Character.OrderItemsValue,
+			&i.Character.SkillPointsValue,
 			&i.EveCharacter.AllianceID,
 			&i.EveCharacter.Birthday,
 			&i.EveCharacter.CorporationID,
@@ -689,6 +694,24 @@ type UpdateCharacterShipIDParams struct {
 
 func (q *Queries) UpdateCharacterShipID(ctx context.Context, arg UpdateCharacterShipIDParams) error {
 	_, err := q.db.ExecContext(ctx, updateCharacterShipID, arg.ShipID, arg.ID)
+	return err
+}
+
+const updateCharacterSkillPointsValue = `-- name: UpdateCharacterSkillPointsValue :exec
+UPDATE characters
+SET
+    skill_points_value = ?
+WHERE
+    id = ?
+`
+
+type UpdateCharacterSkillPointsValueParams struct {
+	SkillPointsValue sql.NullFloat64
+	ID               int64
+}
+
+func (q *Queries) UpdateCharacterSkillPointsValue(ctx context.Context, arg UpdateCharacterSkillPointsValueParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterSkillPointsValue, arg.SkillPointsValue, arg.ID)
 	return err
 }
 

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -15,49 +15,55 @@ INSERT INTO
     characters (
         id,
         asset_value,
-        contract_escrow,
+        contracts_escrow,
+        contract_items_value,
         home_id,
         is_training_watched,
         last_clone_jump_at,
         last_login_at,
         location_id,
-        market_escrow,
+        orders_escrow,
+        order_items_value,
         ship_id,
         total_sp,
         unallocated_sp,
         wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateCharacterParams struct {
-	ID                int64
-	AssetValue        sql.NullFloat64
-	ContractEscrow    sql.NullFloat64
-	HomeID            sql.NullInt64
-	IsTrainingWatched bool
-	LastCloneJumpAt   sql.NullTime
-	LastLoginAt       sql.NullTime
-	LocationID        sql.NullInt64
-	MarketEscrow      sql.NullFloat64
-	ShipID            sql.NullInt64
-	TotalSp           sql.NullInt64
-	UnallocatedSp     sql.NullInt64
-	WalletBalance     sql.NullFloat64
+	ID                 int64
+	AssetValue         sql.NullFloat64
+	ContractsEscrow    sql.NullFloat64
+	ContractItemsValue sql.NullFloat64
+	HomeID             sql.NullInt64
+	IsTrainingWatched  bool
+	LastCloneJumpAt    sql.NullTime
+	LastLoginAt        sql.NullTime
+	LocationID         sql.NullInt64
+	OrdersEscrow       sql.NullFloat64
+	OrderItemsValue    sql.NullFloat64
+	ShipID             sql.NullInt64
+	TotalSp            sql.NullInt64
+	UnallocatedSp      sql.NullInt64
+	WalletBalance      sql.NullFloat64
 }
 
 func (q *Queries) CreateCharacter(ctx context.Context, arg CreateCharacterParams) error {
 	_, err := q.db.ExecContext(ctx, createCharacter,
 		arg.ID,
 		arg.AssetValue,
-		arg.ContractEscrow,
+		arg.ContractsEscrow,
+		arg.ContractItemsValue,
 		arg.HomeID,
 		arg.IsTrainingWatched,
 		arg.LastCloneJumpAt,
 		arg.LastLoginAt,
 		arg.LocationID,
-		arg.MarketEscrow,
+		arg.OrdersEscrow,
+		arg.OrderItemsValue,
 		arg.ShipID,
 		arg.TotalSp,
 		arg.UnallocatedSp,
@@ -90,7 +96,7 @@ func (q *Queries) DisableAllTrainingWatchers(ctx context.Context) error {
 
 const getCharacter = `-- name: GetCharacter :one
 SELECT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contract_escrow, cc.market_escrow,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -141,8 +147,10 @@ func (q *Queries) GetCharacter(ctx context.Context, id int64) (GetCharacterRow, 
 		&i.Character.WalletBalance,
 		&i.Character.IsTrainingWatched,
 		&i.Character.LastCloneJumpAt,
-		&i.Character.ContractEscrow,
-		&i.Character.MarketEscrow,
+		&i.Character.ContractsEscrow,
+		&i.Character.ContractItemsValue,
+		&i.Character.OrdersEscrow,
+		&i.Character.OrderItemsValue,
 		&i.EveCharacter.AllianceID,
 		&i.EveCharacter.Birthday,
 		&i.EveCharacter.CorporationID,
@@ -328,7 +336,7 @@ func (q *Queries) ListCharacterWealthValues(ctx context.Context) ([]ListCharacte
 
 const listCharacters = `-- name: ListCharacters :many
 SELECT DISTINCT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contract_escrow, cc.market_escrow,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contracts_escrow, cc.contract_items_value, cc.orders_escrow, cc.order_items_value,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -385,8 +393,10 @@ func (q *Queries) ListCharacters(ctx context.Context) ([]ListCharactersRow, erro
 			&i.Character.WalletBalance,
 			&i.Character.IsTrainingWatched,
 			&i.Character.LastCloneJumpAt,
-			&i.Character.ContractEscrow,
-			&i.Character.MarketEscrow,
+			&i.Character.ContractsEscrow,
+			&i.Character.ContractItemsValue,
+			&i.Character.OrdersEscrow,
+			&i.Character.OrderItemsValue,
 			&i.EveCharacter.AllianceID,
 			&i.EveCharacter.Birthday,
 			&i.EveCharacter.CorporationID,
@@ -482,21 +492,39 @@ func (q *Queries) UpdateCharacterAssetValue(ctx context.Context, arg UpdateChara
 	return err
 }
 
-const updateCharacterContractEscrow = `-- name: UpdateCharacterContractEscrow :exec
+const updateCharacterContractItemsValue = `-- name: UpdateCharacterContractItemsValue :exec
 UPDATE characters
 SET
-    contract_escrow = ?
+    contract_items_value = ?
 WHERE
     id = ?
 `
 
-type UpdateCharacterContractEscrowParams struct {
-	ContractEscrow sql.NullFloat64
-	ID             int64
+type UpdateCharacterContractItemsValueParams struct {
+	ContractItemsValue sql.NullFloat64
+	ID                 int64
 }
 
-func (q *Queries) UpdateCharacterContractEscrow(ctx context.Context, arg UpdateCharacterContractEscrowParams) error {
-	_, err := q.db.ExecContext(ctx, updateCharacterContractEscrow, arg.ContractEscrow, arg.ID)
+func (q *Queries) UpdateCharacterContractItemsValue(ctx context.Context, arg UpdateCharacterContractItemsValueParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterContractItemsValue, arg.ContractItemsValue, arg.ID)
+	return err
+}
+
+const updateCharacterContractsEscrow = `-- name: UpdateCharacterContractsEscrow :exec
+UPDATE characters
+SET
+    contracts_escrow = ?
+WHERE
+    id = ?
+`
+
+type UpdateCharacterContractsEscrowParams struct {
+	ContractsEscrow sql.NullFloat64
+	ID              int64
+}
+
+func (q *Queries) UpdateCharacterContractsEscrow(ctx context.Context, arg UpdateCharacterContractsEscrowParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterContractsEscrow, arg.ContractsEscrow, arg.ID)
 	return err
 }
 
@@ -590,21 +618,39 @@ func (q *Queries) UpdateCharacterLocationID(ctx context.Context, arg UpdateChara
 	return err
 }
 
-const updateCharacterMarketEscrow = `-- name: UpdateCharacterMarketEscrow :exec
+const updateCharacterOrderItemsValue = `-- name: UpdateCharacterOrderItemsValue :exec
 UPDATE characters
 SET
-    market_escrow = ?
+    order_items_value = ?
 WHERE
     id = ?
 `
 
-type UpdateCharacterMarketEscrowParams struct {
-	MarketEscrow sql.NullFloat64
+type UpdateCharacterOrderItemsValueParams struct {
+	OrderItemsValue sql.NullFloat64
+	ID              int64
+}
+
+func (q *Queries) UpdateCharacterOrderItemsValue(ctx context.Context, arg UpdateCharacterOrderItemsValueParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterOrderItemsValue, arg.OrderItemsValue, arg.ID)
+	return err
+}
+
+const updateCharacterOrdersEscrow = `-- name: UpdateCharacterOrdersEscrow :exec
+UPDATE characters
+SET
+    orders_escrow = ?
+WHERE
+    id = ?
+`
+
+type UpdateCharacterOrdersEscrowParams struct {
+	OrdersEscrow sql.NullFloat64
 	ID           int64
 }
 
-func (q *Queries) UpdateCharacterMarketEscrow(ctx context.Context, arg UpdateCharacterMarketEscrowParams) error {
-	_, err := q.db.ExecContext(ctx, updateCharacterMarketEscrow, arg.MarketEscrow, arg.ID)
+func (q *Queries) UpdateCharacterOrdersEscrow(ctx context.Context, arg UpdateCharacterOrdersEscrowParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterOrdersEscrow, arg.OrdersEscrow, arg.ID)
 	return err
 }
 

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -14,48 +14,54 @@ const createCharacter = `-- name: CreateCharacter :exec
 INSERT INTO
     characters (
         id,
+        asset_value,
+        contract_escrow,
         home_id,
+        is_training_watched,
+        last_clone_jump_at,
         last_login_at,
         location_id,
+        market_escrow,
         ship_id,
         total_sp,
         unallocated_sp,
-        wallet_balance,
-        asset_value,
-        is_training_watched,
-        last_clone_jump_at
+        wallet_balance
     )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateCharacterParams struct {
 	ID                int64
+	AssetValue        sql.NullFloat64
+	ContractEscrow    sql.NullFloat64
 	HomeID            sql.NullInt64
+	IsTrainingWatched bool
+	LastCloneJumpAt   sql.NullTime
 	LastLoginAt       sql.NullTime
 	LocationID        sql.NullInt64
+	MarketEscrow      sql.NullFloat64
 	ShipID            sql.NullInt64
 	TotalSp           sql.NullInt64
 	UnallocatedSp     sql.NullInt64
 	WalletBalance     sql.NullFloat64
-	AssetValue        sql.NullFloat64
-	IsTrainingWatched bool
-	LastCloneJumpAt   sql.NullTime
 }
 
 func (q *Queries) CreateCharacter(ctx context.Context, arg CreateCharacterParams) error {
 	_, err := q.db.ExecContext(ctx, createCharacter,
 		arg.ID,
+		arg.AssetValue,
+		arg.ContractEscrow,
 		arg.HomeID,
+		arg.IsTrainingWatched,
+		arg.LastCloneJumpAt,
 		arg.LastLoginAt,
 		arg.LocationID,
+		arg.MarketEscrow,
 		arg.ShipID,
 		arg.TotalSp,
 		arg.UnallocatedSp,
 		arg.WalletBalance,
-		arg.AssetValue,
-		arg.IsTrainingWatched,
-		arg.LastCloneJumpAt,
 	)
 	return err
 }
@@ -84,7 +90,7 @@ func (q *Queries) DisableAllTrainingWatchers(ctx context.Context) error {
 
 const getCharacter = `-- name: GetCharacter :one
 SELECT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contract_escrow, cc.market_escrow,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -135,6 +141,8 @@ func (q *Queries) GetCharacter(ctx context.Context, id int64) (GetCharacterRow, 
 		&i.Character.WalletBalance,
 		&i.Character.IsTrainingWatched,
 		&i.Character.LastCloneJumpAt,
+		&i.Character.ContractEscrow,
+		&i.Character.MarketEscrow,
 		&i.EveCharacter.AllianceID,
 		&i.EveCharacter.Birthday,
 		&i.EveCharacter.CorporationID,
@@ -320,7 +328,7 @@ func (q *Queries) ListCharacterWealthValues(ctx context.Context) ([]ListCharacte
 
 const listCharacters = `-- name: ListCharacters :many
 SELECT DISTINCT
-    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at,
+    cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at, cc.contract_escrow, cc.market_escrow,
     ec.alliance_id, ec.birthday, ec.corporation_id, ec.description, ec.gender, ec.faction_id, ec.id, ec.name, ec.race_id, ec.security_status, ec.title,
     eec.id, eec.category, eec.name,
     er.id, er.description, er.name,
@@ -377,6 +385,8 @@ func (q *Queries) ListCharacters(ctx context.Context) ([]ListCharactersRow, erro
 			&i.Character.WalletBalance,
 			&i.Character.IsTrainingWatched,
 			&i.Character.LastCloneJumpAt,
+			&i.Character.ContractEscrow,
+			&i.Character.MarketEscrow,
 			&i.EveCharacter.AllianceID,
 			&i.EveCharacter.Birthday,
 			&i.EveCharacter.CorporationID,
@@ -472,6 +482,24 @@ func (q *Queries) UpdateCharacterAssetValue(ctx context.Context, arg UpdateChara
 	return err
 }
 
+const updateCharacterContractEscrow = `-- name: UpdateCharacterContractEscrow :exec
+UPDATE characters
+SET
+    contract_escrow = ?
+WHERE
+    id = ?
+`
+
+type UpdateCharacterContractEscrowParams struct {
+	ContractEscrow sql.NullFloat64
+	ID             int64
+}
+
+func (q *Queries) UpdateCharacterContractEscrow(ctx context.Context, arg UpdateCharacterContractEscrowParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterContractEscrow, arg.ContractEscrow, arg.ID)
+	return err
+}
+
 const updateCharacterHomeId = `-- name: UpdateCharacterHomeId :exec
 UPDATE characters
 SET
@@ -559,6 +587,24 @@ type UpdateCharacterLocationIDParams struct {
 
 func (q *Queries) UpdateCharacterLocationID(ctx context.Context, arg UpdateCharacterLocationIDParams) error {
 	_, err := q.db.ExecContext(ctx, updateCharacterLocationID, arg.LocationID, arg.ID)
+	return err
+}
+
+const updateCharacterMarketEscrow = `-- name: UpdateCharacterMarketEscrow :exec
+UPDATE characters
+SET
+    market_escrow = ?
+WHERE
+    id = ?
+`
+
+type UpdateCharacterMarketEscrowParams struct {
+	MarketEscrow sql.NullFloat64
+	ID           int64
+}
+
+func (q *Queries) UpdateCharacterMarketEscrow(ctx context.Context, arg UpdateCharacterMarketEscrowParams) error {
+	_, err := q.db.ExecContext(ctx, updateCharacterMarketEscrow, arg.MarketEscrow, arg.ID)
 	return err
 }
 

--- a/internal/app/storage/queries/characters.sql.go
+++ b/internal/app/storage/queries/characters.sql.go
@@ -280,6 +280,44 @@ func (q *Queries) ListCharacterIDs(ctx context.Context) ([]int64, error) {
 	return items, nil
 }
 
+const listCharacterWealthValues = `-- name: ListCharacterWealthValues :many
+SELECT
+    id,
+    asset_value,
+    wallet_balance
+FROM
+    characters
+`
+
+type ListCharacterWealthValuesRow struct {
+	ID            int64
+	AssetValue    sql.NullFloat64
+	WalletBalance sql.NullFloat64
+}
+
+func (q *Queries) ListCharacterWealthValues(ctx context.Context) ([]ListCharacterWealthValuesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listCharacterWealthValues)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCharacterWealthValuesRow
+	for rows.Next() {
+		var i ListCharacterWealthValuesRow
+		if err := rows.Scan(&i.ID, &i.AssetValue, &i.WalletBalance); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCharacters = `-- name: ListCharacters :many
 SELECT DISTINCT
     cc.id, cc.asset_value, cc.home_id, cc.last_login_at, cc.location_id, cc.ship_id, cc.total_sp, cc.unallocated_sp, cc.wallet_balance, cc.is_training_watched, cc.last_clone_jump_at,

--- a/internal/app/storage/queries/models.go
+++ b/internal/app/storage/queries/models.go
@@ -18,19 +18,21 @@ type Cache struct {
 }
 
 type Character struct {
-	ID                int64
-	AssetValue        sql.NullFloat64
-	HomeID            sql.NullInt64
-	LastLoginAt       sql.NullTime
-	LocationID        sql.NullInt64
-	ShipID            sql.NullInt64
-	TotalSp           sql.NullInt64
-	UnallocatedSp     sql.NullInt64
-	WalletBalance     sql.NullFloat64
-	IsTrainingWatched bool
-	LastCloneJumpAt   sql.NullTime
-	ContractEscrow    sql.NullFloat64
-	MarketEscrow      sql.NullFloat64
+	ID                 int64
+	AssetValue         sql.NullFloat64
+	HomeID             sql.NullInt64
+	LastLoginAt        sql.NullTime
+	LocationID         sql.NullInt64
+	ShipID             sql.NullInt64
+	TotalSp            sql.NullInt64
+	UnallocatedSp      sql.NullInt64
+	WalletBalance      sql.NullFloat64
+	IsTrainingWatched  bool
+	LastCloneJumpAt    sql.NullTime
+	ContractsEscrow    sql.NullFloat64
+	ContractItemsValue sql.NullFloat64
+	OrdersEscrow       sql.NullFloat64
+	OrderItemsValue    sql.NullFloat64
 }
 
 type CharacterAsset struct {

--- a/internal/app/storage/queries/models.go
+++ b/internal/app/storage/queries/models.go
@@ -29,6 +29,8 @@ type Character struct {
 	WalletBalance     sql.NullFloat64
 	IsTrainingWatched bool
 	LastCloneJumpAt   sql.NullTime
+	ContractEscrow    sql.NullFloat64
+	MarketEscrow      sql.NullFloat64
 }
 
 type CharacterAsset struct {

--- a/internal/app/storage/queries/models.go
+++ b/internal/app/storage/queries/models.go
@@ -33,6 +33,7 @@ type Character struct {
 	ContractItemsValue sql.NullFloat64
 	OrdersEscrow       sql.NullFloat64
 	OrderItemsValue    sql.NullFloat64
+	SkillPointsValue   sql.NullFloat64
 }
 
 type CharacterAsset struct {

--- a/internal/app/testutil/factory.go
+++ b/internal/app/testutil/factory.go
@@ -96,6 +96,12 @@ func (f Factory) CreateCharacterFull(args ...storage.CreateCharacterParams) *app
 	if arg.AssetValue.IsEmpty() {
 		arg.AssetValue = optional.New(rand.Float64() * 100_000_000_000)
 	}
+	if arg.ContractEscrow.IsEmpty() {
+		arg.ContractEscrow = optional.New(rand.Float64() * 10_000_000_000)
+	}
+	if arg.MarketEscrow.IsEmpty() {
+		arg.MarketEscrow = optional.New(rand.Float64() * 10_000_000_000)
+	}
 	if arg.HomeID.IsEmpty() {
 		x := f.CreateEveLocationStructure()
 		arg.HomeID = optional.New(x.ID)

--- a/internal/app/testutil/factory.go
+++ b/internal/app/testutil/factory.go
@@ -108,6 +108,9 @@ func (f Factory) CreateCharacterFull(args ...storage.CreateCharacterParams) *app
 	if arg.OrderItemsValue.IsEmpty() {
 		arg.OrderItemsValue = optional.New(rand.Float64() * 10_000_000_000)
 	}
+	if arg.SkillPointsValue.IsEmpty() {
+		arg.SkillPointsValue = optional.New(rand.Float64() * 100_000_000_000)
+	}
 	if arg.HomeID.IsEmpty() {
 		x := f.CreateEveLocationStructure()
 		arg.HomeID = optional.New(x.ID)

--- a/internal/app/testutil/factory.go
+++ b/internal/app/testutil/factory.go
@@ -96,11 +96,17 @@ func (f Factory) CreateCharacterFull(args ...storage.CreateCharacterParams) *app
 	if arg.AssetValue.IsEmpty() {
 		arg.AssetValue = optional.New(rand.Float64() * 100_000_000_000)
 	}
-	if arg.ContractEscrow.IsEmpty() {
-		arg.ContractEscrow = optional.New(rand.Float64() * 10_000_000_000)
+	if arg.ContractsEscrow.IsEmpty() {
+		arg.ContractsEscrow = optional.New(rand.Float64() * 10_000_000_000)
 	}
-	if arg.MarketEscrow.IsEmpty() {
-		arg.MarketEscrow = optional.New(rand.Float64() * 10_000_000_000)
+	if arg.ContractItemsValue.IsEmpty() {
+		arg.ContractItemsValue = optional.New(rand.Float64() * 10_000_000_000)
+	}
+	if arg.OrdersEscrow.IsEmpty() {
+		arg.OrdersEscrow = optional.New(rand.Float64() * 10_000_000_000)
+	}
+	if arg.OrderItemsValue.IsEmpty() {
+		arg.OrderItemsValue = optional.New(rand.Float64() * 10_000_000_000)
 	}
 	if arg.HomeID.IsEmpty() {
 		x := f.CreateEveLocationStructure()
@@ -189,9 +195,9 @@ func (f Factory) CreateCharacterAsset(args ...storage.CreateCharacterAssetParams
 		x := f.CreateCharacterFull()
 		arg.CharacterID = x.ID
 	}
-	if arg.EveTypeID == 0 {
+	if arg.TypeID == 0 {
 		x := f.CreateEveType()
-		arg.EveTypeID = x.ID
+		arg.TypeID = x.ID
 	}
 	if arg.ItemID == 0 {
 		arg.ItemID = f.calcNewIDWithCharacter("character_assets", "item_id", arg.CharacterID)

--- a/internal/app/ui/assets/browser.go
+++ b/internal/app/ui/assets/browser.go
@@ -508,21 +508,21 @@ func updateItemCounts(td xwidget.TreeData[containerNode]) {
 			case asset.NodeOfficeFolder, asset.NodeAssetSafetyCharacter:
 				for _, n1 := range td.Children(top) {
 					n1.itemCount = optional.FromZeroValue(len(n1.node.Children()))
-					top.itemCount = optional.Sum(top.itemCount, n1.itemCount)
+					top.itemCount = optional.SumNonEmpty(top.itemCount, n1.itemCount)
 				}
 			case asset.NodeAssetSafetyCorporation, asset.NodeImpounded:
 				for _, n1 := range td.Children(top) {
 					n1.itemCount.Clear()
 					for _, n2 := range td.Children(n1) {
 						n2.itemCount = optional.FromZeroValue(len(n2.node.Children()))
-						n1.itemCount = optional.Sum(n1.itemCount, n2.itemCount)
+						n1.itemCount = optional.SumNonEmpty(n1.itemCount, n2.itemCount)
 					}
-					top.itemCount = optional.Sum(top.itemCount, n1.itemCount)
+					top.itemCount = optional.SumNonEmpty(top.itemCount, n1.itemCount)
 				}
 			default:
 				top.itemCount = optional.FromZeroValue(len(top.node.Children()))
 			}
-			location.itemCount = optional.Sum(location.itemCount, top.itemCount)
+			location.itemCount = optional.SumNonEmpty(location.itemCount, top.itemCount)
 		}
 	}
 }
@@ -773,7 +773,7 @@ func (a *browserContainer) filterItemsAsync() {
 		for _, it := range items {
 			itemCount++
 			if as, ok := it.node.Asset(); ok {
-				value = optional.Sum(value, optional.New(as.Price.ValueOrZero()*float64(as.Quantity)))
+				value = optional.SumNonEmpty(value, optional.New(as.Price.ValueOrZero()*float64(as.Quantity)))
 			}
 		}
 		footer := fmt.Sprintf("%s / %s items", ihumanize.Comma(itemCount), ihumanize.Comma(totalItems))

--- a/internal/app/ui/assets/search.go
+++ b/internal/app/ui/assets/search.go
@@ -648,7 +648,7 @@ func (a *Search) filterRowsAsync(sortCol int) {
 		footer := fmt.Sprintf("Showing %s / %s items", ihumanize.Comma(len(rows)), ihumanize.Comma(totalRows))
 		var value optional.Optional[float64]
 		for _, r := range rows {
-			value = optional.Sum(value, r.total)
+			value = optional.SumNonEmpty(value, r.total)
 		}
 		if v, ok := value.Value(); ok {
 			footer += fmt.Sprintf(" • %s ISK est. price", ihumanize.Comma(int(v)))

--- a/internal/app/ui/assets/search.go
+++ b/internal/app/ui/assets/search.go
@@ -195,7 +195,7 @@ func (r *assetRow) setPrice(price optional.Optional[float64], quantity int, isBP
 		r.total.Set(v * float64(quantity))
 	}
 	r.totalDisplay = r.total.StringFunc("?", func(v float64) string {
-		return humanize.FormatFloat(ui.FloatFormat, v)
+		return humanize.FormatFloat(ui.FloatFormatISK, v)
 	})
 }
 

--- a/internal/app/ui/assets/search.go
+++ b/internal/app/ui/assets/search.go
@@ -428,10 +428,14 @@ func newAssetSearch(u coreUI, forCorporation bool) *Search {
 	}, a.u.MainWindow())
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+
 	if a.forCorporation {
 		a.u.Signals().CurrentCorporationExchanged.AddListener(func(ctx context.Context, c *app.Corporation) {
 			a.corporation.Store(c)
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 			if a.corporation.Load().IDOrZero() != arg.CorporationID {
@@ -440,32 +444,32 @@ func newAssetSearch(u coreUI, forCorporation bool) *Search {
 			if arg.Section != app.SectionCorporationAssets {
 				return
 			}
-			a.Update(ctx)
+			a.update(ctx)
 		})
 	} else {
 		a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 			if arg.Section == app.SectionCharacterAssets {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 		a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 			if arg.Section == app.SectionCorporationAssets {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 	}
 	a.u.Signals().EveUniverseSectionChanged.AddListener(func(ctx context.Context, arg app.EveUniverseSectionUpdated) {
 		if arg.Section == app.SectionEveMarketPrices {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	return a
@@ -671,7 +675,7 @@ func (a *Search) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Search) Update(ctx context.Context) {
+func (a *Search) update(ctx context.Context) {
 	reset := func() {
 		fyne.Do(func() {
 			a.rows = xslices.Reset(a.rows)

--- a/internal/app/ui/characters/charactersheet.go
+++ b/internal/app/ui/characters/charactersheet.go
@@ -236,7 +236,7 @@ func (a *CharacterSheet) update(ctx context.Context) {
 	})
 	fyne.Do(func() {
 		a.skillpoints.SetText(ihumanize.OptionalWithComma(c.TrainedSP, "?"))
-		v := optional.Sum(c.AssetValue, c.WalletBalance)
+		v := optional.SumNonEmpty(c.AssetValue, c.WalletBalance)
 		a.wealth.SetText(v.StringFunc("?", func(v float64) string {
 			return humanize.Comma(int64(v))
 		}) + " ISK")

--- a/internal/app/ui/characters/overview.go
+++ b/internal/app/ui/characters/overview.go
@@ -198,6 +198,9 @@ func NewOverview(u baseUI) *Overview {
 	}, a.u.MainWindow())
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().EveUniverseSectionChanged.AddListener(func(ctx context.Context, arg app.EveUniverseSectionUpdated) {
 		switch arg.Section {
 		case app.SectionEveCharacters:
@@ -210,13 +213,13 @@ func NewOverview(u baseUI) *Overview {
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
@@ -412,7 +415,7 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Overview) Update(ctx context.Context) {
+func (a *Overview) update(ctx context.Context) {
 	reset := func() {
 		fyne.Do(func() {
 			a.rows = xslices.Reset(a.rows)

--- a/internal/app/ui/clones/augmentations.go
+++ b/internal/app/ui/clones/augmentations.go
@@ -76,19 +76,23 @@ func NewAugmentations(u baseUI) *Augmentations {
 	})
 	a.collapseBranches.SetToolTip("Collapse branches")
 
+	// signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		if arg.Section == app.SectionCharacterImplants {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -192,7 +196,7 @@ func (a *Augmentations) filterTreeAsync() {
 	}()
 }
 
-func (a *Augmentations) Update(ctx context.Context) {
+func (a *Augmentations) update(ctx context.Context) {
 	td, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to refresh augmentations UI", "err", err)

--- a/internal/app/ui/clones/augmentations_test.go
+++ b/internal/app/ui/clones/augmentations_test.go
@@ -32,7 +32,7 @@ func TestAugmentations_Update(t *testing.T) {
 		}))
 
 		// when
-		a.Update(t.Context())
+		a.update(t.Context())
 
 		// then
 		got := set.Collect(xiter.MapSlice(a.treeData.Children(nil), func(x *augmentationNode) int64 {
@@ -58,7 +58,7 @@ func TestAugmentations_Update(t *testing.T) {
 		}))
 
 		// when
-		a.Update(t.Context())
+		a.update(t.Context())
 
 		// then
 		got := xslices.Map(a.treeData.Children(nil), func(x *augmentationNode) int64 {

--- a/internal/app/ui/clones/clones.go
+++ b/internal/app/ui/clones/clones.go
@@ -209,19 +209,23 @@ func NewClones(u baseUI) *Clones {
 	}, a.u.MainWindow())
 
 	// signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		if arg.Section == app.SectionCharacterJumpClones {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -321,7 +325,7 @@ func (a *Clones) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Clones) Update(ctx context.Context) {
+func (a *Clones) update(ctx context.Context) {
 	rows, err := a.fetchRows(ctx)
 	if err != nil {
 		slog.Error("Failed to refresh clones UI", "err", err)

--- a/internal/app/ui/contracts/contracts.go
+++ b/internal/app/ui/contracts/contracts.go
@@ -371,10 +371,14 @@ func newContracts(u baseUI, forCorporation bool) *Contracts {
 	}, a.u.MainWindow())
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+
 	if a.forCorporation {
 		a.u.Signals().CurrentCorporationExchanged.AddListener(func(ctx context.Context, c *app.Corporation) {
 			a.corporation.Store(c)
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 			if a.corporation.Load().IDOrZero() != arg.CorporationID {
@@ -383,22 +387,22 @@ func newContracts(u baseUI, forCorporation bool) *Contracts {
 			if arg.Section != app.SectionCorporationContracts {
 				return
 			}
-			a.Update(ctx)
+			a.update(ctx)
 		})
 	} else {
 		a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 			if arg.Section == app.SectionCharacterContracts {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 		a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 	}
 	return a
@@ -566,7 +570,7 @@ func (a *Contracts) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Contracts) Update(ctx context.Context) {
+func (a *Contracts) update(ctx context.Context) {
 	var activeCount int
 	var err error
 	var rows []contractRow

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -363,15 +363,6 @@ func newBaseUI(arg UIParams) *baseUI {
 			if arg.Changed.ContainsAny(corporationIDs.All()) {
 				updateStatus(ctx)
 			}
-		case app.SectionEveMarketPrices:
-			for _, c := range u.scs.ListCharacters() {
-				_, err := u.cs.UpdateAssetTotalValue(ctx, c.ID)
-				if err != nil {
-					slog.Error("Failed to update asset value", "characterID", c.ID)
-					continue
-				}
-			}
-			u.ReloadCurrentCharacter(ctx)
 		}
 	})
 

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/github"
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/janiceservice"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 	"github.com/ErikKalkoken/evebuddy/internal/xmaps"
 	"github.com/ErikKalkoken/evebuddy/internal/xsync"
@@ -100,7 +101,7 @@ type baseUI struct {
 	onShowCharacter                 func()
 	onSetCorporation                func(*app.Corporation)
 	onShowAndRun                    func()
-	onUpdateCorporationWalletTotals func(balance float64, ok bool)
+	onUpdateCorporationWalletTotals func(balance optional.Optional[float64])
 	onUpdateMissingScope            func(characterCount int)
 	onUpdateStatus                  func(ctx context.Context)
 	showMailIndicator               func()
@@ -858,28 +859,29 @@ func (u *baseUI) ListCorporationsForSelection(ctx context.Context) ([]*app.Entit
 }
 
 func (u *baseUI) updateCorporationWalletTotal(ctx context.Context) {
-	v, ok := func() (float64, bool) {
+	var v optional.Optional[float64]
+	func() {
 		corporationID := u.CurrentCorporation().IDOrZero()
 		if corporationID == 0 {
-			return 0, false
+			return
 		}
 		hasRole, err := u.rs.PermittedSection(ctx, corporationID, app.SectionCorporationWalletBalances)
 		if err != nil {
 			slog.Error("Failed to determine role for corporation wallet", "error", err)
-			return 0, false
+			return
 		}
 		if !hasRole {
-			return 0, false
+			return
 		}
 		b, err := u.rs.GetWalletBalancesTotal(ctx, corporationID)
 		if err != nil {
 			slog.Error("Failed to update wallet total", "corporationID", corporationID, "error", err)
-			return 0, false
+			return
 		}
-		return b.Value()
+		v = b
 	}()
 	fyne.Do(func() {
-		u.onUpdateCorporationWalletTotals(v, ok)
+		u.onUpdateCorporationWalletTotals(v)
 	})
 }
 

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -18,7 +18,6 @@ import (
 
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/ErikKalkoken/go-set"
 
@@ -482,16 +481,13 @@ func (u *baseUI) Start() bool {
 	go func() {
 		var wg sync.WaitGroup
 		wg.Go(func() {
-			u.initHome(ctx)
+			u.signals.AppInit.Emit(ctx, struct{}{})
 		})
 		wg.Go(func() {
 			u.initCharacter(ctx)
 		})
 		wg.Go(func() {
 			u.initCorporation(ctx)
-		})
-		wg.Go(func() {
-			u.gameSearch.Init(ctx)
 		})
 		wg.Wait()
 
@@ -821,40 +817,6 @@ func (u *baseUI) SetAnyCorporation(ctx context.Context) error {
 
 //////////////////
 // Home
-
-// initHome performs an initial load of all pages under the home tab.
-func (u *baseUI) initHome(ctx context.Context) {
-	ff := map[string]func(context.Context){
-		"characterOverview":  u.characterOverview.Update,
-		"assetSearchAll":     u.assetSearchAll.Update,
-		"augmentations":      u.augmentations.Update,
-		"contracts":          u.contracts.Update,
-		"clones":             u.clones.Update,
-		"colonies":           u.colonies.Update,
-		"industryJobs":       u.industryJobs.Update,
-		"loyaltyPoints":      u.loyaltyPoints.Update,
-		"marketOrdersSell":   u.marketOrdersSell.Update,
-		"marketOrdersBuy":    u.marketOrdersBuy.Update,
-		"slotsManufacturing": u.slotsManufacturing.Update,
-		"slotsReactions":     u.slotsReactions.Update,
-		"slotsResearch":      u.slotsResearch.Update,
-		"training":           u.training.Update,
-		"wealth":             u.wealth.Update,
-	}
-	myLog := slog.With("title", "startup")
-	myLog.Debug("started")
-	g := new(errgroup.Group)
-	g.SetLimit(u.concurrencyLimit)
-	for name, f := range ff {
-		g.Go(func() error {
-			start2 := time.Now()
-			f(ctx)
-			myLog.Debug("part completed", "name", name, "duration", time.Since(start2).Milliseconds())
-			return nil
-		})
-	}
-	g.Wait()
-}
 
 func (u *baseUI) SetColorTheme(s settings.ColorTheme) {
 	u.app.Settings().SetTheme(ui.New(u.defaultTheme, s))

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -374,7 +374,7 @@ func newBaseUI(arg UIParams) *baseUI {
 				return
 			}
 			for id := range characterIDs.All() {
-				if err := u.cs.UpdateTotalNetWorth(ctx, id); err != nil {
+				if err := u.cs.UpdateCalculatedValues(ctx, id); err != nil {
 					slog.Error("Failed to update total net worth", "arg", arg, "err", err)
 					return
 				}

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -350,8 +350,12 @@ func newBaseUI(arg UIParams) *baseUI {
 			if arg.Changed.Contains(u.character.Load().IDOrZero()) {
 				u.ReloadCurrentCharacter(ctx)
 			}
-			characters := u.scs.ListCharacterIDs()
-			if characters.ContainsAny(arg.Changed.All()) {
+			characterIDs, err := u.cs.ListCharacterIDs(ctx)
+			if err != nil {
+				slog.Error("Failed to update total net worth", "arg", arg, "err", err)
+				return
+			}
+			if characterIDs.ContainsAny(arg.Changed.All()) {
 				updateStatus(ctx)
 			}
 		case app.SectionEveCorporations:
@@ -362,6 +366,18 @@ func newBaseUI(arg UIParams) *baseUI {
 			}
 			if arg.Changed.ContainsAny(corporationIDs.All()) {
 				updateStatus(ctx)
+			}
+		case app.SectionEveMarketPrices:
+			characterIDs, err := u.cs.ListCharacterIDs(ctx)
+			if err != nil {
+				slog.Error("Failed to update total net worth", "arg", arg, "err", err)
+				return
+			}
+			for id := range characterIDs.All() {
+				if err := u.cs.UpdateTotalNetWorth(ctx, id); err != nil {
+					slog.Error("Failed to update total net worth", "arg", arg, "err", err)
+					return
+				}
 			}
 		}
 	})

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -95,6 +95,11 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		newContentPage("Wealth", u.wealth),
 	)
 
+	u.wealth.OnUpdate = func(balance optional.Optional[float64]) {
+		homeNav.SetItemBadge(wealth, formatISKValueShort(balance))
+		homeNav.Refresh()
+	}
+
 	const assetsTitle = "Assets"
 	allAssets := xwidget.NewNavPage(
 		assetsTitle,
@@ -282,10 +287,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 	)
 	characterNav.MinWidth = navDrawerMinWidth
 	u.characterWallet.OnBalanceUpdate = func(balance optional.Optional[float64]) {
-		s := balance.StringFunc("?", func(v float64) string {
-			return ihumanize.NumberF(v, 1)
-		})
-		characterNav.SetItemBadge(characterWalletNav, s)
+		characterNav.SetItemBadge(characterWalletNav, formatISKValueShort(balance))
 	}
 
 	// Corporation
@@ -376,24 +378,15 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 
 	for _, d := range app.Divisions {
 		u.corporationWallets[d].OnBalanceUpdate = func(balance optional.Optional[float64]) {
-			s := balance.StringFunc("?", func(v float64) string {
-				return ihumanize.NumberF(v, 1)
-			})
-			corporationNav.SetItemBadge(corporationWalletNavs[d], s)
+			corporationNav.SetItemBadge(corporationWalletNavs[d], formatISKValueShort(balance))
 		}
 		u.corporationWallets[d].NnNameUpdate = func(name string) {
 			corporationNav.SetItemText(corporationWalletNavs[d], name)
 			corporationWalletPages[d].SetTitle(name)
 		}
 	}
-	u.onUpdateCorporationWalletTotals = func(balance float64, ok bool) {
-		var s string
-		if !ok {
-			s = ""
-		} else {
-			s = ihumanize.NumberF(balance, 1)
-		}
-		corporationNav.SetItemBadge(walletsNav, s)
+	u.onUpdateCorporationWalletTotals = func(balance optional.Optional[float64]) {
+		corporationNav.SetItemBadge(walletsNav, formatISKValueShort(balance))
 		corporationNav.Refresh()
 	}
 
@@ -649,6 +642,14 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		}()
 	}
 	return u
+}
+
+func formatISKValueShort(value optional.Optional[float64]) string {
+	v, ok := value.Value()
+	if !ok {
+		return "?"
+	}
+	return ihumanize.NumberF(v, 1)
 }
 
 func (u *DesktopUI) saveAppState() {

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -722,36 +722,38 @@ func NewMobileUI(params UIParams) *MobileUI {
 		updateCharacterCount(ctx)
 		updateUpdateStatus(ctx)
 
-		tickerNewVersion := time.NewTicker(3600 * time.Second)
-		go func() {
-			for {
-				func() {
-					v, err := u.availableUpdate(ctx)
-					if err != nil {
-						slog.Error("fetch github version for menu info", "error", err)
-						return
-					}
-					if v.IsRemoteNewer {
-						hasUpdate.Store(true)
-						fyne.Do(func() {
-							refreshMoreBadge()
-							navItemAbout.Supporting = "Update available"
-							navItemAbout.Trailing = theme.NewPrimaryThemedResource(icons.Numeric1CircleSvg)
-							navItemAbout.Refresh()
-						})
-					} else {
-						hasUpdate.Store(false)
-						fyne.Do(func() {
-							refreshMoreBadge()
-							navItemAbout.Supporting = ""
-							navItemAbout.Trailing = nil
-							navItemAbout.Refresh()
-						})
-					}
-				}()
-				<-tickerNewVersion.C
-			}
-		}()
+		if !u.IsOffline() {
+			tickerNewVersion := time.NewTicker(3600 * time.Second)
+			go func() {
+				for {
+					func() {
+						v, err := u.availableUpdate(ctx)
+						if err != nil {
+							slog.Error("fetch github version for menu info", "error", err)
+							return
+						}
+						if v.IsRemoteNewer {
+							hasUpdate.Store(true)
+							fyne.Do(func() {
+								refreshMoreBadge()
+								navItemAbout.Supporting = "Update available"
+								navItemAbout.Trailing = theme.NewPrimaryThemedResource(icons.Numeric1CircleSvg)
+								navItemAbout.Refresh()
+							})
+						} else {
+							hasUpdate.Store(false)
+							fyne.Do(func() {
+								refreshMoreBadge()
+								navItemAbout.Supporting = ""
+								navItemAbout.Trailing = nil
+								navItemAbout.Refresh()
+							})
+						}
+					}()
+					<-tickerNewVersion.C
+				}
+			}()
+		}
 	}
 
 	u.onUpdateMissingScope = func(characterCount int) {

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -381,17 +381,8 @@ func NewMobileUI(params UIParams) *MobileUI {
 		corpStructuresNav.Supporting = badge
 		corpStructuresNav.Refresh()
 	}
-	u.onUpdateCorporationWalletTotals = func(balance float64, ok bool) {
-		var s string
-		if !ok {
-			s = ""
-		} else {
-			s = fmt.Sprintf("%s ISK", humanize.FormatFloat(ui.FloatFormat, balance))
-			if balance > 1000 {
-				s += fmt.Sprintf(" (%s)", ihumanize.NumberF(balance, 1))
-			}
-		}
-		corpWalletNav.Supporting = s
+	u.onUpdateCorporationWalletTotals = func(balance optional.Optional[float64]) {
+		corpWalletNav.Supporting = formatISKValueLong(balance, ui.FloatFormatISKRounded)
 		corpWalletNav.Refresh()
 	}
 
@@ -847,9 +838,8 @@ func makeHomeNav(u *MobileUI) *xwidget.Navigator {
 			homeNav.PushAndHideNavBar(xwidget.NewAppBar("Wealth", u.wealth))
 		},
 	)
-	u.wealth.OnUpdate = func(wallet, assets float64) {
-		s := fmt.Sprintf("Wallet: %s • Assets: %s", ihumanize.NumberF(wallet, 1), ihumanize.NumberF(assets, 1))
-		navItemWealth.Supporting = s
+	u.wealth.OnUpdate = func(total optional.Optional[float64]) {
+		navItemWealth.Supporting = formatISKValueLong(total, ui.FloatFormatISKRounded)
 		navItemWealth.Refresh()
 	}
 
@@ -927,4 +917,16 @@ func makeHomeNav(u *MobileUI) *xwidget.Navigator {
 
 	homeNav = xwidget.NewNavigator(xwidget.NewAppBar("Home", homeList))
 	return homeNav
+}
+
+func formatISKValueLong(value optional.Optional[float64], format string) string {
+	v, ok := value.Value()
+	if !ok {
+		return "? ISK"
+	}
+	s := fmt.Sprintf("%s ISK", humanize.FormatFloat(format, v))
+	if v > 1000 {
+		s += fmt.Sprintf(" (%s)", ihumanize.NumberF(v, 1))
+	}
+	return s
 }

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -844,9 +844,7 @@ func makeHomeNav(u *MobileUI) *xwidget.Navigator {
 		"Wealth",
 		theme.NewThemedResource(icons.GoldSvg),
 		func() {
-			w, _ := u.GetOrCreateWindow("overview-wealth", "Wealth")
-			w.SetContent(u.wealth)
-			w.Show()
+			homeNav.PushAndHideNavBar(xwidget.NewAppBar("Wealth", u.wealth))
 		},
 	)
 	u.wealth.OnUpdate = func(wallet, assets float64) {

--- a/internal/app/ui/core/statusbar.go
+++ b/internal/app/ui/core/statusbar.go
@@ -208,26 +208,28 @@ func (a *statusBar) start() {
 		a.updateEveStatus(ctx)
 	})
 
-	tickerNewVersion := time.NewTicker(versionTicker)
-	go func() {
-		for {
-			func() {
-				v, err := a.u.availableUpdate(ctx)
-				if err != nil {
-					slog.Error("fetch latest github version for download hint", "err", err)
-					return
-				}
-				if !v.IsRemoteNewer {
-					return
-				}
-				fyne.Do(func() {
-					a.updateHint.set(v)
-					a.updateHint.Show()
-				})
-			}()
-			<-tickerNewVersion.C
-		}
-	}()
+	if !a.u.IsOffline() {
+		tickerNewVersion := time.NewTicker(versionTicker)
+		go func() {
+			for {
+				func() {
+					v, err := a.u.availableUpdate(ctx)
+					if err != nil {
+						slog.Error("fetch latest github version for download hint", "err", err)
+						return
+					}
+					if !v.IsRemoteNewer {
+						return
+					}
+					fyne.Do(func() {
+						a.updateHint.set(v)
+						a.updateHint.Show()
+					})
+				}()
+				<-tickerNewVersion.C
+			}
+		}()
+	}
 }
 
 func (a *statusBar) updateEveStatus(ctx context.Context) {
@@ -235,6 +237,10 @@ func (a *statusBar) updateEveStatus(ctx context.Context) {
 		fyne.Do(func() {
 			a.setEveStatus(status, title, errorMessage)
 		})
+	}
+
+	if a.u.IsOffline() {
+		return
 	}
 
 	if a.u.ess.IsDailyDowntime() {

--- a/internal/app/ui/detailwindow.go
+++ b/internal/app/ui/detailwindow.go
@@ -86,7 +86,7 @@ func MakeDetailWindow(arg MakeDetailWindowParams) {
 
 // FormatISKAmount returns a formatted ISK amount.
 func FormatISKAmount(v float64) string {
-	t := humanize.FormatFloat(FloatFormat, v) + " ISK"
+	t := humanize.FormatFloat(FloatFormatISK, v) + " ISK"
 	if math.Abs(v) > 999 {
 		t += fmt.Sprintf(" (%s)", ihumanize.NumberF(v, 2))
 	}

--- a/internal/app/ui/eveentity.go
+++ b/internal/app/ui/eveentity.go
@@ -74,18 +74,34 @@ func (w *EveEntityListItem) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // Set updates the widget.
+//
+// If o.ID is zero it will render no icon and the name in bold style.
+// This can be used to show totals in tables.
 func (w *EveEntityListItem) Set(o *app.EveEntity) {
 	if w.IsAvatar {
 		w.icon.CornerRadius = w.IconUnitSize / 2
+	}
+	if o.ID == 0 {
+		w.icon.Resource = icons.BlankSvg
+		w.icon.Refresh()
+		w.name.Text = o.Name
+		w.name.TextStyle.Bold = true
+		w.name.Refresh()
+		return
 	}
 	w.loadIcon(o, w.IconPixelSize, func(r fyne.Resource) {
 		w.icon.Resource = r
 		w.icon.Refresh()
 	})
-	w.name.SetText(o.Name)
+	w.name.Text = o.Name
+	w.name.TextStyle.Bold = false
+	w.name.Refresh()
 }
 
 // Set2 updates the widget.
+//
+// If id is zero it will render no icon and the name in bold style.
+// This can be used to show totals in tables.
 func (w *EveEntityListItem) Set2(id int64, name string, category app.EveEntityCategory) {
 	w.Set(&app.EveEntity{
 		Category: category,

--- a/internal/app/ui/gamesearch/gamesearch.go
+++ b/internal/app/ui/gamesearch/gamesearch.go
@@ -161,10 +161,15 @@ func NewGameSearch(u baseUI) *GameSearch {
 		nil,
 		a.recent,
 	)
+
+	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.init(ctx)
+	})
 	return a
 }
 
-func (a *GameSearch) Init(ctx context.Context) {
+func (a *GameSearch) init(ctx context.Context) {
 	ids := a.u.Settings().RecentSearches()
 	if len(ids) == 0 {
 		return

--- a/internal/app/ui/industry/colonies.go
+++ b/internal/app/ui/industry/colonies.go
@@ -274,6 +274,10 @@ func NewColonies(u baseUI) *Colonies {
 	a.search.PlaceHolder = "Search systems & output"
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.Update(ctx)
+	})
+
 	a.u.Signals().RefreshTickerExpired.AddListener(func(_ context.Context, _ struct{}) {
 		fyne.Do(func() {
 			a.body.Refresh()

--- a/internal/app/ui/industry/job.go
+++ b/internal/app/ui/industry/job.go
@@ -335,39 +335,44 @@ func newIndustryJobs(u baseUI, forCorporation bool) *Jobs {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow(), 6, 7)
 
+	// signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+
 	if forCorporation {
 		a.u.Signals().CurrentCorporationExchanged.AddListener(func(ctx context.Context, c *app.Corporation) {
 			a.corporation.Store(c)
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 			if a.corporation.Load().IDOrZero() != arg.CorporationID {
 				return
 			}
 			if arg.Section == app.SectionCorporationIndustryJobs {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 	} else {
 		a.selectInstaller.Selected = industryInstallerMe
 		a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 			if arg.Section == app.SectionCharacterIndustryJobs {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 		a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 			if arg.Section == app.SectionCorporationIndustryJobs {
-				a.Update(ctx)
+				a.update(ctx)
 			}
 		})
 		a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 		a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-			a.Update(ctx)
+			a.update(ctx)
 		})
 	}
 	a.u.Signals().RefreshTickerExpired.AddListener(func(_ context.Context, _ struct{}) {
@@ -615,7 +620,7 @@ func (a *Jobs) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Jobs) Update(ctx context.Context) {
+func (a *Jobs) update(ctx context.Context) {
 	var jobs []industryJobRow
 	var err error
 	if a.forCorporation {

--- a/internal/app/ui/industry/job_internal_test.go
+++ b/internal/app/ui/industry/job_internal_test.go
@@ -43,7 +43,7 @@ func TestIndustryJob_Filter(t *testing.T) {
 		App:     test.NewTempApp(t),
 		Storage: st,
 	}))
-	a.Update(t.Context())
+	a.update(t.Context())
 
 	t.Run("no filter", func(t *testing.T) {
 		a.selectActivity.SetSelected("")
@@ -110,7 +110,7 @@ func TestIndustryJob_FetchJobs(t *testing.T) {
 			App:     test.NewTempApp(t),
 			Storage: st,
 		}))
-		a.Update(t.Context())
+		a.update(t.Context())
 		a.corporation.Store(corporation)
 		xx, err := a.fetchCombinedJobs(t.Context())
 		if !assert.NoError(t, err) {
@@ -129,7 +129,7 @@ func TestIndustryJob_FetchJobs(t *testing.T) {
 			Storage: st,
 		}))
 		a.corporation.Store(corporation)
-		a.Update(t.Context())
+		a.update(t.Context())
 
 		xx, err := a.fetchCorporationJobs(t.Context())
 		if !assert.NoError(t, err) {

--- a/internal/app/ui/industry/marketorders.go
+++ b/internal/app/ui/industry/marketorders.go
@@ -181,7 +181,7 @@ func NewMarketOrders(u baseUI, isBuyOrders bool) *MarketOrders {
 				return cmp.Compare(a.price, b.price)
 			},
 			Update: func(r marketOrderRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(humanize.FormatFloat(ui.FloatFormat, r.price), widget.RichTextStyle{
+				co.(*xwidget.RichText).SetWithText(humanize.FormatFloat(ui.FloatFormatISK, r.price), widget.RichTextStyle{
 					Alignment: fyne.TextAlignTrailing,
 				})
 			},

--- a/internal/app/ui/industry/marketorders.go
+++ b/internal/app/ui/industry/marketorders.go
@@ -278,20 +278,23 @@ func NewMarketOrders(u baseUI, isBuyOrders bool) *MarketOrders {
 	}, a.u.MainWindow())
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
 		case app.SectionCharacterMarketOrders:
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().RefreshTickerExpired.AddListener(func(_ context.Context, _ struct{}) {
 		fyne.Do(func() {
@@ -457,7 +460,7 @@ func (a *MarketOrders) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *MarketOrders) Update(ctx context.Context) {
+func (a *MarketOrders) update(ctx context.Context) {
 	rows, err := a.fetchRows(ctx, a.isBuyOrders)
 	if err != nil {
 		slog.Error("Failed to refresh locations UI", "err", err)

--- a/internal/app/ui/industry/marketorderwindow.go
+++ b/internal/app/ui/industry/marketorderwindow.go
@@ -74,7 +74,7 @@ func ShowMarketOrderWindow(u baseUI, r marketOrderRow) {
 		items = append(items, widget.NewFormItem(
 			"Escrow",
 			widget.NewLabel(r.escrow.StringFunc("-", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			})),
 		))
 	}

--- a/internal/app/ui/industry/slot.go
+++ b/internal/app/ui/industry/slot.go
@@ -35,12 +35,12 @@ type industrySlotRow struct {
 	ready         int
 	free          int
 	total         int
-	isSummary     bool
+	isTotal       bool
 	tags          set.Set[string]
 }
 
 func (r industrySlotRow) characterDisplay() []widget.RichTextSegment {
-	if r.isSummary {
+	if r.isTotal {
 		return xwidget.RichTextSegmentsFromText("Totals", widget.RichTextStyle{
 			TextStyle: fyne.TextStyle{Bold: true},
 		})
@@ -133,7 +133,7 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 			border := co.(*fyne.Container).Objects
 			label := border[0].(*widget.Label)
 			icon := border[1].(*canvas.Image)
-			if r.isSummary {
+			if r.isTotal {
 				label.Text = "Total"
 				label.TextStyle = fyne.TextStyle{Bold: true}
 				label.Refresh()
@@ -160,7 +160,7 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.busy), widget.RichTextStyle{
 				Alignment: fyne.TextAlignTrailing,
 				ColorName: r.busyColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isSummary},
+				TextStyle: fyne.TextStyle{Bold: r.isTotal},
 			})
 		},
 	}, {
@@ -174,7 +174,7 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.ready), widget.RichTextStyle{
 				Alignment: fyne.TextAlignTrailing,
 				ColorName: r.readyColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isSummary},
+				TextStyle: fyne.TextStyle{Bold: r.isTotal},
 			})
 		},
 	}, {
@@ -188,7 +188,7 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.free), widget.RichTextStyle{
 				Alignment: fyne.TextAlignTrailing,
 				ColorName: r.freeColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isSummary},
+				TextStyle: fyne.TextStyle{Bold: r.isTotal},
 			})
 		},
 	}, {
@@ -201,7 +201,7 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 		Update: func(r industrySlotRow, co fyne.CanvasObject) {
 			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.total), widget.RichTextStyle{
 				Alignment: fyne.TextAlignTrailing,
-				TextStyle: fyne.TextStyle{Bold: r.isSummary},
+				TextStyle: fyne.TextStyle{Bold: r.isTotal},
 			})
 		},
 	}})
@@ -236,24 +236,24 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 					return xwidget.RichTextSegmentsFromText(fmt.Sprint(r.busy), widget.RichTextStyle{
 						Alignment: fyne.TextAlignTrailing,
 						ColorName: r.busyColor(),
-						TextStyle: fyne.TextStyle{Bold: r.isSummary},
+						TextStyle: fyne.TextStyle{Bold: r.isTotal},
 					})
 				case industrySlotsColReady:
 					return xwidget.RichTextSegmentsFromText(fmt.Sprint(r.ready), widget.RichTextStyle{
 						Alignment: fyne.TextAlignTrailing,
 						ColorName: r.readyColor(),
-						TextStyle: fyne.TextStyle{Bold: r.isSummary},
+						TextStyle: fyne.TextStyle{Bold: r.isTotal},
 					})
 				case industrySlotsColFree:
 					return xwidget.RichTextSegmentsFromText(fmt.Sprint(r.free), widget.RichTextStyle{
 						Alignment: fyne.TextAlignTrailing,
 						ColorName: r.freeColor(),
-						TextStyle: fyne.TextStyle{Bold: r.isSummary},
+						TextStyle: fyne.TextStyle{Bold: r.isTotal},
 					})
 				case industrySlotsColTotal:
 					return xwidget.RichTextSegmentsFromText(fmt.Sprint(r.total), widget.RichTextStyle{
 						Alignment: fyne.TextAlignTrailing,
-						TextStyle: fyne.TextStyle{Bold: r.isSummary},
+						TextStyle: fyne.TextStyle{Bold: r.isTotal},
 					})
 				}
 				return xwidget.RichTextSegmentsFromText("?")
@@ -385,11 +385,11 @@ func (a *Slots) filterRowsAsync(sortCol int) {
 			total += r.total
 		}
 		rows = append(rows, industrySlotRow{
-			busy:      active,
-			ready:     ready,
-			free:      free,
-			total:     total,
-			isSummary: true,
+			busy:    active,
+			ready:   ready,
+			free:    free,
+			total:   total,
+			isTotal: true,
 		})
 
 		tagOptions := slices.Sorted(set.Union(xslices.Map(rows, func(r industrySlotRow) set.Set[string] {

--- a/internal/app/ui/industry/slot.go
+++ b/internal/app/ui/industry/slot.go
@@ -247,25 +247,29 @@ func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow())
 
+	// signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
 		case app.SectionCharacterIndustryJobs, app.SectionCharacterSkills:
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CorporationSectionChanged.AddListener(func(ctx context.Context, arg app.CorporationSectionUpdated) {
 		if arg.Section == app.SectionCorporationIndustryJobs {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -381,7 +385,7 @@ func (a *Slots) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Slots) Update(ctx context.Context) {
+func (a *Slots) update(ctx context.Context) {
 	rows, err := a.fetchData(ctx, a.slotType)
 	if err != nil {
 		slog.Error("Failed to refresh industrySlots UI", "err", err)

--- a/internal/app/ui/industry/slot.go
+++ b/internal/app/ui/industry/slot.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -17,9 +16,7 @@ import (
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
-	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
-	"github.com/ErikKalkoken/evebuddy/internal/xstrings"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
@@ -112,99 +109,75 @@ const (
 
 func NewSlots(u baseUI, slotType app.IndustryJobType) *Slots {
 	const columnWidthNumber = 75
-	columns := xwidget.NewDataColumns([]xwidget.DataColumn[industrySlotRow]{{
-		ID:    industrySlotsColCharacter,
-		Label: "Character",
-		Width: ui.ColumnWidthEntity,
-		Sort: func(a, b industrySlotRow) int {
-			return xstrings.CompareIgnoreCase(a.characterName, b.characterName)
-		},
-		Create: func() fyne.CanvasObject {
-			icon := xwidget.NewImageFromResource(
-				icons.Characterplaceholder64Jpeg,
-				fyne.NewSquareSize(ui.IconUnitSize),
-			)
-			icon.CornerRadius = ui.IconUnitSize / 2
-			name := widget.NewLabel("Template")
-			name.Truncation = fyne.TextTruncateClip
-			return container.NewBorder(nil, nil, icon, nil, name)
-		},
-		Update: func(r industrySlotRow, co fyne.CanvasObject) {
-			border := co.(*fyne.Container).Objects
-			label := border[0].(*widget.Label)
-			icon := border[1].(*canvas.Image)
-			if r.isTotal {
-				label.Text = "Total"
-				label.TextStyle = fyne.TextStyle{Bold: true}
-				label.Refresh()
-				icon.Resource = icons.BlankSvg
-				icon.Refresh()
-			} else {
-				label.Text = r.characterName
-				label.TextStyle = fyne.TextStyle{}
-				label.Refresh()
-				u.EVEImage().CharacterPortraitAsync(r.characterID, ui.IconPixelSize, func(r fyne.Resource) {
-					icon.Resource = r
-					icon.Refresh()
+	columns := xwidget.NewDataColumns([]xwidget.DataColumn[industrySlotRow]{
+		ui.MakeEveEntityColumn(ui.MakeEveEntityColumnParams[industrySlotRow]{
+			ColumnID: industrySlotsColCharacter,
+			EIS:      u.EVEImage(),
+			GetEntity: func(r industrySlotRow) *app.EveEntity {
+				return &app.EveEntity{
+					ID:       r.characterID,
+					Name:     r.characterName,
+					Category: app.EveEntityCharacter,
+				}
+			},
+			IsAvatar: true,
+			Label:    "Character",
+		}), {
+			ID:    industrySlotsColBusy,
+			Label: "Busy",
+			Width: columnWidthNumber,
+			Sort: func(a, b industrySlotRow) int {
+				return cmp.Compare(a.busy, b.busy)
+			},
+			Update: func(r industrySlotRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.busy), widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					ColorName: r.busyColor(),
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
 				})
-			}
-		},
-	}, {
-		ID:    industrySlotsColBusy,
-		Label: "Busy",
-		Width: columnWidthNumber,
-		Sort: func(a, b industrySlotRow) int {
-			return cmp.Compare(a.busy, b.busy)
-		},
-		Update: func(r industrySlotRow, co fyne.CanvasObject) {
-			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.busy), widget.RichTextStyle{
-				Alignment: fyne.TextAlignTrailing,
-				ColorName: r.busyColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isTotal},
-			})
-		},
-	}, {
-		ID:    industrySlotsColReady,
-		Label: "Ready",
-		Width: columnWidthNumber,
-		Sort: func(a, b industrySlotRow) int {
-			return cmp.Compare(a.ready, b.ready)
-		},
-		Update: func(r industrySlotRow, co fyne.CanvasObject) {
-			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.ready), widget.RichTextStyle{
-				Alignment: fyne.TextAlignTrailing,
-				ColorName: r.readyColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isTotal},
-			})
-		},
-	}, {
-		ID:    industrySlotsColFree,
-		Label: "Free",
-		Width: columnWidthNumber,
-		Sort: func(a, b industrySlotRow) int {
-			return cmp.Compare(a.free, b.free)
-		},
-		Update: func(r industrySlotRow, co fyne.CanvasObject) {
-			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.free), widget.RichTextStyle{
-				Alignment: fyne.TextAlignTrailing,
-				ColorName: r.freeColor(),
-				TextStyle: fyne.TextStyle{Bold: r.isTotal},
-			})
-		},
-	}, {
-		ID:    industrySlotsColTotal,
-		Label: "Total",
-		Width: columnWidthNumber,
-		Sort: func(a, b industrySlotRow) int {
-			return cmp.Compare(a.total, b.total)
-		},
-		Update: func(r industrySlotRow, co fyne.CanvasObject) {
-			co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.total), widget.RichTextStyle{
-				Alignment: fyne.TextAlignTrailing,
-				TextStyle: fyne.TextStyle{Bold: r.isTotal},
-			})
-		},
-	}})
+			},
+		}, {
+			ID:    industrySlotsColReady,
+			Label: "Ready",
+			Width: columnWidthNumber,
+			Sort: func(a, b industrySlotRow) int {
+				return cmp.Compare(a.ready, b.ready)
+			},
+			Update: func(r industrySlotRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.ready), widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					ColorName: r.readyColor(),
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+		}, {
+			ID:    industrySlotsColFree,
+			Label: "Free",
+			Width: columnWidthNumber,
+			Sort: func(a, b industrySlotRow) int {
+				return cmp.Compare(a.free, b.free)
+			},
+			Update: func(r industrySlotRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.free), widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					ColorName: r.freeColor(),
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+		}, {
+			ID:    industrySlotsColTotal,
+			Label: "Total",
+			Width: columnWidthNumber,
+			Sort: func(a, b industrySlotRow) int {
+				return cmp.Compare(a.total, b.total)
+			},
+			Update: func(r industrySlotRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(fmt.Sprint(r.total), widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+		}})
 	a := &Slots{
 		footer:       ui.NewLabelWithWrapping(""),
 		columnSorter: xwidget.NewColumnSorter(columns, industrySlotsColCharacter, xwidget.SortAsc),
@@ -377,19 +350,20 @@ func (a *Slots) filterRowsAsync(sortCol int) {
 
 		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
 		// add totals
-		var active, ready, free, total int
+		var busy, ready, free, total int
 		for _, r := range rows {
-			active += r.busy
+			busy += r.busy
 			ready += r.ready
 			free += r.free
 			total += r.total
 		}
 		rows = append(rows, industrySlotRow{
-			busy:    active,
-			ready:   ready,
-			free:    free,
-			total:   total,
-			isTotal: true,
+			busy:          busy,
+			characterName: "Total",
+			free:          free,
+			isTotal:       true,
+			ready:         ready,
+			total:         total,
 		})
 
 		tagOptions := slices.Sorted(set.Union(xslices.Map(rows, func(r industrySlotRow) set.Set[string] {

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -389,7 +389,7 @@ func (a *Catalogue) update(ctx context.Context) {
 		})
 	}
 
-	totalSP := optional.Sum(c.TrainedSP, c.UnallocatedSP)
+	totalSP := optional.SumNonEmpty(c.TrainedSP, c.UnallocatedSP)
 	top := fmt.Sprintf("%s Total SP (%s Unallocated)",
 		totalSP.StringFunc("?", func(v int64) string {
 			return ihumanize.Comma(v)

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -302,6 +302,9 @@ func NewTraining(u baseUI) *Training {
 	}, a.u.MainWindow())
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
 		case app.SectionCharacterSkills, app.SectionCharacterSkillqueue:
@@ -309,13 +312,13 @@ func NewTraining(u baseUI) *Training {
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterChanged.AddListener(func(ctx context.Context, characterID int64) {
 		a.updateItem(ctx, characterID)
@@ -489,7 +492,7 @@ func (a *Training) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Training) Update(ctx context.Context) {
+func (a *Training) update(ctx context.Context) {
 	rows, err := a.fetchRows(ctx)
 	if err != nil {
 		slog.Error("Failed to refresh training UI", "err", err)

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -591,7 +591,7 @@ func (a *Training) fetchRow(ctx context.Context, c *app.Character) (trainingRow,
 		unallocatedSPDisplay: c.UnallocatedSP.StringFunc("?", func(v int64) string {
 			return humanize.Comma(v)
 		}),
-		totalSP: optional.Sum(c.TrainedSP, c.UnallocatedSP),
+		totalSP: optional.SumNonEmpty(c.TrainedSP, c.UnallocatedSP),
 	}
 	r.totalSPDisplay = r.totalSP.StringFunc("?", func(v int64) string {
 		return humanize.Comma(v)

--- a/internal/app/ui/skills/training_internal_test.go
+++ b/internal/app/ui/skills/training_internal_test.go
@@ -60,7 +60,7 @@ func TestTraining_Filter(t *testing.T) {
 		App:     test.NewTempApp(t),
 		Storage: st,
 	}))
-	a.Update(t.Context())
+	a.update(t.Context())
 
 	t.Run("no filter", func(t *testing.T) {
 		a.selectStatus.SetSelected("")

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -20,10 +20,11 @@ const (
 
 // Global UI constants
 const (
-	IconPixelSize      = 64
-	IconUnitSize       = 28
-	FloatFormat        = "#,###.##"
-	fallbackWebsiteURL = "https://github.com/ErikKalkoken/evebuddy"
+	IconPixelSize         = 64
+	IconUnitSize          = 28
+	FloatFormatISK        = "#,###.##"
+	FloatFormatISKRounded = "#,###."
+	fallbackWebsiteURL    = "https://github.com/ErikKalkoken/evebuddy"
 )
 
 // See also related Fyne issue: https://github.com/fyne-io/fyne/issues/5847

--- a/internal/app/ui/wallets/characterwallet.go
+++ b/internal/app/ui/wallets/characterwallet.go
@@ -146,7 +146,7 @@ func (a *CharacterWallet) UpdateBalance(ctx context.Context) {
 		return
 	}
 
-	s := fmt.Sprintf("%s ISK", humanize.FormatFloat(ui.FloatFormat, balance))
+	s := fmt.Sprintf("%s ISK", humanize.FormatFloat(ui.FloatFormatISK, balance))
 	if balance > 1000 {
 		s += fmt.Sprintf(" (%s)", ihumanize.NumberF(balance, 1))
 	}

--- a/internal/app/ui/wallets/corporationwallet.go
+++ b/internal/app/ui/wallets/corporationwallet.go
@@ -143,7 +143,7 @@ func (a *CorporationWallet) updateBalance(ctx context.Context) {
 		setBalance("Error: "+a.u.ErrorDisplay(err), widget.DangerImportance)
 		return
 	}
-	s := fmt.Sprintf("%s ISK", humanize.FormatFloat(ui.FloatFormat, balance))
+	s := fmt.Sprintf("%s ISK", humanize.FormatFloat(ui.FloatFormatISK, balance))
 	if balance > 1000 {
 		s += fmt.Sprintf(" (%s)", ihumanize.NumberF(balance, 1))
 	}

--- a/internal/app/ui/wallets/loyaltypoints.go
+++ b/internal/app/ui/wallets/loyaltypoints.go
@@ -118,19 +118,23 @@ func NewLoyaltyPoints(u baseUI) *LoyaltyPoints {
 	})
 
 	// signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		if arg.Section == app.SectionCharacterLoyaltyPoints {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -275,7 +279,7 @@ func (a *LoyaltyPoints) filterTreeAsync() {
 	}()
 }
 
-func (a *LoyaltyPoints) Update(ctx context.Context) {
+func (a *LoyaltyPoints) update(ctx context.Context) {
 	data, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to refresh loyaltyPoints UI", "err", err)

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -1,0 +1,336 @@
+package wallets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
+	"github.com/ErikKalkoken/go-set"
+	"github.com/dustin/go-humanize"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/ErikKalkoken/evebuddy/internal/xslices"
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+type overviewRow struct {
+	assets        optional.Optional[float64]
+	assetsDisplay string
+	characterID   int64
+	characterName string
+	tags          set.Set[string]
+	total         optional.Optional[float64]
+	totalDisplay  string
+	wallet        optional.Optional[float64]
+	walletDisplay string
+	searchTarget  string
+	isTotal       bool
+}
+
+type Overview struct {
+	widget.BaseWidget
+
+	OnUpdate func(expired int)
+
+	footer       *widget.Label
+	columnSorter *xwidget.ColumnSorter[overviewRow]
+	main         fyne.CanvasObject
+	rows         []overviewRow
+	rowsFiltered []overviewRow
+	search       *widget.Entry
+	selectTag    *kxwidget.FilterChipSelect
+	sortButton   *xwidget.SortButton
+	u            baseUI
+}
+
+const (
+	overviewColCharacter = iota + 1
+	overviewColTags
+	overviewColAssets
+	overviewColWallet
+	overviewColTotal
+)
+
+const valueWidth = 150
+
+func NewOverview(u baseUI) *Overview {
+	columns := xwidget.NewDataColumns([]xwidget.DataColumn[overviewRow]{
+		ui.MakeEveEntityColumn(ui.MakeEveEntityColumnParams[overviewRow]{
+			ColumnID: overviewColCharacter,
+			EIS:      u.EVEImage(),
+			GetEntity: func(r overviewRow) *app.EveEntity {
+				return &app.EveEntity{
+					ID:       r.characterID,
+					Name:     r.characterName,
+					Category: app.EveEntityCharacter,
+				}
+			},
+			IsAvatar: true,
+			Label:    "Character",
+		}), {
+			ID:    overviewColTags,
+			Label: "Tags",
+			Width: 150,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				s := strings.Join(slices.Sorted(r.tags.All()), ", ")
+				co.(*xwidget.RichText).SetWithText(s)
+			},
+		}, {
+			ID:    overviewColAssets,
+			Label: "Assets",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.assetsDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.assets, b.assets)
+			},
+		}, {
+			ID:    overviewColWallet,
+			Label: "Wallet",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.walletDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.wallet, b.wallet)
+			},
+		}, {
+			ID:    overviewColTotal,
+			Label: "Total",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.totalDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.total, b.total)
+			},
+		}})
+	a := &Overview{
+		columnSorter: xwidget.NewColumnSorter(columns, overviewColCharacter, xwidget.SortAsc),
+		footer:       widget.NewLabel(""),
+		search:       widget.NewEntry(),
+		u:            u,
+	}
+	a.ExtendBaseWidget(a)
+	a.search.ActionItem = kxwidget.NewIconButton(theme.CancelIcon(), func() {
+		a.search.SetText("")
+		a.filterRowsAsync(-1)
+	})
+	a.search.OnChanged = func(_ string) {
+		a.filterRowsAsync(-1)
+	}
+	a.search.PlaceHolder = "Search characters"
+	if a.u.IsMobile() {
+		a.main = xwidget.MakeDataList(
+			columns,
+			&a.rowsFiltered,
+			func(col int, r overviewRow) []widget.RichTextSegment {
+				var s []widget.RichTextSegment
+				// switch col {
+				// case overviewColCharacter:
+				// 	s = r.jc.Location.DisplayRichText()
+				// case clonesColT:
+				// 	s = xwidget.RichTextSegmentsFromText(r.jc.Location.RegionName())
+				// case clonesColImplants:
+				// 	s = xwidget.RichTextSegmentsFromText(fmt.Sprint(r.jc.ImplantsCount))
+				// case clonesColCharacter:
+				// 	s = xwidget.RichTextSegmentsFromText(r.jc.Character.Name)
+				// case clonesColJumps:
+				// 	s = xwidget.RichTextSegmentsFromText(r.jumps())
+				// }
+				return s
+			},
+			nil,
+		)
+	} else {
+		a.main = xwidget.MakeDataTable(
+			columns,
+			&a.rowsFiltered,
+			func() fyne.CanvasObject {
+				x := xwidget.NewRichText()
+				x.Truncation = fyne.TextTruncateClip
+				return x
+			},
+			a.columnSorter,
+			a.filterRowsAsync,
+			nil,
+		)
+	}
+	a.selectTag = kxwidget.NewFilterChipSelect("Tag", []string{}, func(string) {
+		a.filterRowsAsync(-1)
+	})
+	a.sortButton = a.columnSorter.NewSortButton(func() {
+		a.filterRowsAsync(-1)
+	}, a.u.MainWindow())
+
+	// Signals
+	// a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
+	// 	switch arg.Section {
+	// 	case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
+	// 		a.Update(ctx)
+	// 	}
+	// })
+	// a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
+	// 	a.Update(ctx)
+	// })
+	// a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
+	// 	a.Update(ctx)
+	// })
+	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
+		a.Update(ctx)
+	})
+	a.u.Signals().CharacterChanged.AddListener(func(ctx context.Context, characterID int64) {
+		a.Update(ctx)
+	})
+	return a
+}
+
+func (a *Overview) CreateRenderer() fyne.WidgetRenderer {
+	filter := container.NewHBox(a.selectTag)
+	if a.u.IsMobile() {
+		filter.Add(a.sortButton)
+	}
+	var topBox *fyne.Container
+	if a.u.IsMobile() {
+		topBox = container.NewVBox(
+			a.search,
+			container.NewHScroll(filter),
+		)
+	} else {
+		topBox = container.NewBorder(nil, nil, filter, nil, a.search)
+	}
+	c := container.NewBorder(
+		topBox,
+		a.footer,
+		nil,
+		nil,
+		a.main,
+	)
+	return widget.NewSimpleRenderer(c)
+}
+
+func (a *Overview) filterRowsAsync(sortCol int) {
+	totalRows := len(a.rows)
+	rows := slices.Clone(a.rows)
+	selectTag := a.selectTag.Selected
+	search := strings.ToLower(a.search.Text)
+	sortCol, dir, doSort := a.columnSorter.CalcSort(sortCol)
+
+	go func() {
+		if selectTag != "" {
+			rows = slices.DeleteFunc(rows, func(r overviewRow) bool {
+				return !r.tags.Contains(selectTag)
+			})
+		}
+		if len(search) > 1 {
+			rows = slices.DeleteFunc(rows, func(r overviewRow) bool {
+				return !strings.Contains(r.searchTarget, search)
+			})
+		}
+		a.columnSorter.SortRows(rows, sortCol, dir, doSort)
+		tagOptions := slices.Sorted(set.Union(xslices.Map(rows, func(r overviewRow) set.Set[string] {
+			return r.tags
+		})...).All())
+
+		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
+
+		// add totals
+		var assets, wallets, totals optional.Optional[float64]
+		for _, r := range rows {
+			assets = optional.Sum(assets, r.assets)
+			wallets = optional.Sum(wallets, r.wallet)
+			totals = optional.Sum(totals, r.total)
+		}
+		rows = append(rows, overviewRow{
+			assets:        assets,
+			assetsDisplay: formatISKValue(assets),
+			characterID:   0,
+			characterName: "Total",
+			tags:          set.Set[string]{},
+			total:         totals,
+			totalDisplay:  formatISKValue(totals),
+			wallet:        wallets,
+			walletDisplay: formatISKValue(totals),
+			searchTarget:  "",
+			isTotal:       true,
+		})
+
+		fyne.Do(func() {
+			a.footer.Text = footer
+			a.footer.Importance = widget.MediumImportance
+			a.footer.Refresh()
+			a.selectTag.SetOptions(tagOptions)
+			a.rowsFiltered = rows
+			a.main.Refresh()
+		})
+	}()
+}
+
+func (a *Overview) Update(ctx context.Context) {
+	rows, err := a.fetchRows(ctx)
+	if err != nil {
+		slog.Error("Failed to refresh wealth overview UI", "err", err)
+		fyne.Do(func() {
+			a.footer.Text = "ERROR: " + a.u.ErrorDisplay(err)
+			a.footer.Importance = widget.DangerImportance
+			a.footer.Refresh()
+		})
+		return
+	}
+	fyne.Do(func() {
+		a.rows = rows
+		a.filterRowsAsync(-1)
+	})
+}
+
+func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
+	characters, err := a.u.Character().CharacterNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	oo, err := a.u.Character().ListWealthValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var rows []overviewRow
+	for _, o := range oo {
+		rows = append(rows, overviewRow{
+			assets:        o.Assets,
+			assetsDisplay: formatISKValue(o.Assets),
+			characterID:   o.CharacterID,
+			characterName: characters[o.CharacterID],
+			searchTarget:  strings.ToLower(characters[o.CharacterID]),
+			tags:          set.Set[string]{},
+			total:         o.Total,
+			totalDisplay:  formatISKValue(o.Total),
+			wallet:        o.Wallet,
+			walletDisplay: formatISKValue(o.Wallet),
+		})
+	}
+	return rows, nil
+}
+
+func formatISKValue(v optional.Optional[float64]) string {
+	return v.StringFunc("?", func(v float64) string {
+		return humanize.FormatFloat(ui.FloatFormat, v)
+	})
+}

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -9,6 +9,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -34,6 +35,7 @@ type overviewRow struct {
 	ordersEscrowDisplay    string
 	searchTarget           string
 	tags                   set.Set[string]
+	tagsDisplay            string
 	total                  optional.Optional[float64]
 	totalDisplay           string
 	walletBalance          optional.Optional[float64]
@@ -62,6 +64,7 @@ type Overview struct {
 	selectTag    *kxwidget.FilterChipSelect
 	sortButton   *xwidget.SortButton
 	u            baseUI
+	showHelp     *xwidget.TappableIcon
 }
 
 const (
@@ -75,6 +78,16 @@ const (
 )
 
 const valueWidth = 125
+
+const helpText = `Wallet Balance: The balance of the wallet.
+
+Combined Assets: The estimated value of all personal assets, items in outstanding sell orders on the market and items in outstanding contracts.
+
+Contract Escrow: The total sum of all escrows in a character's currently outstanding contracts.
+
+Orders Escrow: The total sum of all escrows in a character's currently outstanding buy orders on the market.
+
+Not included: Blueprints, PLEX in the account wallet`
 
 func NewOverview(u baseUI) *Overview {
 	columns := xwidget.NewDataColumns([]xwidget.DataColumn[overviewRow]{
@@ -95,8 +108,7 @@ func NewOverview(u baseUI) *Overview {
 			Label: "Tags",
 			Width: 150,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
-				s := strings.Join(slices.Sorted(r.tags.All()), ", ")
-				co.(*xwidget.RichText).SetWithText(s)
+				co.(*xwidget.RichText).SetWithText(r.tagsDisplay)
 			},
 		}, {
 			ID:    overviewColWalletBalance,
@@ -181,24 +193,71 @@ func NewOverview(u baseUI) *Overview {
 		a.filterRowsAsync(-1)
 	}
 	a.search.PlaceHolder = "Search characters"
+
+	a.showHelp = xwidget.NewTappableIcon(theme.QuestionIcon(), func() {
+		var pu *widget.PopUp
+		closePopUp := widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
+			pu.Hide()
+		})
+		title := widget.NewLabel("Help")
+		title.TextStyle.Bold = true
+		text := widget.NewLabel(helpText)
+		text.Wrapping = fyne.TextWrapWord
+
+		p := theme.Padding()
+		canvas := fyne.CurrentApp().Driver().CanvasForObject(a.showHelp)
+		var spacerSize fyne.Size
+		if a.u.IsMobile() {
+			_, s := canvas.InteractiveArea()
+			spacerSize = fyne.NewSize(s.Width-4*p, s.Height/2)
+		} else {
+			spacerSize = fyne.NewSize(300, 400)
+		}
+		spacer := xwidget.NewSpacer(spacerSize)
+		c := container.NewStack(spacer, container.NewBorder(
+			container.NewHBox(title, layout.NewSpacer(), closePopUp),
+			nil,
+			nil,
+			nil,
+			container.NewVScroll(container.NewPadded(text)),
+		))
+		pu = widget.NewPopUp(c, canvas)
+
+		if a.u.IsMobile() {
+			x := a.showHelp.MinSize().Width - pu.MinSize().Width
+			y := a.showHelp.MinSize().Height - pu.MinSize().Height
+			pu.ShowAtRelativePosition(fyne.NewPos(x, y), a.showHelp)
+		} else {
+			pos, s := canvas.InteractiveArea()
+			x := pos.X
+			y := pos.Y + s.Height/2
+			pu.ShowAtPosition(fyne.NewPos(x, y))
+		}
+	})
+	a.showHelp.SetToolTip("Shows help for this screen")
+
 	if a.u.IsMobile() {
 		a.main = xwidget.MakeDataList(
 			columns,
 			&a.rowsFiltered,
 			func(col int, r overviewRow) []widget.RichTextSegment {
 				var s []widget.RichTextSegment
-				// switch col {
-				// case overviewColCharacter:
-				// 	s = r.jc.Location.DisplayRichText()
-				// case clonesColT:
-				// 	s = xwidget.RichTextSegmentsFromText(r.jc.Location.RegionName())
-				// case clonesColImplants:
-				// 	s = xwidget.RichTextSegmentsFromText(fmt.Sprint(r.jc.ImplantsCount))
-				// case clonesColCharacter:
-				// 	s = xwidget.RichTextSegmentsFromText(r.jc.Character.Name)
-				// case clonesColJumps:
-				// 	s = xwidget.RichTextSegmentsFromText(r.jumps())
-				// }
+				switch col {
+				case overviewColCharacter:
+					s = xwidget.RichTextSegmentsFromText(r.characterName)
+				case overviewColTags:
+					s = xwidget.RichTextSegmentsFromText(r.tagsDisplay)
+				case overviewColWalletBalance:
+					s = xwidget.RichTextSegmentsFromText(r.walletDisplay)
+				case overviewColCombinedAssetsValue:
+					s = xwidget.RichTextSegmentsFromText(r.combinedAssetsDisplay)
+				case overviewColContractsEscrow:
+					s = xwidget.RichTextSegmentsFromText(r.contractsEscrowDisplay)
+				case overviewColOrdersEscrow:
+					s = xwidget.RichTextSegmentsFromText(r.ordersEscrowDisplay)
+				case overviewColTotal:
+					s = xwidget.RichTextSegmentsFromText(r.totalDisplay)
+				}
 				return s
 			},
 			nil,
@@ -273,7 +332,7 @@ func (a *Overview) CreateRenderer() fyne.WidgetRenderer {
 	}
 	c := container.NewBorder(
 		topBox,
-		a.footer,
+		container.NewHBox(a.footer, layout.NewSpacer(), a.showHelp),
 		nil,
 		nil,
 		a.main,
@@ -390,6 +449,7 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 			ordersEscrowDisplay:    formatISKValue(o.OrdersEscrow),
 			searchTarget:           strings.ToLower(o.EveCharacter.Name),
 			tags:                   tags,
+			tagsDisplay:            strings.Join(slices.Sorted(tags.All()), ", "),
 			total:                  total,
 			totalDisplay:           formatISKValue(total),
 			walletBalance:          o.WalletBalance,

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -22,9 +22,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
-// TODOs
-// - add all variants for calculating contract escrow
-
 type overviewRow struct {
 	characterID            int64
 	characterName          string
@@ -252,8 +249,10 @@ func NewOverview(u baseUI) *Overview {
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
 		a.update(ctx)
 	})
-	a.u.Signals().CharacterChanged.AddListener(func(ctx context.Context, characterID int64) {
-		a.update(ctx)
+	a.u.Signals().EveUniverseSectionChanged.AddListener(func(ctx context.Context, arg app.EveUniverseSectionUpdated) {
+		if arg.Section == app.SectionEveMarketPrices {
+			a.update(ctx)
+		}
 	})
 	return a
 }
@@ -308,30 +307,35 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
 
 		// add totals
-		var assetsValue, walletBalance, totals, contractEscrow, marketEscrow optional.Optional[float64]
+		var assets, wallets, totals, contracts, orders []optional.Optional[float64]
 		for _, r := range rows {
-			assetsValue = optional.SumNonEmpty(assetsValue, r.combinedAssetsValue)
-			walletBalance = optional.SumNonEmpty(walletBalance, r.walletBalance)
-			contractEscrow = optional.SumNonEmpty(contractEscrow, r.contractsEscrow)
-			marketEscrow = optional.SumNonEmpty(marketEscrow, r.ordersEscrow)
-			totals = optional.SumNonEmpty(totals, r.total)
+			assets = append(assets, r.combinedAssetsValue)
+			contracts = append(contracts, r.contractsEscrow)
+			orders = append(orders, r.ordersEscrow)
+			totals = append(totals, r.total)
+			wallets = append(wallets, r.walletBalance)
 		}
+		assetsTotal := optional.Sum(assets...)
+		contractsTotal := optional.Sum(contracts...)
+		grandTotal := optional.Sum(totals...)
+		ordersTotal := optional.Sum(orders...)
+		walletsTotal := optional.Sum(wallets...)
 		rows = append(rows, overviewRow{
-			combinedAssetsValue:    assetsValue,
-			combinedAssetsDisplay:  formatISKValue(assetsValue),
 			characterID:            0,
 			characterName:          "Total",
-			tags:                   set.Set[string]{},
-			total:                  totals,
-			totalDisplay:           formatISKValue(totals),
-			walletBalance:          walletBalance,
-			walletDisplay:          formatISKValue(walletBalance),
-			ordersEscrow:           marketEscrow,
-			ordersEscrowDisplay:    formatISKValue(marketEscrow),
-			contractsEscrow:        contractEscrow,
-			contractsEscrowDisplay: formatISKValue(contractEscrow),
-			searchTarget:           "",
+			combinedAssetsDisplay:  formatISKValue(assetsTotal),
+			combinedAssetsValue:    assetsTotal,
+			contractsEscrow:        contractsTotal,
+			contractsEscrowDisplay: formatISKValue(contractsTotal),
 			isTotal:                true,
+			ordersEscrow:           ordersTotal,
+			ordersEscrowDisplay:    formatISKValue(ordersTotal),
+			searchTarget:           "",
+			tags:                   set.Set[string]{},
+			total:                  grandTotal,
+			totalDisplay:           formatISKValue(grandTotal),
+			walletBalance:          walletsTotal,
+			walletDisplay:          formatISKValue(walletsTotal),
 		})
 
 		fyne.Do(func() {

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -374,17 +374,8 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 		if err != nil {
 			return rows, err
 		}
-		var total optional.Optional[float64]
 		combinedAssets := o.CombinedAssetsValue()
-		if v1, ok := combinedAssets.Value(); ok {
-			if v2, ok := o.WalletBalance.Value(); ok {
-				if v3, ok := o.ContractsEscrow.Value(); ok {
-					if v4, ok := o.OrdersEscrow.Value(); ok {
-						total.Set(v1 + v2 + v3 + v4)
-					}
-				}
-			}
-		}
+		total := optional.Sum(combinedAssets, o.WalletBalance, o.ContractsEscrow, o.OrdersEscrow)
 		rows = append(rows, overviewRow{
 			characterID:            o.ID,
 			characterName:          o.EveCharacter.Name,

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -30,8 +30,6 @@ type overviewRow struct {
 	combinedAssetsValue    optional.Optional[float64]
 	contractsEscrow        optional.Optional[float64]
 	contractsEscrowDisplay string
-	grandTotal             optional.Optional[float64]
-	grandTotalDisplay      string
 	isTotal                bool
 	ordersEscrow           optional.Optional[float64]
 	ordersEscrowDisplay    string
@@ -80,12 +78,11 @@ const (
 	overviewColOrdersEscrow
 	overviewColTotalNetWorth
 	overviewColSkillPoints
-	overviewColGrandTotal
 )
 
 const valueWidth = 125
 
-const helpText = `Wallet Balance: The balance of the wallet.
+const overviewHelpText = `Wallet Balance: The balance of the wallet.
 
 Combined Assets: The estimated value of all personal assets, items in outstanding sell orders on the market and items in outstanding contracts.
 
@@ -96,8 +93,6 @@ Orders Escrow: The total sum of all escrows in a character's currently outstandi
 Total Net Worth: Sum of Wallet Balance, Combined Assets, Contract Escrow and Orders Escrow.
 
 Skill Points: Value of extracted skill points (trained + unallocated) calculated with: (MarketPriceOfLargeSkillInjector − MarketPriceOfSkillExtractor) x ((TotalSP − 5,000,000) / 500,000)
-
-Grand total: Sum of Total Net Worth and Skill Points
 
 NOTE: Blueprints, PLEX in the account wallet are not included.`
 
@@ -202,19 +197,6 @@ func NewOverview(u baseUI) *Overview {
 			Sort: func(a, b overviewRow) int {
 				return optional.Compare(a.skillPoints, b.skillPoints)
 			},
-		}, {
-			ID:    overviewColGrandTotal,
-			Label: "Grand Total",
-			Width: valueWidth,
-			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.grandTotalDisplay, widget.RichTextStyle{
-					Alignment: fyne.TextAlignTrailing,
-					TextStyle: fyne.TextStyle{Bold: r.isTotal},
-				})
-			},
-			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.grandTotal, b.grandTotal)
-			},
 		},
 	})
 	a := &Overview{
@@ -234,46 +216,9 @@ func NewOverview(u baseUI) *Overview {
 	a.search.PlaceHolder = "Search characters"
 
 	a.showHelp = xwidget.NewTappableIcon(theme.QuestionIcon(), func() {
-		var pu *widget.PopUp
-		closePopUp := widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
-			pu.Hide()
-		})
-		title := widget.NewLabel("Help")
-		title.TextStyle.Bold = true
-		text := widget.NewLabel(helpText)
-		text.Wrapping = fyne.TextWrapWord
-
-		p := theme.Padding()
-		canvas := fyne.CurrentApp().Driver().CanvasForObject(a.showHelp)
-		var spacerSize fyne.Size
-		if a.u.IsMobile() {
-			_, s := canvas.InteractiveArea()
-			spacerSize = fyne.NewSize(s.Width-2*p, s.Height/2)
-		} else {
-			spacerSize = fyne.NewSize(300, 400)
-		}
-		spacer := xwidget.NewSpacer(spacerSize)
-		c := container.NewStack(spacer, container.NewBorder(
-			container.NewHBox(title, layout.NewSpacer(), closePopUp),
-			nil,
-			nil,
-			nil,
-			container.NewVScroll(container.NewPadded(text)),
-		))
-		pu = widget.NewPopUp(c, canvas)
-
-		if a.u.IsMobile() {
-			pos, s := canvas.InteractiveArea()
-			x := pos.X
-			y := pos.Y + s.Height/2
-			pu.ShowAtPosition(fyne.NewPos(x, y))
-		} else {
-			x := a.showHelp.MinSize().Width - pu.MinSize().Width
-			y := a.showHelp.MinSize().Height - pu.MinSize().Height + 2*p
-			pu.ShowAtRelativePosition(fyne.NewPos(x, y), a.showHelp)
-		}
+		showHelpPopUp(overviewHelpText, a.u.IsMobile(), a.showHelp)
 	})
-	a.showHelp.SetToolTip("Shows help for this screen")
+	a.showHelp.SetToolTip("Show explanation for columns")
 
 	if a.u.IsMobile() {
 		a.main = xwidget.MakeDataList(
@@ -298,8 +243,6 @@ func NewOverview(u baseUI) *Overview {
 					s = xwidget.RichTextSegmentsFromText(r.totalNetWorthDisplay)
 				case overviewColSkillPoints:
 					s = xwidget.RichTextSegmentsFromText(r.skillPointsDisplay)
-				case overviewColGrandTotal:
-					s = xwidget.RichTextSegmentsFromText(r.grandTotalDisplay)
 				}
 				return s
 			},
@@ -338,6 +281,7 @@ func NewOverview(u baseUI) *Overview {
 			app.SectionCharacterAssets,
 			app.SectionCharacterContracts,
 			app.SectionCharacterMarketOrders,
+			app.SectionCharacterSkills,
 			app.SectionCharacterWalletBalance:
 			a.update(ctx)
 		}
@@ -408,24 +352,22 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 
 		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
 
-		// add totals1
-		var assets, wallets, totals1, contracts, orders, skillpoints, totals2 []optional.Optional[float64]
+		// add totals
+		var assets, wallets, totals, contracts, orders, skillpoints []optional.Optional[float64]
 		for _, r := range rows {
 			assets = append(assets, r.combinedAssetsValue)
 			contracts = append(contracts, r.contractsEscrow)
 			orders = append(orders, r.ordersEscrow)
 			skillpoints = append(skillpoints, r.skillPoints)
-			totals1 = append(totals1, r.totalNetWorth)
-			totals2 = append(totals2, r.grandTotal)
+			totals = append(totals, r.totalNetWorth)
 			wallets = append(wallets, r.walletBalance)
 		}
 		assetsTotal := optional.Sum(assets...)
 		contractsTotal := optional.Sum(contracts...)
-		grandTotal1 := optional.Sum(totals1...)
+		grandTotal1 := optional.Sum(totals...)
 		ordersTotal := optional.Sum(orders...)
 		walletsTotal := optional.Sum(wallets...)
 		skillpointsTotal := optional.Sum(skillpoints...)
-		grandTotal2 := optional.Sum(totals2...)
 		rows = append(rows, overviewRow{
 			characterID:            0,
 			characterName:          "Total",
@@ -433,8 +375,6 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 			combinedAssetsValue:    assetsTotal,
 			contractsEscrow:        contractsTotal,
 			contractsEscrowDisplay: formatISKValue(contractsTotal),
-			grandTotal:             grandTotal2,
-			grandTotalDisplay:      formatISKValue(grandTotal2),
 			isTotal:                true,
 			ordersEscrow:           ordersTotal,
 			ordersEscrowDisplay:    formatISKValue(ordersTotal),
@@ -490,7 +430,6 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 
 		combinedAssets := o.CombinedAssetsValue()
 		total := optional.Sum(combinedAssets, o.WalletBalance, o.ContractsEscrow, o.OrdersEscrow)
-		grandTotal := optional.Sum(total, o.SkillPointsValue)
 		rows = append(rows, overviewRow{
 			characterID:            o.ID,
 			characterName:          o.EveCharacter.Name,
@@ -498,8 +437,6 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 			combinedAssetsValue:    combinedAssets,
 			contractsEscrow:        o.ContractsEscrow,
 			contractsEscrowDisplay: formatISKValue(o.ContractsEscrow),
-			grandTotal:             grandTotal,
-			grandTotalDisplay:      formatISKValue(grandTotal),
 			ordersEscrow:           o.OrdersEscrow,
 			ordersEscrowDisplay:    formatISKValue(o.OrdersEscrow),
 			searchTarget:           strings.ToLower(o.EveCharacter.Name),
@@ -520,4 +457,47 @@ func formatISKValue(v optional.Optional[float64]) string {
 	return v.StringFunc("?", func(v float64) string {
 		return humanize.FormatFloat("#,###.", v)
 	})
+}
+
+// showHelpPopUp shows a popUp with text as content
+// and it's position aligned to widget obj.
+func showHelpPopUp(text string, isMobile bool, obj fyne.CanvasObject) {
+	var pu *widget.PopUp
+	closePopUp := widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
+		pu.Hide()
+	})
+	title := widget.NewLabel("Help")
+	title.TextStyle.Bold = true
+	body := widget.NewLabel(text)
+	body.Wrapping = fyne.TextWrapWord
+
+	p := theme.Padding()
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(obj)
+	var spacerSize fyne.Size
+	if isMobile {
+		_, s := canvas.InteractiveArea()
+		spacerSize = fyne.NewSize(s.Width-2*p, s.Height/2)
+	} else {
+		spacerSize = fyne.NewSize(300, 400)
+	}
+	spacer := xwidget.NewSpacer(spacerSize)
+	c := container.NewStack(spacer, container.NewBorder(
+		container.NewHBox(title, layout.NewSpacer(), closePopUp),
+		nil,
+		nil,
+		nil,
+		container.NewVScroll(container.NewPadded(body)),
+	))
+	pu = widget.NewPopUp(c, canvas)
+
+	if isMobile {
+		pos, s := canvas.InteractiveArea()
+		x := pos.X
+		y := pos.Y + s.Height/2
+		pu.ShowAtPosition(fyne.NewPos(x, y))
+	} else {
+		x := obj.MinSize().Width - pu.MinSize().Width
+		y := obj.MinSize().Height - pu.MinSize().Height + 2*p
+		pu.ShowAtRelativePosition(fyne.NewPos(x, y), obj)
+	}
 }

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -30,14 +30,18 @@ type overviewRow struct {
 	combinedAssetsValue    optional.Optional[float64]
 	contractsEscrow        optional.Optional[float64]
 	contractsEscrowDisplay string
+	grandTotal             optional.Optional[float64]
+	grandTotalDisplay      string
 	isTotal                bool
 	ordersEscrow           optional.Optional[float64]
 	ordersEscrowDisplay    string
 	searchTarget           string
+	skillPoints            optional.Optional[float64]
+	skillPointsDisplay     string
 	tags                   set.Set[string]
 	tagsDisplay            string
-	total                  optional.Optional[float64]
-	totalDisplay           string
+	totalNetWorth          optional.Optional[float64]
+	totalNetWorthDisplay   string
 	walletBalance          optional.Optional[float64]
 	walletDisplay          string
 }
@@ -74,7 +78,9 @@ const (
 	overviewColCombinedAssetsValue
 	overviewColContractsEscrow
 	overviewColOrdersEscrow
-	overviewColTotal
+	overviewColTotalNetWorth
+	overviewColSkillPoints
+	overviewColGrandTotal
 )
 
 const valueWidth = 125
@@ -87,7 +93,13 @@ Contract Escrow: The total sum of all escrows in a character's currently outstan
 
 Orders Escrow: The total sum of all escrows in a character's currently outstanding buy orders on the market.
 
-Not included: Blueprints, PLEX in the account wallet`
+Total Net Worth: Sum of Wallet Balance, Combined Assets, Contract Escrow and Orders Escrow.
+
+Skill Points: Value of extracted skill points (trained + unallocated) calculated with: (MarketPriceOfLargeSkillInjector − MarketPriceOfSkillExtractor) x ((TotalSP − 5,000,000) / 500,000)
+
+Grand total: Sum of Total Net Worth and Skill Points
+
+NOTE: Blueprints, PLEX in the account wallet are not included.`
 
 func NewOverview(u baseUI) *Overview {
 	columns := xwidget.NewDataColumns([]xwidget.DataColumn[overviewRow]{
@@ -165,19 +177,46 @@ func NewOverview(u baseUI) *Overview {
 				return optional.Compare(a.ordersEscrow, b.ordersEscrow)
 			},
 		}, {
-			ID:    overviewColTotal,
+			ID:    overviewColTotalNetWorth,
 			Label: "Total Net Worth",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.totalDisplay, widget.RichTextStyle{
+				co.(*xwidget.RichText).SetWithText(r.totalNetWorthDisplay, widget.RichTextStyle{
 					Alignment: fyne.TextAlignTrailing,
 					TextStyle: fyne.TextStyle{Bold: r.isTotal},
 				})
 			},
 			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.total, b.total)
+				return optional.Compare(a.totalNetWorth, b.totalNetWorth)
 			},
-		}})
+		}, {
+			ID:    overviewColSkillPoints,
+			Label: "Skill Points",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.skillPointsDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.skillPoints, b.skillPoints)
+			},
+		}, {
+			ID:    overviewColGrandTotal,
+			Label: "Grand Total",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.grandTotalDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.grandTotal, b.grandTotal)
+			},
+		},
+	})
 	a := &Overview{
 		columnSorter: xwidget.NewColumnSorter(columns, overviewColCharacter, xwidget.SortAsc),
 		footer:       widget.NewLabel(""),
@@ -255,8 +294,12 @@ func NewOverview(u baseUI) *Overview {
 					s = xwidget.RichTextSegmentsFromText(r.contractsEscrowDisplay)
 				case overviewColOrdersEscrow:
 					s = xwidget.RichTextSegmentsFromText(r.ordersEscrowDisplay)
-				case overviewColTotal:
-					s = xwidget.RichTextSegmentsFromText(r.totalDisplay)
+				case overviewColTotalNetWorth:
+					s = xwidget.RichTextSegmentsFromText(r.totalNetWorthDisplay)
+				case overviewColSkillPoints:
+					s = xwidget.RichTextSegmentsFromText(r.skillPointsDisplay)
+				case overviewColGrandTotal:
+					s = xwidget.RichTextSegmentsFromText(r.grandTotalDisplay)
 				}
 				return s
 			},
@@ -365,20 +408,24 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 
 		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
 
-		// add totals
-		var assets, wallets, totals, contracts, orders []optional.Optional[float64]
+		// add totals1
+		var assets, wallets, totals1, contracts, orders, skillpoints, totals2 []optional.Optional[float64]
 		for _, r := range rows {
 			assets = append(assets, r.combinedAssetsValue)
 			contracts = append(contracts, r.contractsEscrow)
 			orders = append(orders, r.ordersEscrow)
-			totals = append(totals, r.total)
+			skillpoints = append(skillpoints, r.skillPoints)
+			totals1 = append(totals1, r.totalNetWorth)
+			totals2 = append(totals2, r.grandTotal)
 			wallets = append(wallets, r.walletBalance)
 		}
 		assetsTotal := optional.Sum(assets...)
 		contractsTotal := optional.Sum(contracts...)
-		grandTotal := optional.Sum(totals...)
+		grandTotal1 := optional.Sum(totals1...)
 		ordersTotal := optional.Sum(orders...)
 		walletsTotal := optional.Sum(wallets...)
+		skillpointsTotal := optional.Sum(skillpoints...)
+		grandTotal2 := optional.Sum(totals2...)
 		rows = append(rows, overviewRow{
 			characterID:            0,
 			characterName:          "Total",
@@ -386,13 +433,17 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 			combinedAssetsValue:    assetsTotal,
 			contractsEscrow:        contractsTotal,
 			contractsEscrowDisplay: formatISKValue(contractsTotal),
+			grandTotal:             grandTotal2,
+			grandTotalDisplay:      formatISKValue(grandTotal2),
 			isTotal:                true,
 			ordersEscrow:           ordersTotal,
 			ordersEscrowDisplay:    formatISKValue(ordersTotal),
 			searchTarget:           "",
+			skillPoints:            skillpointsTotal,
+			skillPointsDisplay:     formatISKValue(skillpointsTotal),
 			tags:                   set.Set[string]{},
-			total:                  grandTotal,
-			totalDisplay:           formatISKValue(grandTotal),
+			totalNetWorth:          grandTotal1,
+			totalNetWorthDisplay:   formatISKValue(grandTotal1),
 			walletBalance:          walletsTotal,
 			walletDisplay:          formatISKValue(walletsTotal),
 		})
@@ -436,8 +487,10 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 		if err != nil {
 			return rows, err
 		}
+
 		combinedAssets := o.CombinedAssetsValue()
 		total := optional.Sum(combinedAssets, o.WalletBalance, o.ContractsEscrow, o.OrdersEscrow)
+		grandTotal := optional.Sum(total, o.SkillPointsValue)
 		rows = append(rows, overviewRow{
 			characterID:            o.ID,
 			characterName:          o.EveCharacter.Name,
@@ -445,13 +498,17 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 			combinedAssetsValue:    combinedAssets,
 			contractsEscrow:        o.ContractsEscrow,
 			contractsEscrowDisplay: formatISKValue(o.ContractsEscrow),
+			grandTotal:             grandTotal,
+			grandTotalDisplay:      formatISKValue(grandTotal),
 			ordersEscrow:           o.OrdersEscrow,
 			ordersEscrowDisplay:    formatISKValue(o.OrdersEscrow),
 			searchTarget:           strings.ToLower(o.EveCharacter.Name),
+			skillPoints:            o.SkillPointsValue,
+			skillPointsDisplay:     formatISKValue(o.SkillPointsValue),
 			tags:                   tags,
 			tagsDisplay:            strings.Join(slices.Sorted(tags.All()), ", "),
-			total:                  total,
-			totalDisplay:           formatISKValue(total),
+			totalNetWorth:          total,
+			totalNetWorthDisplay:   formatISKValue(total),
 			walletBalance:          o.WalletBalance,
 			walletDisplay:          formatISKValue(o.WalletBalance),
 		})

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -24,7 +24,6 @@ import (
 
 // TODOs
 // - add all variants for calculating contract escrow
-// - add values for contracts items and market orders to assets value
 
 type overviewRow struct {
 	characterID            int64

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -23,17 +23,21 @@ import (
 )
 
 type overviewRow struct {
-	assets        optional.Optional[float64]
-	assetsDisplay string
-	characterID   int64
-	characterName string
-	tags          set.Set[string]
-	total         optional.Optional[float64]
-	totalDisplay  string
-	wallet        optional.Optional[float64]
-	walletDisplay string
-	searchTarget  string
-	isTotal       bool
+	assetsValue           optional.Optional[float64]
+	assetsDisplay         string
+	characterID           int64
+	characterName         string
+	contractEscrow        optional.Optional[float64]
+	contractEscrowDisplay string
+	isTotal               bool
+	marketEscrow          optional.Optional[float64]
+	marketEscrowDisplay   string
+	searchTarget          string
+	tags                  set.Set[string]
+	total                 optional.Optional[float64]
+	totalDisplay          string
+	walletBalance         optional.Optional[float64]
+	walletDisplay         string
 }
 
 func (r overviewRow) eveEntity() *app.EveEntity {
@@ -63,12 +67,14 @@ type Overview struct {
 const (
 	overviewColCharacter = iota + 1
 	overviewColTags
-	overviewColAssets
-	overviewColWallet
+	overviewColWalletBalance
+	overviewColAssetsValue
+	overviewColContractEscrow
+	overviewColMarketEscrow
 	overviewColTotal
 )
 
-const valueWidth = 150
+const valueWidth = 125
 
 func NewOverview(u baseUI) *Overview {
 	columns := xwidget.NewDataColumns([]xwidget.DataColumn[overviewRow]{
@@ -93,21 +99,8 @@ func NewOverview(u baseUI) *Overview {
 				co.(*xwidget.RichText).SetWithText(s)
 			},
 		}, {
-			ID:    overviewColAssets,
-			Label: "Assets",
-			Width: valueWidth,
-			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.assetsDisplay, widget.RichTextStyle{
-					Alignment: fyne.TextAlignTrailing,
-					TextStyle: fyne.TextStyle{Bold: r.isTotal},
-				})
-			},
-			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.assets, b.assets)
-			},
-		}, {
-			ID:    overviewColWallet,
-			Label: "Wallet",
+			ID:    overviewColWalletBalance,
+			Label: "Wallet Balance",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
 				co.(*xwidget.RichText).SetWithText(r.walletDisplay, widget.RichTextStyle{
@@ -116,7 +109,48 @@ func NewOverview(u baseUI) *Overview {
 				})
 			},
 			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.wallet, b.wallet)
+				return optional.Compare(a.walletBalance, b.walletBalance)
+			},
+		}, {
+			ID:    overviewColAssetsValue,
+			Label: "Assets Value",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.assetsDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.assetsValue, b.assetsValue)
+			},
+		},
+		{
+			ID:    overviewColContractEscrow,
+			Label: "Contract Escrow",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.contractEscrowDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.contractEscrow, b.contractEscrow)
+			},
+		},
+		{
+			ID:    overviewColMarketEscrow,
+			Label: "Market Escrow",
+			Width: valueWidth,
+			Update: func(r overviewRow, co fyne.CanvasObject) {
+				co.(*xwidget.RichText).SetWithText(r.marketEscrowDisplay, widget.RichTextStyle{
+					Alignment: fyne.TextAlignTrailing,
+					TextStyle: fyne.TextStyle{Bold: r.isTotal},
+				})
+			},
+			Sort: func(a, b overviewRow) int {
+				return optional.Compare(a.marketEscrow, b.marketEscrow)
 			},
 		}, {
 			ID:    overviewColTotal,
@@ -267,24 +301,30 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 		footer := fmt.Sprintf("Showing %d / %d characters", len(rows), totalRows)
 
 		// add totals
-		var assets, wallets, totals optional.Optional[float64]
+		var assetsValue, walletBalance, totals, contractEscrow, marketEscrow optional.Optional[float64]
 		for _, r := range rows {
-			assets = optional.Sum(assets, r.assets)
-			wallets = optional.Sum(wallets, r.wallet)
+			assetsValue = optional.Sum(assetsValue, r.assetsValue)
+			walletBalance = optional.Sum(walletBalance, r.walletBalance)
+			contractEscrow = optional.Sum(contractEscrow, r.contractEscrow)
+			marketEscrow = optional.Sum(marketEscrow, r.marketEscrow)
 			totals = optional.Sum(totals, r.total)
 		}
 		rows = append(rows, overviewRow{
-			assets:        assets,
-			assetsDisplay: formatISKValue(assets),
-			characterID:   0,
-			characterName: "Total",
-			tags:          set.Set[string]{},
-			total:         totals,
-			totalDisplay:  formatISKValue(totals),
-			wallet:        wallets,
-			walletDisplay: formatISKValue(totals),
-			searchTarget:  "",
-			isTotal:       true,
+			assetsValue:           assetsValue,
+			assetsDisplay:         formatISKValue(assetsValue),
+			characterID:           0,
+			characterName:         "Total",
+			tags:                  set.Set[string]{},
+			total:                 totals,
+			totalDisplay:          formatISKValue(totals),
+			walletBalance:         walletBalance,
+			walletDisplay:         formatISKValue(walletBalance),
+			marketEscrow:          marketEscrow,
+			marketEscrowDisplay:   formatISKValue(marketEscrow),
+			contractEscrow:        contractEscrow,
+			contractEscrowDisplay: formatISKValue(contractEscrow),
+			searchTarget:          "",
+			isTotal:               true,
 		})
 
 		fyne.Do(func() {
@@ -316,31 +356,41 @@ func (a *Overview) update(ctx context.Context) {
 }
 
 func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
-	characters, err := a.u.Character().CharacterNames(ctx)
-	if err != nil {
-		return nil, err
-	}
-	oo, err := a.u.Character().ListWealthValues(ctx)
+	cc, err := a.u.Character().ListCharacters(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var rows []overviewRow
-	for _, o := range oo {
-		tags, err := a.u.Character().ListTagsForCharacter(ctx, o.CharacterID)
+	for _, o := range cc {
+		tags, err := a.u.Character().ListTagsForCharacter(ctx, o.ID)
 		if err != nil {
 			return rows, err
 		}
+		var total optional.Optional[float64]
+		if v1, ok := o.AssetValue.Value(); ok {
+			if v2, ok := o.WalletBalance.Value(); ok {
+				if v3, ok := o.ContractEscrow.Value(); ok {
+					if v4, ok := o.MarketEscrow.Value(); ok {
+						total.Set(v1 + v2 + v3 + v4)
+					}
+				}
+			}
+		}
 		rows = append(rows, overviewRow{
-			assets:        o.Assets,
-			assetsDisplay: formatISKValue(o.Assets),
-			characterID:   o.CharacterID,
-			characterName: characters[o.CharacterID],
-			searchTarget:  strings.ToLower(characters[o.CharacterID]),
-			tags:          tags,
-			total:         o.Total,
-			totalDisplay:  formatISKValue(o.Total),
-			wallet:        o.Wallet,
-			walletDisplay: formatISKValue(o.Wallet),
+			assetsValue:           o.AssetValue,
+			assetsDisplay:         formatISKValue(o.AssetValue),
+			characterID:           o.ID,
+			characterName:         o.EveCharacter.Name,
+			searchTarget:          strings.ToLower(o.EveCharacter.Name),
+			tags:                  tags,
+			total:                 total,
+			totalDisplay:          formatISKValue(total),
+			walletBalance:         o.WalletBalance,
+			walletDisplay:         formatISKValue(o.WalletBalance),
+			marketEscrow:          o.MarketEscrow,
+			marketEscrowDisplay:   formatISKValue(o.MarketEscrow),
+			contractEscrow:        o.ContractEscrow,
+			contractEscrowDisplay: formatISKValue(o.ContractEscrow),
 		})
 	}
 	return rows, nil
@@ -348,6 +398,6 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 
 func formatISKValue(v optional.Optional[float64]) string {
 	return v.StringFunc("?", func(v float64) string {
-		return humanize.FormatFloat(ui.FloatFormat, v)
+		return humanize.FormatFloat("#,###.", v)
 	})
 }

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -22,22 +22,26 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
+// TODOs
+// - add all variants for calculating contract escrow
+// - add values for contracts items and market orders to assets value
+
 type overviewRow struct {
-	assetsValue           optional.Optional[float64]
-	assetsDisplay         string
-	characterID           int64
-	characterName         string
-	contractEscrow        optional.Optional[float64]
-	contractEscrowDisplay string
-	isTotal               bool
-	marketEscrow          optional.Optional[float64]
-	marketEscrowDisplay   string
-	searchTarget          string
-	tags                  set.Set[string]
-	total                 optional.Optional[float64]
-	totalDisplay          string
-	walletBalance         optional.Optional[float64]
-	walletDisplay         string
+	characterID            int64
+	characterName          string
+	combinedAssetsDisplay  string
+	combinedAssetsValue    optional.Optional[float64]
+	contractsEscrow        optional.Optional[float64]
+	contractsEscrowDisplay string
+	isTotal                bool
+	ordersEscrow           optional.Optional[float64]
+	ordersEscrowDisplay    string
+	searchTarget           string
+	tags                   set.Set[string]
+	total                  optional.Optional[float64]
+	totalDisplay           string
+	walletBalance          optional.Optional[float64]
+	walletDisplay          string
 }
 
 func (r overviewRow) eveEntity() *app.EveEntity {
@@ -68,9 +72,9 @@ const (
 	overviewColCharacter = iota + 1
 	overviewColTags
 	overviewColWalletBalance
-	overviewColAssetsValue
-	overviewColContractEscrow
-	overviewColMarketEscrow
+	overviewColCombinedAssetsValue
+	overviewColContractsEscrow
+	overviewColOrdersEscrow
 	overviewColTotal
 )
 
@@ -112,49 +116,49 @@ func NewOverview(u baseUI) *Overview {
 				return optional.Compare(a.walletBalance, b.walletBalance)
 			},
 		}, {
-			ID:    overviewColAssetsValue,
-			Label: "Assets Value",
+			ID:    overviewColCombinedAssetsValue,
+			Label: "Combined Assets",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.assetsDisplay, widget.RichTextStyle{
+				co.(*xwidget.RichText).SetWithText(r.combinedAssetsDisplay, widget.RichTextStyle{
 					Alignment: fyne.TextAlignTrailing,
 					TextStyle: fyne.TextStyle{Bold: r.isTotal},
 				})
 			},
 			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.assetsValue, b.assetsValue)
+				return optional.Compare(a.combinedAssetsValue, b.combinedAssetsValue)
 			},
 		},
 		{
-			ID:    overviewColContractEscrow,
-			Label: "Contract Escrow",
+			ID:    overviewColContractsEscrow,
+			Label: "Contracts Escrow",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.contractEscrowDisplay, widget.RichTextStyle{
+				co.(*xwidget.RichText).SetWithText(r.contractsEscrowDisplay, widget.RichTextStyle{
 					Alignment: fyne.TextAlignTrailing,
 					TextStyle: fyne.TextStyle{Bold: r.isTotal},
 				})
 			},
 			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.contractEscrow, b.contractEscrow)
+				return optional.Compare(a.contractsEscrow, b.contractsEscrow)
 			},
 		},
 		{
-			ID:    overviewColMarketEscrow,
-			Label: "Market Escrow",
+			ID:    overviewColOrdersEscrow,
+			Label: "Orders Escrow",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
-				co.(*xwidget.RichText).SetWithText(r.marketEscrowDisplay, widget.RichTextStyle{
+				co.(*xwidget.RichText).SetWithText(r.ordersEscrowDisplay, widget.RichTextStyle{
 					Alignment: fyne.TextAlignTrailing,
 					TextStyle: fyne.TextStyle{Bold: r.isTotal},
 				})
 			},
 			Sort: func(a, b overviewRow) int {
-				return optional.Compare(a.marketEscrow, b.marketEscrow)
+				return optional.Compare(a.ordersEscrow, b.ordersEscrow)
 			},
 		}, {
 			ID:    overviewColTotal,
-			Label: "Total",
+			Label: "Total Net Worth",
 			Width: valueWidth,
 			Update: func(r overviewRow, co fyne.CanvasObject) {
 				co.(*xwidget.RichText).SetWithText(r.totalDisplay, widget.RichTextStyle{
@@ -232,7 +236,11 @@ func NewOverview(u baseUI) *Overview {
 	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
-		case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
+		case
+			app.SectionCharacterAssets,
+			app.SectionCharacterContracts,
+			app.SectionCharacterMarketOrders,
+			app.SectionCharacterWalletBalance:
 			a.update(ctx)
 		}
 	})
@@ -303,28 +311,28 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 		// add totals
 		var assetsValue, walletBalance, totals, contractEscrow, marketEscrow optional.Optional[float64]
 		for _, r := range rows {
-			assetsValue = optional.Sum(assetsValue, r.assetsValue)
+			assetsValue = optional.Sum(assetsValue, r.combinedAssetsValue)
 			walletBalance = optional.Sum(walletBalance, r.walletBalance)
-			contractEscrow = optional.Sum(contractEscrow, r.contractEscrow)
-			marketEscrow = optional.Sum(marketEscrow, r.marketEscrow)
+			contractEscrow = optional.Sum(contractEscrow, r.contractsEscrow)
+			marketEscrow = optional.Sum(marketEscrow, r.ordersEscrow)
 			totals = optional.Sum(totals, r.total)
 		}
 		rows = append(rows, overviewRow{
-			assetsValue:           assetsValue,
-			assetsDisplay:         formatISKValue(assetsValue),
-			characterID:           0,
-			characterName:         "Total",
-			tags:                  set.Set[string]{},
-			total:                 totals,
-			totalDisplay:          formatISKValue(totals),
-			walletBalance:         walletBalance,
-			walletDisplay:         formatISKValue(walletBalance),
-			marketEscrow:          marketEscrow,
-			marketEscrowDisplay:   formatISKValue(marketEscrow),
-			contractEscrow:        contractEscrow,
-			contractEscrowDisplay: formatISKValue(contractEscrow),
-			searchTarget:          "",
-			isTotal:               true,
+			combinedAssetsValue:    assetsValue,
+			combinedAssetsDisplay:  formatISKValue(assetsValue),
+			characterID:            0,
+			characterName:          "Total",
+			tags:                   set.Set[string]{},
+			total:                  totals,
+			totalDisplay:           formatISKValue(totals),
+			walletBalance:          walletBalance,
+			walletDisplay:          formatISKValue(walletBalance),
+			ordersEscrow:           marketEscrow,
+			ordersEscrowDisplay:    formatISKValue(marketEscrow),
+			contractsEscrow:        contractEscrow,
+			contractsEscrowDisplay: formatISKValue(contractEscrow),
+			searchTarget:           "",
+			isTotal:                true,
 		})
 
 		fyne.Do(func() {
@@ -367,30 +375,31 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 			return rows, err
 		}
 		var total optional.Optional[float64]
-		if v1, ok := o.AssetValue.Value(); ok {
+		combinedAssets := o.CombinedAssetsValue()
+		if v1, ok := combinedAssets.Value(); ok {
 			if v2, ok := o.WalletBalance.Value(); ok {
-				if v3, ok := o.ContractEscrow.Value(); ok {
-					if v4, ok := o.MarketEscrow.Value(); ok {
+				if v3, ok := o.ContractsEscrow.Value(); ok {
+					if v4, ok := o.OrdersEscrow.Value(); ok {
 						total.Set(v1 + v2 + v3 + v4)
 					}
 				}
 			}
 		}
 		rows = append(rows, overviewRow{
-			assetsValue:           o.AssetValue,
-			assetsDisplay:         formatISKValue(o.AssetValue),
-			characterID:           o.ID,
-			characterName:         o.EveCharacter.Name,
-			searchTarget:          strings.ToLower(o.EveCharacter.Name),
-			tags:                  tags,
-			total:                 total,
-			totalDisplay:          formatISKValue(total),
-			walletBalance:         o.WalletBalance,
-			walletDisplay:         formatISKValue(o.WalletBalance),
-			marketEscrow:          o.MarketEscrow,
-			marketEscrowDisplay:   formatISKValue(o.MarketEscrow),
-			contractEscrow:        o.ContractEscrow,
-			contractEscrowDisplay: formatISKValue(o.ContractEscrow),
+			characterID:            o.ID,
+			characterName:          o.EveCharacter.Name,
+			combinedAssetsDisplay:  formatISKValue(combinedAssets),
+			combinedAssetsValue:    combinedAssets,
+			contractsEscrow:        o.ContractsEscrow,
+			contractsEscrowDisplay: formatISKValue(o.ContractsEscrow),
+			ordersEscrow:           o.OrdersEscrow,
+			ordersEscrowDisplay:    formatISKValue(o.OrdersEscrow),
+			searchTarget:           strings.ToLower(o.EveCharacter.Name),
+			tags:                   tags,
+			total:                  total,
+			totalDisplay:           formatISKValue(total),
+			walletBalance:          o.WalletBalance,
+			walletDisplay:          formatISKValue(o.WalletBalance),
 		})
 	}
 	return rows, nil

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -209,7 +209,7 @@ func NewOverview(u baseUI) *Overview {
 		var spacerSize fyne.Size
 		if a.u.IsMobile() {
 			_, s := canvas.InteractiveArea()
-			spacerSize = fyne.NewSize(s.Width-4*p, s.Height/2)
+			spacerSize = fyne.NewSize(s.Width-2*p, s.Height/2)
 		} else {
 			spacerSize = fyne.NewSize(300, 400)
 		}
@@ -224,14 +224,14 @@ func NewOverview(u baseUI) *Overview {
 		pu = widget.NewPopUp(c, canvas)
 
 		if a.u.IsMobile() {
-			x := a.showHelp.MinSize().Width - pu.MinSize().Width
-			y := a.showHelp.MinSize().Height - pu.MinSize().Height
-			pu.ShowAtRelativePosition(fyne.NewPos(x, y), a.showHelp)
-		} else {
 			pos, s := canvas.InteractiveArea()
 			x := pos.X
 			y := pos.Y + s.Height/2
 			pu.ShowAtPosition(fyne.NewPos(x, y))
+		} else {
+			x := a.showHelp.MinSize().Width - pu.MinSize().Width
+			y := a.showHelp.MinSize().Height - pu.MinSize().Height + 2*p
+			pu.ShowAtRelativePosition(fyne.NewPos(x, y), a.showHelp)
 		}
 	})
 	a.showHelp.SetToolTip("Shows help for this screen")

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -311,11 +311,11 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 		// add totals
 		var assetsValue, walletBalance, totals, contractEscrow, marketEscrow optional.Optional[float64]
 		for _, r := range rows {
-			assetsValue = optional.Sum(assetsValue, r.combinedAssetsValue)
-			walletBalance = optional.Sum(walletBalance, r.walletBalance)
-			contractEscrow = optional.Sum(contractEscrow, r.contractsEscrow)
-			marketEscrow = optional.Sum(marketEscrow, r.ordersEscrow)
-			totals = optional.Sum(totals, r.total)
+			assetsValue = optional.SumNonEmpty(assetsValue, r.combinedAssetsValue)
+			walletBalance = optional.SumNonEmpty(walletBalance, r.walletBalance)
+			contractEscrow = optional.SumNonEmpty(contractEscrow, r.contractsEscrow)
+			marketEscrow = optional.SumNonEmpty(marketEscrow, r.ordersEscrow)
+			totals = optional.SumNonEmpty(totals, r.total)
 		}
 		rows = append(rows, overviewRow{
 			combinedAssetsValue:    assetsValue,

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -36,6 +36,14 @@ type overviewRow struct {
 	isTotal       bool
 }
 
+func (r overviewRow) eveEntity() *app.EveEntity {
+	return &app.EveEntity{
+		Category: app.EveEntityCharacter,
+		ID:       r.characterID,
+		Name:     r.characterName,
+	}
+}
+
 type Overview struct {
 	widget.BaseWidget
 
@@ -172,7 +180,9 @@ func NewOverview(u baseUI) *Overview {
 			},
 			a.columnSorter,
 			a.filterRowsAsync,
-			nil,
+			func(_ int, r overviewRow) {
+				u.InfoViewer().Show(r.eveEntity())
+			},
 		)
 	}
 	a.selectTag = kxwidget.NewFilterChipSelect("Tag", []string{}, func(string) {
@@ -183,23 +193,26 @@ func NewOverview(u baseUI) *Overview {
 	}, a.u.MainWindow())
 
 	// Signals
-	// a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
-	// 	switch arg.Section {
-	// 	case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
-	// 		a.Update(ctx)
-	// 	}
-	// })
-	// a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-	// 	a.Update(ctx)
-	// })
-	// a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-	// 	a.Update(ctx)
-	// })
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
+		switch arg.Section {
+		case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
+			a.update(ctx)
+		}
+	})
+	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
+		a.update(ctx)
+	})
+	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
+		a.update(ctx)
+	})
 	a.u.Signals().TagsChanged.AddListener(func(ctx context.Context, _ struct{}) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterChanged.AddListener(func(ctx context.Context, characterID int64) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -285,7 +298,7 @@ func (a *Overview) filterRowsAsync(sortCol int) {
 	}()
 }
 
-func (a *Overview) Update(ctx context.Context) {
+func (a *Overview) update(ctx context.Context) {
 	rows, err := a.fetchRows(ctx)
 	if err != nil {
 		slog.Error("Failed to refresh wealth overview UI", "err", err)
@@ -313,13 +326,17 @@ func (a *Overview) fetchRows(ctx context.Context) ([]overviewRow, error) {
 	}
 	var rows []overviewRow
 	for _, o := range oo {
+		tags, err := a.u.Character().ListTagsForCharacter(ctx, o.CharacterID)
+		if err != nil {
+			return rows, err
+		}
 		rows = append(rows, overviewRow{
 			assets:        o.Assets,
 			assetsDisplay: formatISKValue(o.Assets),
 			characterID:   o.CharacterID,
 			characterName: characters[o.CharacterID],
 			searchTarget:  strings.ToLower(characters[o.CharacterID]),
-			tags:          set.Set[string]{},
+			tags:          tags,
 			total:         o.Total,
 			totalDisplay:  formatISKValue(o.Total),
 			wallet:        o.Wallet,

--- a/internal/app/ui/wallets/walletjournal.go
+++ b/internal/app/ui/wallets/walletjournal.go
@@ -154,7 +154,7 @@ func newWalletJournal(u baseUI, division app.Division) *WalletJournal {
 		Width: 200,
 		Update: func(r walletJournalRow, co fyne.CanvasObject) {
 			co.(*xwidget.RichText).SetWithText(r.balance.StringFunc("?", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			}), widget.RichTextStyle{
 				Alignment: fyne.TextAlignTrailing,
 			},
@@ -373,11 +373,11 @@ func (a *WalletJournal) fetchCharacterRows(ctx context.Context, character *app.C
 		r := walletJournalRow{
 			amount: o.Amount,
 			amountFormatted: o.Amount.StringFunc("?", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			}),
 			balance: o.Balance,
 			balanceFormatted: o.Balance.StringFunc("?", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			}),
 			ownerID:        character.ID,
 			ownerName:      character.NameOrZero(),
@@ -451,11 +451,11 @@ func (a *WalletJournal) fetchCorporationRows(ctx context.Context, corporation *a
 		r := walletJournalRow{
 			amount: o.Amount,
 			amountFormatted: o.Amount.StringFunc("?", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			}),
 			balance: o.Balance,
 			balanceFormatted: o.Balance.StringFunc("?", func(v float64) string {
-				return humanize.FormatFloat(ui.FloatFormat, v)
+				return humanize.FormatFloat(ui.FloatFormatISK, v)
 			}),
 			ownerID:        corporation.ID,
 			ownerName:      corporation.NameOrZero(),

--- a/internal/app/ui/wallets/wallettransaction.go
+++ b/internal/app/ui/wallets/wallettransaction.go
@@ -510,12 +510,12 @@ func (a *WalletTransactions) fetchCharacterRows(ctx context.Context, character *
 			quantity:         int(o.Quantity),
 			quantityDisplay:  humanize.Comma(int64(o.Quantity)),
 			total:            total,
-			totalFormatted:   humanize.FormatFloat(ui.FloatFormat, total),
+			totalFormatted:   humanize.FormatFloat(ui.FloatFormatISK, total),
 			transactionID:    o.TransactionID,
 			typeID:           o.Type.ID,
 			typeName:         o.Type.Name,
 			unitPrice:        o.UnitPrice,
-			unitPriceDisplay: humanize.FormatFloat(ui.FloatFormat, o.UnitPrice),
+			unitPriceDisplay: humanize.FormatFloat(ui.FloatFormatISK, o.UnitPrice),
 		}
 		if o.IsBuy {
 			r.totalColor = theme.ColorNameError
@@ -596,12 +596,12 @@ func (a *WalletTransactions) fetchCorporationRows(ctx context.Context, corporati
 			quantity:         int(o.Quantity),
 			quantityDisplay:  humanize.Comma(int64(o.Quantity)),
 			total:            total,
-			totalFormatted:   humanize.FormatFloat(ui.FloatFormat, total),
+			totalFormatted:   humanize.FormatFloat(ui.FloatFormatISK, total),
 			transactionID:    o.TransactionID,
 			typeID:           o.Type.ID,
 			typeName:         o.Type.Name,
 			unitPrice:        o.UnitPrice,
-			unitPriceDisplay: humanize.FormatFloat(ui.FloatFormat, o.UnitPrice),
+			unitPriceDisplay: humanize.FormatFloat(ui.FloatFormatISK, o.UnitPrice),
 		}
 		if o.IsBuy {
 			r.totalColor = theme.ColorNameError

--- a/internal/app/ui/wallets/wealth.go
+++ b/internal/app/ui/wallets/wealth.go
@@ -42,7 +42,7 @@ type wealthRow struct {
 type Wealth struct {
 	widget.BaseWidget
 
-	OnUpdate func(wallet, assets float64)
+	OnUpdate func(totalNetWorth optional.Optional[float64])
 
 	assetDetail          *coord.CartesianCategoricalChart
 	characterSplit       *prop.PieChart
@@ -144,7 +144,7 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (a *Wealth) update(ctx context.Context) {
-	rows, err := a.fetchData(ctx)
+	rows, total, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to fetch data for charts", "err", err)
 		fyne.Do(func() {
@@ -176,7 +176,7 @@ func (a *Wealth) update(ctx context.Context) {
 
 	fyne.Do(func() {
 		if a.OnUpdate != nil {
-			a.OnUpdate(0, 0)
+			a.OnUpdate(total)
 		}
 	})
 }
@@ -365,15 +365,17 @@ func reduceCategoricalPoints(rows []data.CategoricalPoint, m int) []data.Categor
 	return rows
 }
 
-func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, error) {
+func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, optional.Optional[float64], error) {
 	cc, err := a.u.Character().ListCharacters(ctx)
 	if err != nil {
-		return nil, err
+		return nil, optional.Optional[float64]{}, err
 	}
 	var rows []wealthRow
+	var totals []optional.Optional[float64]
 	for _, c := range cc {
 		combinedAssets := c.CombinedAssetsValue()
 		total := optional.Sum(c.WalletBalance, combinedAssets, c.ContractsEscrow, c.OrdersEscrow)
+		totals = append(totals, total)
 		if total.IsEmpty() {
 			continue
 		}
@@ -392,7 +394,8 @@ func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, error) {
 	slices.SortFunc(rows, func(a, b wealthRow) int {
 		return strings.Compare(a.characterName, b.characterName)
 	})
-	return rows, nil
+	grantTotal := optional.Sum(totals...)
+	return rows, grantTotal, nil
 }
 
 type colorWheel struct {

--- a/internal/app/ui/wallets/wealth.go
+++ b/internal/app/ui/wallets/wealth.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
-	"github.com/ErikKalkoken/evebuddy/internal/xslices"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 )
 
 const (
@@ -30,10 +30,13 @@ const (
 )
 
 type wealthRow struct {
-	character string
-	wallet    float64
-	assets    float64
-	total     float64
+	characterID     int64
+	characterName   string
+	walletBalance   float64
+	combinedAssets  float64
+	contractsEscrow float64
+	ordersEscrow    float64
+	total           float64
 }
 
 type Wealth struct {
@@ -99,7 +102,11 @@ func NewWealth(u baseUI) *Wealth {
 	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
-		case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
+		case
+			app.SectionCharacterAssets,
+			app.SectionCharacterContracts,
+			app.SectionCharacterMarketOrders,
+			app.SectionCharacterWalletBalance:
 			a.update(ctx)
 		}
 	})
@@ -121,7 +128,7 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 	tabs := container.NewAppTabs(
 		container.NewTabItem("Characters", a.overview),
 		container.NewTabItem(
-			"Overview",
+			"Total",
 			container.NewAdaptiveGrid(2, a.totalSplit, a.characterSplit),
 		),
 		container.NewTabItem(
@@ -147,7 +154,7 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (a *Wealth) update(ctx context.Context) {
-	rows, characters, err := a.fetchData(ctx)
+	rows, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to fetch data for charts", "err", err)
 		fyne.Do(func() {
@@ -158,7 +165,7 @@ func (a *Wealth) update(ctx context.Context) {
 		})
 		return
 	}
-	if characters == 0 {
+	if len(rows) == 0 {
 		fyne.Do(func() {
 			a.top.Text = "No characters"
 			a.top.Importance = widget.LowImportance
@@ -172,33 +179,31 @@ func (a *Wealth) update(ctx context.Context) {
 		a.top.Hide()
 	})
 
-	var totalWallet, totalAssets float64
-	for _, r := range rows {
-		totalAssets += r.assets
-		totalWallet += r.wallet
-	}
-	a.updateAssetDetail(ctx, rows, totalAssets)
-	a.updateAssetSplit(ctx, rows, totalAssets)
-	a.updateCharacterSplit(ctx, rows, totalAssets, totalWallet)
-	a.updateTotalSplit(ctx, totalAssets, totalWallet)
-	a.updateWalletDetail(ctx, rows, totalWallet)
-	a.updateWalletSplit(ctx, rows, totalWallet)
+	a.updateAssetDetail(ctx, rows)
+	a.updateAssetSplit(ctx, rows)
+	a.updateCharacterSplit(ctx, rows)
+	a.updateTotalSplit(ctx, rows)
+	a.updateWalletDetail(ctx, rows)
+	a.updateWalletSplit(ctx, rows)
 
 	fyne.Do(func() {
 		if a.OnUpdate != nil {
-			a.OnUpdate(totalWallet*wealthMultiplier, totalAssets*wealthMultiplier)
+			a.OnUpdate(0, 0)
 		}
 	})
 }
 
-func (a *Wealth) updateAssetDetail(_ context.Context, rows []wealthRow, totalAssets float64) {
+func (a *Wealth) updateAssetDetail(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
-	d := xslices.Map(rows, func(r wealthRow) data.CategoricalPoint {
-		return data.CategoricalPoint{
-			C:   r.character,
-			Val: r.assets,
-		}
-	})
+	var total float64
+	var d []data.CategoricalPoint
+	for _, r := range rows {
+		d = append(d, data.CategoricalPoint{
+			C:   r.characterName,
+			Val: r.combinedAssets,
+		})
+		total += r.combinedAssets
+	}
 	d = reduceCategoricalPoints(d, wealthMaxCharacters)
 
 	fyne.Do(func() {
@@ -214,19 +219,23 @@ func (a *Wealth) updateAssetDetail(_ context.Context, rows []wealthRow, totalAss
 			slog.Error("wealth: asset details", "error", err)
 			return
 		}
-		a.assetDetail.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", totalAssets))
+		a.assetDetail.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", total))
 	})
 }
 
-func (a *Wealth) updateAssetSplit(_ context.Context, rows []wealthRow, totalAssets float64) {
+func (a *Wealth) updateAssetSplit(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
-	d := xslices.Map(rows, func(r wealthRow) data.ProportionalPoint {
-		return data.ProportionalPoint{
-			C:       r.character,
-			Val:     r.assets,
+	var total float64
+	var d []data.ProportionalPoint
+	for _, r := range rows {
+		d = append(d, data.ProportionalPoint{
+			C:       r.characterName,
+			Val:     r.combinedAssets,
 			ColName: colors.next(),
-		}
-	})
+		})
+		total += r.combinedAssets
+	}
+
 	d = reduceProportionalPoints(d, wealthMaxCharacters)
 	fyne.Do(func() {
 		a.assetSplit.RemoveSeries("Characters")
@@ -241,19 +250,22 @@ func (a *Wealth) updateAssetSplit(_ context.Context, rows []wealthRow, totalAsse
 			slog.Error("wealth: asset split", "error", err)
 			return
 		}
-		a.assetSplit.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", totalAssets))
+		a.assetSplit.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", total))
 	})
 }
 
-func (a *Wealth) updateCharacterSplit(_ context.Context, rows []wealthRow, totalAssets float64, totalWallet float64) {
+func (a *Wealth) updateCharacterSplit(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
-	d := xslices.Map(rows, func(r wealthRow) data.ProportionalPoint {
-		return data.ProportionalPoint{
-			C:       r.character,
-			Val:     r.assets,
+	var total float64
+	var d []data.ProportionalPoint
+	for _, r := range rows {
+		d = append(d, data.ProportionalPoint{
+			C:       r.characterName,
+			Val:     r.total,
 			ColName: colors.next(),
-		}
-	})
+		})
+		total += r.total
+	}
 	d = reduceProportionalPoints(d, wealthMaxCharacters)
 	fyne.Do(func() {
 		a.characterSplit.RemoveSeries("Characters")
@@ -268,21 +280,37 @@ func (a *Wealth) updateCharacterSplit(_ context.Context, rows []wealthRow, total
 			slog.Error("wealth: character split", "error", err)
 			return
 		}
-		a.characterSplit.SetTitle(fmt.Sprintf("Wealth By Character - Total: %.1f B ISK", totalAssets+totalWallet))
+		a.characterSplit.SetTitle(fmt.Sprintf("Total Net Worth By Character - Total: %.1f B ISK", total))
 	})
 }
 
-func (a *Wealth) updateTotalSplit(_ context.Context, totalAssets float64, totalWallet float64) {
+func (a *Wealth) updateTotalSplit(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
+	var assets, wallets, contracts, orders, total float64
+	for _, r := range rows {
+		assets += r.combinedAssets
+		contracts += r.contractsEscrow
+		orders += r.ordersEscrow
+		total += r.total
+		wallets += r.walletBalance
+	}
 	fyne.Do(func() {
 		a.totalSplit.RemoveSeries("")
 		s, err := prop.NewSeries("", []data.ProportionalPoint{{
-			C:       "Assets combined",
-			Val:     totalAssets,
+			C:       "Wallet Balances",
+			Val:     wallets,
 			ColName: colors.next(),
 		}, {
-			C:       "Wallets combined",
-			Val:     totalWallet,
+			C:       "Combined Assets",
+			Val:     assets,
+			ColName: colors.next(),
+		}, {
+			C:       "Contracts Escrow",
+			Val:     contracts,
+			ColName: colors.next(),
+		}, {
+			C:       "Orders Escrow",
+			Val:     orders,
 			ColName: colors.next(),
 		}})
 		if err != nil {
@@ -295,19 +323,22 @@ func (a *Wealth) updateTotalSplit(_ context.Context, totalAssets float64, totalW
 			slog.Error("wealth: total split", "error", err)
 			return
 		}
-		title := fmt.Sprintf("Wealth By Source - Total: %.1f B ISK", totalWallet+totalAssets)
+		title := fmt.Sprintf("Total Net Worth By Category - Total: %.1f B ISK", total)
 		a.totalSplit.SetTitle(title)
 	})
 }
 
-func (a *Wealth) updateWalletDetail(_ context.Context, rows []wealthRow, totalWallet float64) {
+func (a *Wealth) updateWalletDetail(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
-	d := xslices.Map(rows, func(r wealthRow) data.CategoricalPoint {
-		return data.CategoricalPoint{
-			C:   r.character,
-			Val: r.wallet,
-		}
-	})
+	var total float64
+	var d []data.CategoricalPoint
+	for _, r := range rows {
+		d = append(d, data.CategoricalPoint{
+			C:   r.characterName,
+			Val: r.walletBalance,
+		})
+		total += r.walletBalance
+	}
 	d = reduceCategoricalPoints(d, wealthMaxCharacters)
 	fyne.Do(func() {
 		a.walletDetail.RemoveSeries("Characters")
@@ -322,19 +353,22 @@ func (a *Wealth) updateWalletDetail(_ context.Context, rows []wealthRow, totalWa
 			slog.Error("wealth: wallet details", "error", err)
 			return
 		}
-		a.walletDetail.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", totalWallet))
+		a.walletDetail.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", total))
 	})
 }
 
-func (a *Wealth) updateWalletSplit(_ context.Context, rows []wealthRow, totalWallet float64) {
+func (a *Wealth) updateWalletSplit(_ context.Context, rows []wealthRow) {
 	colors := newColorWheel()
-	d := xslices.Map(rows, func(r wealthRow) data.ProportionalPoint {
-		return data.ProportionalPoint{
-			C:       r.character,
-			Val:     r.wallet,
+	var total float64
+	var d []data.ProportionalPoint
+	for _, r := range rows {
+		d = append(d, data.ProportionalPoint{
+			C:       r.characterName,
+			Val:     r.walletBalance,
 			ColName: colors.next(),
-		}
-	})
+		})
+		total += r.total
+	}
 	d = reduceProportionalPoints(d, wealthMaxCharacters)
 	fyne.Do(func() {
 		a.walletSplit.RemoveSeries("Characters")
@@ -349,7 +383,7 @@ func (a *Wealth) updateWalletSplit(_ context.Context, rows []wealthRow, totalWal
 			slog.Error("wealth: wallet split", "error", err)
 			return
 		}
-		a.walletSplit.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", totalWallet))
+		a.walletSplit.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", total))
 	})
 }
 
@@ -404,49 +438,34 @@ func reduceCategoricalPoints(rows []data.CategoricalPoint, m int) []data.Categor
 	return rows
 }
 
-func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, int, error) {
+func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, error) {
 	cc, err := a.u.Character().ListCharacters(ctx)
 	if err != nil {
-		return nil, 0, err
-	}
-	var selected []*app.Character
-	for _, c := range cc {
-		hasAssets, err := a.u.Character().HasSection(ctx, c.ID, app.SectionCharacterAssets)
-		if err != nil {
-			return nil, 0, err
-		}
-		hasWallet, err := a.u.Character().HasSection(ctx, c.ID, app.SectionCharacterWalletBalance)
-		if err != nil {
-			return nil, 0, err
-		}
-		if hasAssets && hasWallet {
-			selected = append(selected, c)
-		}
+		return nil, err
 	}
 	var rows []wealthRow
-	for _, c := range selected {
-		assetTotal, err := a.u.Character().AssetTotalValue(ctx, c.ID)
-		if err != nil {
-			return nil, 0, err
-		}
-		if c.WalletBalance.IsEmpty() && assetTotal.IsEmpty() {
+	for _, c := range cc {
+		combinedAssets := c.CombinedAssetsValue()
+		total := optional.Sum(c.WalletBalance, combinedAssets, c.ContractsEscrow, c.OrdersEscrow)
+		if total.IsEmpty() {
 			continue
 		}
-		character := TruncateWithSuffix(c.EveCharacter.Name, wealthNameTruncationLimit, wealthNameTruncationSuffix)
-		wallet := c.WalletBalance.ValueOrZero() / wealthMultiplier
-		assets := assetTotal.ValueOrZero() / wealthMultiplier
+		name := TruncateWithSuffix(c.EveCharacter.Name, wealthNameTruncationLimit, wealthNameTruncationSuffix)
 		r := wealthRow{
-			character: character,
-			assets:    assets,
-			wallet:    wallet,
-			total:     assets + wallet,
+			characterID:     c.ID,
+			characterName:   name,
+			combinedAssets:  combinedAssets.ValueOrZero() / wealthMultiplier,
+			contractsEscrow: c.ContractsEscrow.ValueOrZero() / wealthMultiplier,
+			ordersEscrow:    c.OrdersEscrow.ValueOrZero() / wealthMultiplier,
+			total:           total.ValueOrZero() / wealthMultiplier,
+			walletBalance:   c.WalletBalance.ValueOrZero() / wealthMultiplier,
 		}
 		rows = append(rows, r)
 	}
 	slices.SortFunc(rows, func(a, b wealthRow) int {
-		return strings.Compare(a.character, b.character)
+		return strings.Compare(a.characterName, b.characterName)
 	})
-	return rows, len(selected), nil
+	return rows, nil
 }
 
 type colorWheel struct {

--- a/internal/app/ui/wallets/wealth.go
+++ b/internal/app/ui/wallets/wealth.go
@@ -45,13 +45,11 @@ type Wealth struct {
 	OnUpdate func(wallet, assets float64)
 
 	assetDetail          *coord.CartesianCategoricalChart
-	assetSplit           *prop.PieChart
 	characterSplit       *prop.PieChart
 	top                  *widget.Label
 	totalSplit           *prop.PieChart
 	u                    baseUI
 	walletDetail         *coord.CartesianCategoricalChart
-	walletSplit          *prop.PieChart
 	defaultPieLabelStyle style.ValueLabelStyle
 	defaultBarLabelStyle style.ValueLabelStyle
 	overview             *Overview
@@ -60,13 +58,11 @@ type Wealth struct {
 func NewWealth(u baseUI) *Wealth {
 	a := &Wealth{
 		assetDetail:    coord.NewCartesianCategoricalChart(""),
-		assetSplit:     prop.NewPieChart(""),
 		characterSplit: prop.NewPieChart(""),
 		top:            ui.NewLabelWithWrapping(""),
 		totalSplit:     prop.NewPieChart(""),
 		u:              u,
 		walletDetail:   coord.NewCartesianCategoricalChart(""),
-		walletSplit:    prop.NewPieChart(""),
 		overview:       NewOverview(u),
 	}
 	a.ExtendBaseWidget(a)
@@ -82,8 +78,6 @@ func NewWealth(u baseUI) *Wealth {
 	a.assetDetail.HideLegend()
 	a.assetDetail.SetYAxisStyle(yls, style.DefaultAxisStyle())
 	a.assetDetail.SetYAxisLabel("B ISK")
-	a.assetSplit.SetTitleStyle(ts)
-	a.walletSplit.SetTitleStyle(ts)
 	a.walletDetail.SetTitleStyle(ts)
 	a.walletDetail.HideLegend()
 	a.walletDetail.SetYAxisStyle(yls, style.DefaultAxisStyle())
@@ -131,10 +125,6 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 			"Total",
 			container.NewAdaptiveGrid(2, a.totalSplit, a.characterSplit),
 		),
-		container.NewTabItem(
-			"Breakdown",
-			container.NewAdaptiveGrid(2, a.assetSplit, a.walletSplit),
-		),
 		container.NewTabItem("Assets", a.assetDetail),
 		container.NewTabItem("Wallets", a.walletDetail),
 	)
@@ -180,11 +170,9 @@ func (a *Wealth) update(ctx context.Context) {
 	})
 
 	a.updateAssetDetail(ctx, rows)
-	a.updateAssetSplit(ctx, rows)
 	a.updateCharacterSplit(ctx, rows)
 	a.updateTotalSplit(ctx, rows)
 	a.updateWalletDetail(ctx, rows)
-	a.updateWalletSplit(ctx, rows)
 
 	fyne.Do(func() {
 		if a.OnUpdate != nil {
@@ -220,37 +208,6 @@ func (a *Wealth) updateAssetDetail(_ context.Context, rows []wealthRow) {
 			return
 		}
 		a.assetDetail.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", total))
-	})
-}
-
-func (a *Wealth) updateAssetSplit(_ context.Context, rows []wealthRow) {
-	colors := newColorWheel()
-	var total float64
-	var d []data.ProportionalPoint
-	for _, r := range rows {
-		d = append(d, data.ProportionalPoint{
-			C:       r.characterName,
-			Val:     r.combinedAssets,
-			ColName: colors.next(),
-		})
-		total += r.combinedAssets
-	}
-
-	d = reduceProportionalPoints(d, wealthMaxCharacters)
-	fyne.Do(func() {
-		a.assetSplit.RemoveSeries("Characters")
-		s, err := prop.NewSeries("Characters", d)
-		if err != nil {
-			slog.Error("wealth: asset split", "error", err)
-			return
-		}
-		s.SetValueLabelStyle(true, a.defaultPieLabelStyle)
-		err = a.assetSplit.AddSeries(s)
-		if err != nil {
-			slog.Error("wealth: asset split", "error", err)
-			return
-		}
-		a.assetSplit.SetTitle(fmt.Sprintf("Assets By Character - Total: %.1f B ISK", total))
 	})
 }
 
@@ -354,36 +311,6 @@ func (a *Wealth) updateWalletDetail(_ context.Context, rows []wealthRow) {
 			return
 		}
 		a.walletDetail.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", total))
-	})
-}
-
-func (a *Wealth) updateWalletSplit(_ context.Context, rows []wealthRow) {
-	colors := newColorWheel()
-	var total float64
-	var d []data.ProportionalPoint
-	for _, r := range rows {
-		d = append(d, data.ProportionalPoint{
-			C:       r.characterName,
-			Val:     r.walletBalance,
-			ColName: colors.next(),
-		})
-		total += r.total
-	}
-	d = reduceProportionalPoints(d, wealthMaxCharacters)
-	fyne.Do(func() {
-		a.walletSplit.RemoveSeries("Characters")
-		s, err := prop.NewSeries("Characters", d)
-		if err != nil {
-			slog.Error("wealth: wallet split", "error", err)
-			return
-		}
-		s.SetValueLabelStyle(true, a.defaultPieLabelStyle)
-		err = a.walletSplit.AddSeries(s)
-		if err != nil {
-			slog.Error("wealth: wallet split", "error", err)
-			return
-		}
-		a.walletSplit.SetTitle(fmt.Sprintf("Wallets By Character - Total: %.1f B ISK", total))
 	})
 }
 

--- a/internal/app/ui/wallets/wealth.go
+++ b/internal/app/ui/wallets/wealth.go
@@ -29,6 +29,13 @@ const (
 	wealthNameTruncationSuffix = 2
 )
 
+type wealthRow struct {
+	character string
+	wallet    float64
+	assets    float64
+	total     float64
+}
+
 type Wealth struct {
 	widget.BaseWidget
 
@@ -44,6 +51,7 @@ type Wealth struct {
 	walletSplit          *prop.PieChart
 	defaultPieLabelStyle style.ValueLabelStyle
 	defaultBarLabelStyle style.ValueLabelStyle
+	overview             *Overview
 }
 
 func NewWealth(u baseUI) *Wealth {
@@ -56,6 +64,7 @@ func NewWealth(u baseUI) *Wealth {
 		u:              u,
 		walletDetail:   coord.NewCartesianCategoricalChart(""),
 		walletSplit:    prop.NewPieChart(""),
+		overview:       NewOverview(u),
 	}
 	a.ExtendBaseWidget(a)
 	a.top.Hide()
@@ -96,13 +105,20 @@ func NewWealth(u baseUI) *Wealth {
 			a.Update(ctx)
 		}
 	})
+	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
+		a.Update(ctx)
+	})
+	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
+		a.Update(ctx)
+	})
 	return a
 }
 
 func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 	tabs := container.NewAppTabs(
+		container.NewTabItem("Characters", a.overview),
 		container.NewTabItem(
-			"Total",
+			"Overview",
 			container.NewAdaptiveGrid(2, a.totalSplit, a.characterSplit),
 		),
 		container.NewTabItem(
@@ -128,6 +144,7 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (a *Wealth) Update(ctx context.Context) {
+	go a.overview.Update(ctx)
 	rows, characters, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to fetch data for charts", "err", err)
@@ -383,13 +400,6 @@ func reduceCategoricalPoints(rows []data.CategoricalPoint, m int) []data.Categor
 			Val: others,
 		})
 	return rows
-}
-
-type wealthRow struct {
-	character string
-	wallet    float64
-	assets    float64
-	total     float64
 }
 
 func (a *Wealth) fetchData(ctx context.Context) ([]wealthRow, int, error) {

--- a/internal/app/ui/wallets/wealth.go
+++ b/internal/app/ui/wallets/wealth.go
@@ -94,22 +94,25 @@ func NewWealth(u baseUI) *Wealth {
 	a.defaultBarLabelStyle = ls
 
 	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
 	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
 		switch arg.Section {
 		case app.SectionCharacterAssets, app.SectionCharacterWalletBalance:
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().EveUniverseSectionChanged.AddListener(func(ctx context.Context, arg app.EveUniverseSectionUpdated) {
 		if arg.Section == app.SectionEveMarketPrices {
-			a.Update(ctx)
+			a.update(ctx)
 		}
 	})
 	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
-		a.Update(ctx)
+		a.update(ctx)
 	})
 	return a
 }
@@ -143,8 +146,7 @@ func (a *Wealth) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(c)
 }
 
-func (a *Wealth) Update(ctx context.Context) {
-	go a.overview.Update(ctx)
+func (a *Wealth) update(ctx context.Context) {
 	rows, characters, err := a.fetchData(ctx)
 	if err != nil {
 		slog.Error("Failed to fetch data for charts", "err", err)

--- a/internal/optional/optional.go
+++ b/internal/optional/optional.go
@@ -259,19 +259,32 @@ func FlatMap[X, Y any](o Optional[X], mapper func(v X) Optional[Y]) Optional[Y] 
 }
 
 // Sum returns the sum of values v.
-// Empty values are added with their zero value (e.g. 0).
-// When all values are empty it returns an empty value.
+// When any value is empty it returns an empty value.
+// The behavior is models after SQL's SUM of nullable values.
 func Sum[T numeric](v ...Optional[T]) Optional[T] {
-	var s T
-	var isPresent bool
+	var s Optional[T]
 	for _, u := range v {
+		if !u.isPresent {
+			return Optional[T]{}
+		}
+		s.value += u.value
+		s.isPresent = true
+	}
+	return s
+}
+
+// SumNonEmpty returns the sum of non-empty values v.
+// Empty values are ignored.
+// When all values are empty it returns an empty value.
+func SumNonEmpty[T numeric](v ...Optional[T]) Optional[T] {
+	var s Optional[T]
+	for _, u := range v {
+		var v T
 		if u.isPresent {
-			s += u.value
-			isPresent = true
+			v = u.value
+			s.isPresent = true
+			s.value += v
 		}
 	}
-	if !isPresent {
-		return Optional[T]{}
-	}
-	return New(s)
+	return s
 }

--- a/internal/optional/optional_test.go
+++ b/internal/optional/optional_test.go
@@ -225,12 +225,27 @@ func TestSum(t *testing.T) {
 		a, b, want optional.Optional[int]
 	}{
 		{optional.New(5), optional.New(3), optional.New(8)},
+		{optional.New(5), optional.Optional[int]{}, optional.Optional[int]{}},
+		{optional.Optional[int]{}, optional.New(5), optional.Optional[int]{}},
+		{optional.Optional[int]{}, optional.Optional[int]{}, optional.Optional[int]{}},
+	}
+	for _, tc := range cases {
+		got := optional.Sum(tc.a, tc.b)
+		xassert.Equal(t, tc.want, got)
+	}
+}
+
+func TestSumNonEmpty(t *testing.T) {
+	cases := []struct {
+		a, b, want optional.Optional[int]
+	}{
+		{optional.New(5), optional.New(3), optional.New(8)},
 		{optional.New(5), optional.Optional[int]{}, optional.New(5)},
 		{optional.Optional[int]{}, optional.New(5), optional.New(5)},
 		{optional.Optional[int]{}, optional.Optional[int]{}, optional.Optional[int]{}},
 	}
 	for _, tc := range cases {
-		got := optional.Sum(tc.a, tc.b)
+		got := optional.SumNonEmpty(tc.a, tc.b)
 		xassert.Equal(t, tc.want, got)
 	}
 }

--- a/internal/optional/optional_test.go
+++ b/internal/optional/optional_test.go
@@ -233,6 +233,8 @@ func TestSum(t *testing.T) {
 		got := optional.Sum(tc.a, tc.b)
 		xassert.Equal(t, tc.want, got)
 	}
+
+	xassert.Equal(t, optional.Optional[int]{}, optional.Sum[int]())
 }
 
 func TestSumNonEmpty(t *testing.T) {
@@ -248,6 +250,8 @@ func TestSumNonEmpty(t *testing.T) {
 		got := optional.SumNonEmpty(tc.a, tc.b)
 		xassert.Equal(t, tc.want, got)
 	}
+
+	xassert.Equal(t, optional.Optional[int]{}, optional.Sum[int]())
 }
 
 func TestFromPointerOptional(t *testing.T) {

--- a/tools/fakechars/builder.go
+++ b/tools/fakechars/builder.go
@@ -257,7 +257,7 @@ func (b *CharacterBuilder) createAssets() {
 			b.f.CreateCharacterAsset(storage.CreateCharacterAssetParams{
 				CharacterID: b.character.ID,
 				LocationID:  locationID,
-				EveTypeID:   b.randomType().ID,
+				TypeID:   b.randomType().ID,
 			})
 		}
 		printProgress("assets", len(b.locations), i)


### PR DESCRIPTION
- Added new tab to wealth sections that lists the total net worth of each character with a breakdown in categories
- Widgets are now initialized via signal at app start instead of direct function calls
- The wealth list now shows the total net worth of characters, similar to the in-game [Total Net Worth Indicator](https://support.eveonline.com/hc/en-us/articles/115002091569-Total-Net-Worth-Indicator). The values should be roughly the same, with the exception of PLEX value, which EVE Buddy can not include.
- The wealth list also shows the estimated extraction value of a character's skill points
- Removed the "Breakdown" pie charts at it was just a variant of showing the same information as in the bar charts
- Now also shows the total net worth of all characters in the respective navigation menu item on desktop

Closes #432 