### PR TITLE
feat# 309 Clipboard Export for Pyfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A multi-platform companion app for Eve Online players available on Windows, Linu
 
 EVE Buddy is a multi-platform companion app for [Eve Online](https://www.eveonline.com/) players. It provides the following key features:
 
-- **Character monitor**: Check current information about each of your characters, e.g. inspect the training queue of a character or browse it's assets.
+- **Character monitor**: Check current information about each of your characters, e.g. inspect the training queue of a character or browse it's assets. Export trained skills to clipboard in [PyFA](https://github.com/pyfa-org/Pyfa)-compatible format or to a CSV file (Windows and macOS).
 - **Corporation monitor**: Check current information about each of your corporations: e.g. check wallets and assets.
 - **Overviews**: Keep track of and get unique insights about all your characters and corporations with consolidated views, e.g. find assets across of your characters or see which character has manufacturing slots available.
 - **Notifications**: Get notified on your desktop or mobile about new EVE communications and other important updates, e.g. a structure was attacked or a training queue became empty.
@@ -89,7 +89,9 @@ The following is a detailed list of EVE Buddy's features. Most features are avai
   - Clones: Current augmentations, jump clones & jump cooldown timer
   - Communications: Browse through all communications
   - Mails: Browser through all mails
-  - Skills: Training queue, catalogue of all trained skills and what ships can be flown
+  - Skills: Training queue, catalogue of all trained skills and what ships can be flown, and export trained skills to clipboard or CSV (desktop only)
+    - **Copy to clipboard**: Copies all trained skills in [PyFA](https://github.com/pyfa-org/Pyfa)-compatible plain-text format (`Skill Name Level`, one per line) so they can be pasted directly into PyFA's character skill import.
+    - **Export to CSV**: Saves all trained skills to a `.csv` file with `Name` and `Level` columns for use in spreadsheets or other tools.
   - Wallet: Wallet and market Transactions
 
 - **Corporation monitor**: Check current information about each of your corporations: (depending on their roles)

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -24,7 +24,7 @@ import (
 
 const cacheKeyTrainingNotified = "expired-training-notified"
 
-type SkillExportItem struct {
+type skillExportItem struct {
 	Name  string
 	Level int64
 }
@@ -213,23 +213,23 @@ func (s *CharacterService) ListSkills(ctx context.Context, characterID int64) ([
 	return skills2, nil
 }
 
-// GetSkillsForExport returns active skills sorted by name for export.
-func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID int64) ([]SkillExportItem, error) {
+// getSkillsForExport returns active skills sorted by name for export.
+func (s *CharacterService) getSkillsForExport(ctx context.Context, characterID int64) ([]skillExportItem, error) {
 	skills, err := s.ListSkills(ctx, characterID)
 	if err != nil {
 		return nil, err
 	}
-	items := make([]SkillExportItem, 0, len(skills))
+	items := make([]skillExportItem, 0, len(skills))
 	for _, o := range skills {
 		if o.ActiveSkillLevel == 0 {
 			continue
 		}
-		items = append(items, SkillExportItem{
+		items = append(items, skillExportItem{
 			Name:  o.Skill.Type.Name,
 			Level: o.ActiveSkillLevel,
 		})
 	}
-	slices.SortFunc(items, func(a, b SkillExportItem) int {
+	slices.SortFunc(items, func(a, b skillExportItem) int {
 		return strings.Compare(a.Name, b.Name)
 	})
 	return items, nil
@@ -237,20 +237,20 @@ func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID i
 
 // MakeSkillsExportLines returns PyFA-compatible export lines from active skills.
 func (s *CharacterService) MakeSkillsExportLines(ctx context.Context, characterID int64) (string, error) {
-	items, err := s.GetSkillsForExport(ctx, characterID)
+	items, err := s.getSkillsForExport(ctx, characterID)
 	if err != nil {
 		return "", err
 	}
 	var sb strings.Builder
 	for _, r := range items {
-		sb.WriteString(fmt.Sprintf("%s %d\n", r.Name, r.Level))
+		fmt.Fprintf(&sb, "%s %d\n", r.Name, r.Level)
 	}
 	return sb.String(), nil
 }
 
 // WriteSkillsExportCSV writes active skills as CSV to the provided writer.
 func (s *CharacterService) WriteSkillsExportCSV(ctx context.Context, characterID int64, w io.Writer) error {
-	items, err := s.GetSkillsForExport(ctx, characterID)
+	items, err := s.getSkillsForExport(ctx, characterID)
 	if err != nil {
 		return err
 	}

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -213,7 +213,7 @@ func (s *CharacterService) ListSkills(ctx context.Context, characterID int64) ([
 	return skills2, nil
 }
 
-// GetSkillsForExport returns trained skills sorted by name for export.
+// GetSkillsForExport returns active skills sorted by name for export.
 func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID int64) ([]SkillExportItem, error) {
 	skills, err := s.ListSkills(ctx, characterID)
 	if err != nil {
@@ -221,12 +221,12 @@ func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID i
 	}
 	items := make([]SkillExportItem, 0, len(skills))
 	for _, o := range skills {
-		if o.TrainedSkillLevel == 0 {
+		if o.ActiveSkillLevel == 0 {
 			continue
 		}
 		items = append(items, SkillExportItem{
 			Name:  o.Skill.Type.Name,
-			Level: o.TrainedSkillLevel,
+			Level: o.ActiveSkillLevel,
 		})
 	}
 	slices.SortFunc(items, func(a, b SkillExportItem) int {
@@ -235,7 +235,7 @@ func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID i
 	return items, nil
 }
 
-// MakeSkillsExportLines returns PyFA-compatible export lines from trained skills.
+// MakeSkillsExportLines returns PyFA-compatible export lines from active skills.
 func (s *CharacterService) MakeSkillsExportLines(ctx context.Context, characterID int64) (string, error) {
 	items, err := s.GetSkillsForExport(ctx, characterID)
 	if err != nil {
@@ -248,7 +248,7 @@ func (s *CharacterService) MakeSkillsExportLines(ctx context.Context, characterI
 	return sb.String(), nil
 }
 
-// WriteSkillsExportCSV writes trained skills as CSV to the provided writer.
+// WriteSkillsExportCSV writes active skills as CSV to the provided writer.
 func (s *CharacterService) WriteSkillsExportCSV(ctx context.Context, characterID int64, w io.Writer) error {
 	items, err := s.GetSkillsForExport(ctx, characterID)
 	if err != nil {

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -2,8 +2,10 @@ package characterservice
 
 import (
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"slices"
@@ -21,6 +23,11 @@ import (
 )
 
 const cacheKeyTrainingNotified = "expired-training-notified"
+
+type SkillExportItem struct {
+	Name  string
+	Level int64
+}
 
 func (s *CharacterService) GetAttributes(ctx context.Context, characterID int64) (*app.CharacterAttributes, error) {
 	return s.st.GetCharacterAttributes(ctx, characterID)
@@ -204,6 +211,63 @@ func (s *CharacterService) ListSkills(ctx context.Context, characterID int64) ([
 		skills2 = append(skills2, o)
 	}
 	return skills2, nil
+}
+
+// GetSkillsForExport returns trained skills sorted by name for export.
+func (s *CharacterService) GetSkillsForExport(ctx context.Context, characterID int64) ([]SkillExportItem, error) {
+	skills, err := s.ListSkills(ctx, characterID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]SkillExportItem, 0, len(skills))
+	for _, o := range skills {
+		if o.TrainedSkillLevel == 0 {
+			continue
+		}
+		items = append(items, SkillExportItem{
+			Name:  o.Skill.Type.Name,
+			Level: o.TrainedSkillLevel,
+		})
+	}
+	slices.SortFunc(items, func(a, b SkillExportItem) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return items, nil
+}
+
+// MakeSkillsExportLines returns PyFA-compatible export lines from trained skills.
+func (s *CharacterService) MakeSkillsExportLines(ctx context.Context, characterID int64) (string, error) {
+	items, err := s.GetSkillsForExport(ctx, characterID)
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	for _, r := range items {
+		sb.WriteString(fmt.Sprintf("%s %d\n", r.Name, r.Level))
+	}
+	return sb.String(), nil
+}
+
+// WriteSkillsExportCSV writes trained skills as CSV to the provided writer.
+func (s *CharacterService) WriteSkillsExportCSV(ctx context.Context, characterID int64, w io.Writer) error {
+	items, err := s.GetSkillsForExport(ctx, characterID)
+	if err != nil {
+		return err
+	}
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"Name", "Level"}); err != nil {
+		return err
+	}
+	for _, r := range items {
+		if err := cw.Write([]string{r.Name, fmt.Sprintf("%d", r.Level)}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *CharacterService) updateSkillsESI(ctx context.Context, arg characterSectionUpdateParams) (bool, error) {

--- a/internal/app/characterservice/skills_test.go
+++ b/internal/app/characterservice/skills_test.go
@@ -247,48 +247,6 @@ func TestCharacterService_ListSkills(t *testing.T) {
 	})
 }
 
-func TestCharacterService_GetSkillsForExport(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
-	defer db.Close()
-	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	t.Run("should return only active skills sorted by name", func(t *testing.T) {
-		// given
-		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
-		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
-		skillA := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5001, GroupID: group.ID, Name: "Zeta Skill", IsPublished: true})
-		skillB := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
-		skillC := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5003, GroupID: group.ID, Name: "Beta Skill", IsPublished: true})
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skillA.ID,
-			ActiveSkillLevel: 5,
-		}))
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skillB.ID,
-			ActiveSkillLevel: 3,
-		}))
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skillC.ID,
-			ActiveSkillLevel: 0,
-		}))
-
-		// when
-		items, err := cs.GetSkillsForExport(t.Context(), c.ID)
-
-		// then
-		require.NoError(t, err)
-		require.Len(t, items, 2)
-		xassert.Equal(t, "Alpha Skill", items[0].Name)
-		xassert.Equal(t, int64(3), items[0].Level)
-		xassert.Equal(t, "Zeta Skill", items[1].Name)
-		xassert.Equal(t, int64(5), items[1].Level)
-	})
-}
-
 func TestCharacterService_MakeSkillsExportLines(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/characterservice/skills_test.go
+++ b/internal/app/characterservice/skills_test.go
@@ -251,7 +251,7 @@ func TestCharacterService_GetSkillsForExport(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	t.Run("should return only trained skills sorted by name", func(t *testing.T) {
+	t.Run("should return only active skills sorted by name", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		c := factory.CreateCharacter()
@@ -261,19 +261,19 @@ func TestCharacterService_GetSkillsForExport(t *testing.T) {
 		skillB := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
 		skillC := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5003, GroupID: group.ID, Name: "Beta Skill", IsPublished: true})
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skillA.ID,
-			TrainedSkillLevel: 5,
+			CharacterID:      c.ID,
+			TypeID:           skillA.ID,
+			ActiveSkillLevel: 5,
 		}))
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skillB.ID,
-			TrainedSkillLevel: 3,
+			CharacterID:      c.ID,
+			TypeID:           skillB.ID,
+			ActiveSkillLevel: 3,
 		}))
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skillC.ID,
-			TrainedSkillLevel: 0,
+			CharacterID:      c.ID,
+			TypeID:           skillC.ID,
+			ActiveSkillLevel: 0,
 		}))
 
 		// when
@@ -302,14 +302,14 @@ func TestCharacterService_MakeSkillsExportLines(t *testing.T) {
 		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
 		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6002, GroupID: group.ID, Name: "Delta Skill", IsPublished: true})
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skill1.ID,
-			TrainedSkillLevel: 4,
+			CharacterID:      c.ID,
+			TypeID:           skill1.ID,
+			ActiveSkillLevel: 4,
 		}))
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skill2.ID,
-			TrainedSkillLevel: 2,
+			CharacterID:      c.ID,
+			TypeID:           skill2.ID,
+			ActiveSkillLevel: 2,
 		}))
 
 		// when
@@ -325,7 +325,7 @@ func TestCharacterService_WriteSkillsExportCSV(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	t.Run("should write trained skills CSV with header", func(t *testing.T) {
+	t.Run("should write active skills CSV with header", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		c := factory.CreateCharacter()
@@ -334,14 +334,14 @@ func TestCharacterService_WriteSkillsExportCSV(t *testing.T) {
 		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
 		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skill1.ID,
-			TrainedSkillLevel: 4,
+			CharacterID:      c.ID,
+			TypeID:           skill1.ID,
+			ActiveSkillLevel: 4,
 		}))
 		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:       c.ID,
-			TypeID:            skill2.ID,
-			TrainedSkillLevel: 2,
+			CharacterID:      c.ID,
+			TypeID:           skill2.ID,
+			ActiveSkillLevel: 2,
 		}))
 
 		var b bytes.Buffer

--- a/internal/app/characterservice/skills_test.go
+++ b/internal/app/characterservice/skills_test.go
@@ -1,6 +1,7 @@
 package characterservice_test
 
 import (
+	"bytes"
 	"context"
 	"maps"
 	"testing"
@@ -243,5 +244,113 @@ func TestCharacterService_ListSkills(t *testing.T) {
 
 		o1 := m[es1.ID]
 		assert.False(t, o1.HasPrerequisites)
+	})
+}
+
+func TestCharacterService_GetSkillsForExport(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("should return only trained skills sorted by name", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
+		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
+		skillA := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5001, GroupID: group.ID, Name: "Zeta Skill", IsPublished: true})
+		skillB := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
+		skillC := factory.CreateEveType(storage.CreateEveTypeParams{ID: 5003, GroupID: group.ID, Name: "Beta Skill", IsPublished: true})
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skillA.ID,
+			TrainedSkillLevel: 5,
+		}))
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skillB.ID,
+			TrainedSkillLevel: 3,
+		}))
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skillC.ID,
+			TrainedSkillLevel: 0,
+		}))
+
+		// when
+		items, err := cs.GetSkillsForExport(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		xassert.Equal(t, "Alpha Skill", items[0].Name)
+		xassert.Equal(t, int64(3), items[0].Level)
+		xassert.Equal(t, "Zeta Skill", items[1].Name)
+		xassert.Equal(t, int64(5), items[1].Level)
+	})
+}
+
+func TestCharacterService_MakeSkillsExportLines(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("should return pyfa compatible lines", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
+		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
+		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
+		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6002, GroupID: group.ID, Name: "Delta Skill", IsPublished: true})
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skill1.ID,
+			TrainedSkillLevel: 4,
+		}))
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skill2.ID,
+			TrainedSkillLevel: 2,
+		}))
+
+		// when
+		text, err := cs.MakeSkillsExportLines(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, "Delta Skill 2\nGamma Skill 4\n", text)
+	})
+}
+
+func TestCharacterService_WriteSkillsExportCSV(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("should write trained skills CSV with header", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
+		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
+		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
+		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skill1.ID,
+			TrainedSkillLevel: 4,
+		}))
+		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID:       c.ID,
+			TypeID:            skill2.ID,
+			TrainedSkillLevel: 2,
+		}))
+
+		var b bytes.Buffer
+
+		// when
+		err := cs.WriteSkillsExportCSV(t.Context(), c.ID, &b)
+
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, "Name,Level\nAlpha Skill,2\nGamma Skill,4\n", b.String())
 	})
 }

--- a/internal/app/testutil/testdouble/testdouble.go
+++ b/internal/app/testutil/testdouble/testdouble.go
@@ -369,6 +369,12 @@ func (u *UIFake) ShowSnackbar(text string) {
 	}
 }
 
+func (u *UIFake) ShowSnackbarWithTimeout(text string, timeout time.Duration) {
+	if f := u.showSnackbarFunc; f != nil {
+		f(text)
+	}
+}
+
 func (u *UIFake) Signals() *app.Signals {
 	return u.signals
 }

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -676,6 +676,10 @@ func (u *baseUI) ShowSnackbar(text string) {
 	u.snackbar.Show(text)
 }
 
+func (u *baseUI) ShowSnackbarWithTimeout(text string, timeout time.Duration) {
+	u.snackbar.ShowWithTimeout(text, timeout)
+}
+
 func (u *baseUI) Signals() *app.Signals {
 	return u.signals
 }

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"cmp"
 	"context"
+	"encoding/csv"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -11,8 +12,11 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	kxdialog "github.com/ErikKalkoken/fyne-kx/dialog"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 
@@ -65,6 +69,7 @@ type Catalogue struct {
 	u              baseUI
 	sortButton     *xwidget.SortButton
 	columnSorter   *xwidget.ColumnSorter[skillRow]
+	exportButton   *xwidget.ContextMenuButton
 }
 
 func NewCatalogue(u baseUI) *Catalogue {
@@ -130,6 +135,17 @@ func NewCatalogue(u baseUI) *Catalogue {
 		a.filterRowsAsync()
 	}, a.u.MainWindow())
 
+	if !u.IsMobile() {
+		a.exportButton = xwidget.NewContextMenuButtonWithIcon("Export", theme.DownloadIcon(), fyne.NewMenu("",
+			fyne.NewMenuItem("Copy to clipboard", func() {
+				a.copySkillsToClipboard()
+			}),
+			fyne.NewMenuItem("Export to CSV", func() {
+				a.exportSkillsToCSV()
+			}),
+		))
+	}
+
 	// signals
 	a.u.Signals().CurrentCharacterExchanged.AddListener(func(ctx context.Context, c *app.Character) {
 		a.character.Store(c)
@@ -162,6 +178,7 @@ func (a *Catalogue) CreateRenderer() fyne.WidgetRenderer {
 		topBox.Add(a.search)
 		topBox.Add(container.NewHScroll(filter))
 	} else {
+		filter.Add(a.exportButton)
 		topBox.Add(container.NewBorder(nil, nil, filter, nil, a.search))
 	}
 	c := container.NewBorder(
@@ -424,4 +441,92 @@ func makeGridOrList(isMobile bool, length func() int, makeCreateItem func(trunc 
 		})
 	}
 	return w
+}
+
+// makeExportLines returns a PyFA-compatible text with one trained skill per line
+// in the format "SkillName Level" (e.g. "Spaceship Command 5"), sorted by name.
+// Only skills with a trained level > 0 are included.
+func (a *Catalogue) makeExportLines() string {
+	rows := slices.Clone(a.rows)
+	rows = slices.DeleteFunc(rows, func(r skillRow) bool {
+		return r.levelTrained == 0
+	})
+	slices.SortFunc(rows, func(x, y skillRow) int {
+		return strings.Compare(x.name, y.name)
+	})
+	var sb strings.Builder
+	for _, r := range rows {
+		sb.WriteString(fmt.Sprintf("%s %d\n", r.name, r.levelTrained))
+	}
+	return sb.String()
+}
+
+func (a *Catalogue) copySkillsToClipboard() {
+	fyne.CurrentApp().Clipboard().SetContent(a.makeExportLines())
+	a.u.ShowSnackbar("Skills copied to clipboard")
+}
+
+func (a *Catalogue) exportSkillsToCSV() {
+	rows := slices.Clone(a.rows)
+	rows = slices.DeleteFunc(rows, func(r skillRow) bool {
+		return r.levelTrained == 0
+	})
+	slices.SortFunc(rows, func(x, y skillRow) int {
+		return strings.Compare(x.name, y.name)
+	})
+
+	// Use a dedicated window so the file browser is a native resizable OS window
+	// rather than a fixed-size overlay on the main window.
+	w := fyne.CurrentApp().NewWindow("Export skills to CSV")
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		defer w.Close()
+		if writer == nil {
+			return
+		}
+		defer writer.Close()
+		if err != nil {
+			slog.Error("Failed to open file for skill export", "err", err)
+			return
+		}
+		cw := csv.NewWriter(writer)
+		if err := cw.Write([]string{"Name", "Level"}); err != nil {
+			slog.Error("Failed to write CSV header", "err", err)
+			return
+		}
+		for _, r := range rows {
+			if err := cw.Write([]string{r.name, fmt.Sprintf("%d", r.levelTrained)}); err != nil {
+				slog.Error("Failed to write CSV row", "err", err)
+				return
+			}
+		}
+		cw.Flush()
+		if err := cw.Error(); err != nil {
+			slog.Error("Failed to flush CSV writer", "err", err)
+			return
+		}
+		slog.Info("Skills exported to CSV", "uri", writer.URI())
+		a.u.ShowSnackbar("Skills exported to CSV")
+	}, w)
+	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
+	d.SetFileName("skills.csv")
+	kxdialog.AddDialogKeyHandler(d, w)
+	// dialogFillLayout propagates window resize events to the dialog overlay.
+	w.SetContent(container.New(&dialogFillLayout{d: d}))
+	w.Resize(fyne.NewSize(700, 500))
+	w.Show()
+	d.Show()
+}
+
+// dialogFillLayout is a fyne.Layout that resizes a dialog to match its
+// container whenever the container (and its parent window) is resized.
+type dialogFillLayout struct {
+	d dialog.Dialog
+}
+
+func (l *dialogFillLayout) Layout(_ []fyne.CanvasObject, size fyne.Size) {
+	l.d.Resize(size)
+}
+
+func (l *dialogFillLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
+	return fyne.NewSize(400, 300)
 }

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -140,7 +140,7 @@ func NewCatalogue(u baseUI) *Catalogue {
 			fyne.NewMenuItem("Copy to clipboard", func() {
 				a.copySkillsToClipboard()
 			}),
-			fyne.NewMenuItem("Export to CSV", func() {
+			fyne.NewMenuItem("Save as CSV", func() {
 				a.exportSkillsToCSV()
 			}),
 		))

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -144,7 +144,7 @@ func NewCatalogue(u baseUI) *Catalogue {
 			a.exportSkillsToCSV()
 		}),
 	))
-	a.exportButton.SetToolTip("Export Skills")
+	a.exportButton.SetToolTip("Export skills to clipboard or CSV file")
 
 	// signals
 	a.u.Signals().CurrentCharacterExchanged.AddListener(func(ctx context.Context, c *app.Character) {

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -3,16 +3,17 @@ package skills
 import (
 	"cmp"
 	"context"
-	"encoding/csv"
 	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -135,16 +136,15 @@ func NewCatalogue(u baseUI) *Catalogue {
 		a.filterRowsAsync()
 	}, a.u.MainWindow())
 
-	if !u.IsMobile() {
-		a.exportButton = xwidget.NewContextMenuButtonWithIcon("Export", theme.DownloadIcon(), fyne.NewMenu("",
-			fyne.NewMenuItem("Copy to clipboard", func() {
-				a.copySkillsToClipboard()
-			}),
-			fyne.NewMenuItem("Save as CSV", func() {
-				a.exportSkillsToCSV()
-			}),
-		))
-	}
+	a.exportButton = xwidget.NewContextMenuButtonWithIcon("Export", theme.DownloadIcon(), fyne.NewMenu("",
+		fyne.NewMenuItem("Copy to clipboard", func() {
+			a.copySkillsToClipboard()
+		}),
+		fyne.NewMenuItem("Save as CSV", func() {
+			a.exportSkillsToCSV()
+		}),
+	))
+	a.exportButton.SetToolTip("Export Skills")
 
 	// signals
 	a.u.Signals().CurrentCharacterExchanged.AddListener(func(ctx context.Context, c *app.Character) {
@@ -173,12 +173,14 @@ func NewCatalogue(u baseUI) *Catalogue {
 
 func (a *Catalogue) CreateRenderer() fyne.WidgetRenderer {
 	filter := container.NewHBox(a.selectGroup, a.selectMain, a.sortButton)
-	topBox := container.NewVBox(a.top)
+	topBox := container.NewVBox()
 	if a.u.IsMobile() {
+		topBox.Add(a.top)
 		topBox.Add(a.search)
 		topBox.Add(container.NewHScroll(filter))
 	} else {
-		filter.Add(a.exportButton)
+		topAligned := container.NewVBox(layout.NewSpacer(), a.top, layout.NewSpacer())
+		topBox.Add(container.NewBorder(nil, nil, nil, container.NewPadded(a.exportButton), topAligned))
 		topBox.Add(container.NewBorder(nil, nil, filter, nil, a.search))
 	}
 	c := container.NewBorder(
@@ -443,69 +445,53 @@ func makeGridOrList(isMobile bool, length func() int, makeCreateItem func(trunc 
 	return w
 }
 
-// makeExportLines returns a PyFA-compatible text with one trained skill per line
-// in the format "SkillName Level" (e.g. "Spaceship Command 5"), sorted by name.
-// Only skills with a trained level > 0 are included.
-func (a *Catalogue) makeExportLines() string {
-	rows := slices.Clone(a.rows)
-	rows = slices.DeleteFunc(rows, func(r skillRow) bool {
-		return r.levelTrained == 0
-	})
-	slices.SortFunc(rows, func(x, y skillRow) int {
-		return strings.Compare(x.name, y.name)
-	})
-	var sb strings.Builder
-	for _, r := range rows {
-		sb.WriteString(fmt.Sprintf("%s %d\n", r.name, r.levelTrained))
-	}
-	return sb.String()
-}
-
 func (a *Catalogue) copySkillsToClipboard() {
-	fyne.CurrentApp().Clipboard().SetContent(a.makeExportLines())
-	a.u.ShowSnackbar("Skills copied to clipboard")
+	characterID := a.character.Load().IDOrZero()
+	if characterID == 0 {
+		a.u.ShowSnackbar("No character")
+		return
+	}
+	text, err := a.u.Character().MakeSkillsExportLines(context.Background(), characterID)
+	if err != nil {
+		slog.Error("Failed to generate skill export lines", "characterID", characterID, "err", err)
+		a.u.ShowSnackbar("Failed to copy skills to clipboard")
+		return
+	}
+	fyne.CurrentApp().Clipboard().SetContent(text)
+	a.u.ShowSnackbarWithTimeout("Skills copied to clipboard", 1200*time.Millisecond)
 }
 
 func (a *Catalogue) exportSkillsToCSV() {
-	rows := slices.Clone(a.rows)
-	rows = slices.DeleteFunc(rows, func(r skillRow) bool {
-		return r.levelTrained == 0
-	})
-	slices.SortFunc(rows, func(x, y skillRow) int {
-		return strings.Compare(x.name, y.name)
-	})
+	characterID := a.character.Load().IDOrZero()
+	if characterID == 0 {
+		a.u.ShowSnackbar("No character")
+		return
+	}
 
 	// Use a dedicated window so the file browser is a native resizable OS window
 	// rather than a fixed-size overlay on the main window.
 	w := fyne.CurrentApp().NewWindow("Export skills to CSV")
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		defer w.Close()
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, saveErr error) {
 		if writer == nil {
+			w.Close()
 			return
 		}
+		if saveErr != nil {
+			w.Close()
+			slog.Error("Failed to open file for skill export", "err", saveErr)
+			a.u.ShowSnackbar("Failed to export skills to CSV")
+			return
+		}
+		// Close the dialog window right away so the main UI regains focus quickly.
+		w.Close()
 		defer writer.Close()
-		if err != nil {
-			slog.Error("Failed to open file for skill export", "err", err)
-			return
-		}
-		cw := csv.NewWriter(writer)
-		if err := cw.Write([]string{"Name", "Level"}); err != nil {
-			slog.Error("Failed to write CSV header", "err", err)
-			return
-		}
-		for _, r := range rows {
-			if err := cw.Write([]string{r.name, fmt.Sprintf("%d", r.levelTrained)}); err != nil {
-				slog.Error("Failed to write CSV row", "err", err)
-				return
-			}
-		}
-		cw.Flush()
-		if err := cw.Error(); err != nil {
-			slog.Error("Failed to flush CSV writer", "err", err)
+		if err := a.u.Character().WriteSkillsExportCSV(context.Background(), characterID, writer); err != nil {
+			slog.Error("Failed to write CSV skill export", "characterID", characterID, "err", err)
+			a.u.ShowSnackbar("Failed to export skills to CSV")
 			return
 		}
 		slog.Info("Skills exported to CSV", "uri", writer.URI())
-		a.u.ShowSnackbar("Skills exported to CSV")
+		a.u.ShowSnackbarWithTimeout("Skills exported to CSV", 1200*time.Millisecond)
 	}, w)
 	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
 	d.SetFileName("skills.csv")

--- a/internal/app/ui/skills/skills.go
+++ b/internal/app/ui/skills/skills.go
@@ -2,6 +2,8 @@
 package skills
 
 import (
+	"time"
+
 	"fyne.io/fyne/v2"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
@@ -23,5 +25,6 @@ type baseUI interface {
 	IsMobile() bool
 	MainWindow() fyne.Window
 	ShowSnackbar(text string)
+	ShowSnackbarWithTimeout(text string, timeout time.Duration)
 	Signals() *app.Signals
 }

--- a/tools/build_exe.ps1
+++ b/tools/build_exe.ps1
@@ -79,7 +79,7 @@ Write-Success "Working directory: $repoRoot"
 
 if (-not $SkipTests) {
     Write-Step "Running tests"
-    go test -test.short ./...
+    go test -short ./...
     if ($LASTEXITCODE -ne 0) {
         Write-Fail "Tests failed. Fix failures or use -SkipTests to skip."
         exit 1

--- a/tools/build_exe.ps1
+++ b/tools/build_exe.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Builds EVE Buddy for Windows desktop.
+
+.DESCRIPTION
+    Automates the build process for EVE Buddy on Windows.
+    Optionally runs tests, then produces either a development build or a
+    release-packaged executable with embedded icon and metadata.
+
+.PARAMETER Release
+    Build a release package using `fyne package` (produces EVE_Buddy.exe
+    with icon and version metadata embedded). Omit for a fast dev build.
+
+.PARAMETER SkipTests
+    Skip running `go test` before building.
+
+.EXAMPLE
+    # Fast dev build
+    .\tools\build_exe.ps1
+
+.EXAMPLE
+    # Release build, no tests
+    .\tools\build_exe.ps1 -Release -SkipTests
+
+.EXAMPLE
+    # Release build with tests
+    .\tools\build_exe.ps1 -Release
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Release,
+    [switch]$SkipTests
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Write-Step([string]$message) {
+    Write-Host "`n==> $message" -ForegroundColor Cyan
+}
+
+function Write-Success([string]$message) {
+    Write-Host "    $message" -ForegroundColor Green
+}
+
+function Write-Fail([string]$message) {
+    Write-Host "    ERROR: $message" -ForegroundColor Red
+}
+
+# ── Prereq checks ─────────────────────────────────────────────────────────────
+
+Write-Step "Checking prerequisites"
+
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
+    Write-Fail "Go not found. Install from https://go.dev/dl/"
+    exit 1
+}
+$goVersion = go version
+Write-Success "Found $goVersion"
+
+# Verify fyne tool is available via go tool directive
+$fyneCheck = go tool fyne version 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Fail "fyne tool not available. Run: go get fyne.io/tools/cmd/fyne"
+    exit 1
+}
+Write-Success "Found fyne tool"
+
+# ── Change to repo root ────────────────────────────────────────────────────────
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot   = Split-Path -Parent $scriptDir
+Set-Location $repoRoot
+Write-Success "Working directory: $repoRoot"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+if (-not $SkipTests) {
+    Write-Step "Running tests"
+    go test -test.short ./...
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Tests failed. Fix failures or use -SkipTests to skip."
+        exit 1
+    }
+    Write-Success "All tests passed"
+}
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+$tags = "migrated_fynedo"
+
+if ($Release) {
+    Write-Step "Building release package (fyne package)"
+    go tool fyne package --os windows --release --tags $tags
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Release build failed"
+        exit 1
+    }
+    $output = Get-ChildItem -Path $repoRoot -Filter "*.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    Write-Success "Release package ready: $($output.Name)"
+} else {
+    Write-Step "Building development binary (go build)"
+    go build -tags $tags -o evebuddy.exe .
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Build failed"
+        exit 1
+    }
+    Write-Success "Development binary ready: evebuddy.exe"
+}
+
+Write-Host "`nBuild complete." -ForegroundColor Green


### PR DESCRIPTION
Resolves: #309 

## Summary

Adds an **Export** button to the Skills Catalogue on Windows and macOS desktops. The button provides two export options via a drop-down menu:

- **Copy to clipboard** — copies all trained skills in [PyFA](https://github.com/pyfa-org/Pyfa)-compatible plain-text format so they can be pasted directly into PyFA's character skill import dialog.
- **Export to CSV** — opens a native, resizable file-save window and writes a standard CSV file for use in spreadsheets or other tools.

The feature is desktop-only (guarded by `IsMobile()`) and does not appear on Android.

## Export formats

### Clipboard (PyFA-compatible)

One trained skill per line, using the skill's full name and numeric level (0–5):

```
Caldari Cruiser 5
Missile Launcher Operation 4
Shield Upgrades 5
Thermodynamics 3
```

This matches PyFA's clipboard import spec (`rsplit(None, 1)` on each line), so pasting into PyFA's **Character → Import Skills** dialog works without any modification.

### CSV file

Standard comma-separated file with a header row:

```csv
Name,Level
Caldari Cruiser,5
Missile Launcher Operation,4
Shield Upgrades,5
Thermodynamics,3
```

Both formats export **all trained skills** (level > 0) for the currently selected character, sorted alphabetically by skill name. Active UI filters are intentionally ignored so the export always represents the full trained skill set.

## Changes

| File | Change |
|------|--------|
| `internal/app/ui/skills/catalogue.go` | Added `exportButton` field, `makeExportLines()`, `copySkillsToClipboard()`, `exportSkillsToCSV()` methods, `dialogFillLayout` type, and wired the button into `CreateRenderer()` |
| `README.md` | Documented the feature under Character monitor → Skills |
| `tools/build_exe.ps1` | New PowerShell script automating the Windows build (dev and release) |

## UI behaviour

- The **Export** button appears in the Skills Catalogue toolbar between the sort button and the search bar, desktop only.
- Clicking it shows a drop-down with **Copy to clipboard** and **Export to CSV**.
- After copying, a snackbar confirms: *"Skills copied to clipboard"*.
- The CSV file-save dialog opens in its own resizable OS window (700×500 default). A `dialogFillLayout` layout propagates window resize events to the dialog overlay so it always fills the window.
- After saving, a snackbar confirms: *"Skills exported to CSV"*.


### Skills View Update

<img width="1917" height="985" alt="skills_ui_update" src="https://github.com/user-attachments/assets/b9194e0f-af82-4f40-83be-29bbf4683b3a" />

### Skills Export Button Options (Copy to Clipboard/Save as CSV)

<img width="1918" height="980" alt="skills_ui_export_button_options" src="https://github.com/user-attachments/assets/b6715106-fbcb-4852-984c-4bb100743922" />


### Skills Save to CSV File Dialogue

<img width="1919" height="984" alt="skills_ui_export_save_file_dialogue" src="https://github.com/user-attachments/assets/c234e547-c7fd-47a4-b322-19e32a54651e" />

### Copy to Clipboard and import to PyFA Application (Tested)

<img width="1063" height="686" alt="pyfa_skills_import" src="https://github.com/user-attachments/assets/2d1e5ea5-9eb2-4729-8ebb-c74da6362dd4" />

### Copy to Clipboard and paste into plain text file (Tested)

<img width="1916" height="982" alt="skills_ui_paste_clipboard_plain_text" src="https://github.com/user-attachments/assets/8afbfbfc-4482-42bb-8269-77850ecc79fb" />


## Windows build script (`tools/build_exe.ps1`)

A PowerShell helper script has been added to make building on Windows straightforward during development and for producing release packages.

### Usage

```powershell
# Fast development build — produces evebuddy.exe via `go build`
.\tools\build_exe.ps1

# Development build, skip tests
.\tools\build_exe.ps1 -SkipTests

# Release package — produces a fully packaged exe with embedded icon and
# version metadata via `fyne package`
.\tools\build_exe.ps1 -Release

# Release build, skip tests
.\tools\build_exe.ps1 -Release -SkipTests
```

### What it does

| Step | Detail |
|------|--------|
| Prereq check | Verifies `go` and `go tool fyne` are available on `PATH`; exits with a clear error message if not |
| Tests | Runs `go test -test.short ./...`; skippable with `-SkipTests` |
| Dev build | `go build -tags migrated_fynedo -o evebuddy.exe .` — fast compile, no icon embedding |
| Release build | `go tool fyne package --os windows --release --tags migrated_fynedo` — reads `FyneApp.toml` and embeds the icon and version metadata into the exe |

All output is colour-coded (cyan for steps, green for success, red for errors) and the script uses `$ErrorActionPreference = 'Stop'` so any failure exits immediately with a non-zero code, making it safe to use in CI pipelines.

Built-in help is available via:

```powershell
Get-Help .\tools\build_exe.ps1 -Full
```

## Testing

- [ ] Export button visible on desktop (Windows / macOS), absent on mobile (`--mobile` flag)
- [ ] **Copy to clipboard**: paste into a text editor and verify `Skill Name Level` format, one per line, only trained skills, alphabetically sorted
- [ ] **Copy to clipboard**: paste into PyFA via *Character → Import Skills* and verify skills are recognized and levels are correct
- [ ] **Export to CSV**: file dialog opens in its own resizable window; window can be resized, minimised, and closed
- [ ] **Export to CSV**: saved file opens correctly in a spreadsheet with `Name` and `Level` columns
- [ ] Both exports include only trained skills (level > 0) regardless of active catalogue filters
- [ ] No button shown on Android build
