### PR TITLE
feat: export training

### DIFF
--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -303,8 +303,9 @@ func NewTraining(u baseUI) *Training {
 	a.selectTag = kxwidget.NewFilterChipSelect("Tag", []string{}, func(string) {
 		a.filterRowsAsync(-1)
 	})
-	a.exportButton = xwidget.NewContextMenuButton(
+	a.exportButton = xwidget.NewContextMenuButtonWithIcon(
 		"Export",
+		theme.DownloadIcon(),
 		fyne.NewMenu("",
 			fyne.NewMenuItem("Copy to clipboard", a.copyTrainingToClipboard),
 			fyne.NewMenuItem("Save as CSV", a.saveTrainingAsCSV),

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -311,6 +311,7 @@ func NewTraining(u baseUI) *Training {
 			fyne.NewMenuItem("Save as CSV", a.saveTrainingAsCSV),
 		),
 	)
+	a.exportButton.SetToolTip("Export training data to clipboard or file")
 	a.sortButton = a.columnSorter.NewSortButton(func() {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow())
@@ -457,7 +458,7 @@ func (a *Training) makeDataList() *xwidget.StripedList {
 	return l
 }
 
-func (a *Training) makeCSVString() string {
+func (a *Training) makeTrainingCSVString() string {
 	rows := a.rowsFiltered
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
@@ -484,7 +485,7 @@ func (a *Training) makeCSVString() string {
 }
 
 func (a *Training) copyTrainingToClipboard() {
-	fyne.CurrentApp().Clipboard().SetContent(a.makeCSVString())
+	fyne.CurrentApp().Clipboard().SetContent(a.makeTrainingCSVString())
 	a.u.ShowSnackbar("Copied to clipboard")
 }
 
@@ -506,7 +507,7 @@ func (a *Training) saveTrainingAsCSV() {
 			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return
 		}
-		_, err = writer.Write([]byte(a.makeCSVString()))
+		_, err = writer.Write([]byte(a.makeTrainingCSVString()))
 		if err != nil {
 			ui.ShowErrorAndLog("Failed to write CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -1,8 +1,10 @@
 package skills
 
 import (
+	"bytes"
 	"cmp"
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,9 +14,12 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	kxdialog "github.com/ErikKalkoken/fyne-kx/dialog"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	"github.com/ErikKalkoken/go-set"
 	"github.com/dustin/go-humanize"
@@ -115,6 +120,7 @@ type Training struct {
 
 	OnUpdate func(expired int)
 
+	exportButton *xwidget.ContextMenuButton
 	footer       *widget.Label
 	columnSorter *xwidget.ColumnSorter[trainingRow]
 	main         fyne.CanvasObject
@@ -297,6 +303,13 @@ func NewTraining(u baseUI) *Training {
 	a.selectTag = kxwidget.NewFilterChipSelect("Tag", []string{}, func(string) {
 		a.filterRowsAsync(-1)
 	})
+	a.exportButton = xwidget.NewContextMenuButton(
+		"Export",
+		fyne.NewMenu("",
+			fyne.NewMenuItem("Copy to clipboard", a.copyTrainingToClipboard),
+			fyne.NewMenuItem("Save as CSV", a.saveTrainingAsCSV),
+		),
+	)
 	a.sortButton = a.columnSorter.NewSortButton(func() {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow())
@@ -335,6 +348,8 @@ func (a *Training) CreateRenderer() fyne.WidgetRenderer {
 	filter := container.NewHBox(a.selectStatus, a.selectTag)
 	if a.u.IsMobile() {
 		filter.Add(a.sortButton)
+	} else {
+		filter.Add(a.exportButton)
 	}
 	var topBox *fyne.Container
 	if a.u.IsMobile() {
@@ -439,6 +454,72 @@ func (a *Training) makeDataList() *xwidget.StripedList {
 		a.showTrainingQueueWindow(r)
 	}
 	return l
+}
+
+func (a *Training) makeCSVString() string {
+	rows := a.rowsFiltered
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	_ = w.Write([]string{
+		"Character", "Tags", "Current Skill", "Current Remaining",
+		"Queued", "Queue Time", "Trained SP", "Unallocated SP", "Total SP",
+	})
+	for _, r := range rows {
+		tags := strings.Join(slices.Sorted(r.tags.All()), ";")
+		_ = w.Write([]string{
+			r.characterName,
+			tags,
+			r.skillName,
+			r.currentRemainingTimeString(),
+			r.totalRemainingCountDisplay,
+			r.totalRemainingTimeString(),
+			r.trainedSPDisplay,
+			r.unallocatedSPDisplay,
+			r.totalSPDisplay,
+		})
+	}
+	w.Flush()
+	return buf.String()
+}
+
+func (a *Training) copyTrainingToClipboard() {
+	fyne.CurrentApp().Clipboard().SetContent(a.makeCSVString())
+	a.u.ShowSnackbar("Copied to clipboard")
+}
+
+func (a *Training) saveTrainingAsCSV() {
+	_, s := a.u.MainWindow().Canvas().InteractiveArea()
+	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
+
+	w := fyne.CurrentApp().NewWindow("Save Training Data as CSV")
+	w.Resize(winSize)
+	w.SetContent(widget.NewLabel(""))
+
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		w.Close()
+		if writer == nil {
+			return
+		}
+		defer writer.Close()
+		if err != nil {
+			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			return
+		}
+		_, err = writer.Write([]byte(a.makeCSVString()))
+		if err != nil {
+			ui.ShowErrorAndLog("Failed to write CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			return
+		}
+		slog.Info("Training data exported to file", "uri", writer.URI())
+		a.u.ShowSnackbar("Training data saved")
+	}, w)
+	d.SetFileName("training.csv")
+	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
+	d.SetTitleText("Save training data as CSV")
+	kxdialog.AddDialogKeyHandler(d, w)
+	d.Resize(winSize)
+	w.Show()
+	d.Show()
 }
 
 func (a *Training) filterRowsAsync(sortCol int) {

--- a/internal/app/ui/skills/training_internal_test.go
+++ b/internal/app/ui/skills/training_internal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne/v2/test"
 
+	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
@@ -101,4 +102,36 @@ func TestTraining_Filter(t *testing.T) {
 		want := []string{"Bravo"}
 		assert.ElementsMatch(t, want, got)
 	})
+}
+
+func TestTraining_MakeTrainingCSVString(t *testing.T) {
+	a := &Training{
+		rowsFiltered: []trainingRow{
+			{
+				characterName:              "Alpha",
+				tags:                       set.Of("pilot", "logistics"),
+				skillName:                  "Gunnery V",
+				isActive:                   false,
+				totalRemainingCountDisplay: "3",
+				trainedSPDisplay:           "10000000",
+				unallocatedSPDisplay:       "1000000",
+				totalSPDisplay:             "11000000",
+			},
+			{
+				characterName:              "Bravo",
+				tags:                       set.Of[string](),
+				skillName:                  "N/A",
+				isActive:                   false,
+				totalRemainingCountDisplay: "",
+				trainedSPDisplay:           "5000000",
+				unallocatedSPDisplay:       "0",
+				totalSPDisplay:             "5000000",
+			},
+		},
+	}
+	got := a.makeTrainingCSVString()
+	want := "Character,Tags,Current Skill,Current Remaining,Queued,Queue Time,Trained SP,Unallocated SP,Total SP\n" +
+		"Alpha,logistics;pilot,Gunnery V,N/A,3,N/A,10000000,1000000,11000000\n" +
+		"Bravo,,N/A,N/A,,N/A,5000000,0,5000000\n"
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
Resolves: #451 

## Summary

Adds an **Export** button to the Home → Training view (desktop only). The button appears between the **Tag** filter chip and the **Search** input and exposes two export actions via a drop-down menu:

- **Copy to clipboard** — copies the current filtered training data to the clipboard as CSV, ready to paste into any text editor, spreadsheet, or plain-text file.
- **Save as CSV** — opens a file-save dialog in its own dedicated window where the user can choose a location and save the data as a `.csv` file.

The export always operates on the **currently visible (filtered) rows**, so status, tag, and search filters are all respected before exporting. This means the user can narrow down the data first — for example, filtering to only active characters with a specific tag — and then export only that subset.

---

## Changes

### `internal/app/ui/skills/training.go`

| Area | Change |
|---|---|
| Imports | Added `bytes`, `encoding/csv`, `fyne.io/fyne/v2/dialog`, `fyne.io/fyne/v2/storage`, `kxdialog "github.com/ErikKalkoken/fyne-kx/dialog"` |
| `Training` struct | Added `exportButton *xwidget.ContextMenuButton` field |
| `NewTraining` | Initialises `exportButton` as a `ContextMenuButton` labelled **"Export"** with two menu items wired to the new methods |
| `CreateRenderer` | Adds `exportButton` to the filter `HBox` on **desktop only** (mobile layout unchanged) |
| `makeCSVString()` | New method — snapshots `rowsFiltered`, writes a CSV header row and one data row per character using `encoding/csv` |
| `copyTrainingToClipboard()` | New method — calls `makeCSVString()` and writes the result to `fyne.CurrentApp().Clipboard()`, then shows a snackbar confirmation |
| `saveTrainingAsCSV()` | New method — opens a `dialog.NewFileSave` inside its own dedicated `fyne.Window`, sized at 80 % of the main window's interactive area; closes the window on save or cancel |

---

## CSV Format

The exported CSV contains the following columns in order:

| Column | Source |
|---|---|
| Character | Character name |
| Tags | Semicolon-separated list of tags assigned to the character |
| Current Skill | Name and level of the skill currently in training (e.g. `Gunnery V`) |
| Current Remaining | Time remaining on the current skill (`N/A` if inactive) |
| Queued | Number of skills remaining in the queue |
| Queue Time | Total time remaining for the full skill queue (`N/A` if inactive) |
| Trained SP | Total trained skill points |
| Unallocated SP | Unallocated skill points |
| Total SP | Sum of trained and unallocated skill points |

---

## Behaviour Details

- The export button is **desktop-only** (Windows / macOS). It does not appear in the mobile layout.
- Both export actions use the **filtered** row set — the same rows shown in the table at the time of export. The three available filters can be combined freely before exporting:
  - **Status filter** — limit to `Active` or `Inactive` characters only.
  - **Tag filter** — limit to characters that have a specific tag assigned.
  - **Search bar** — limit to characters whose name contains the search term (case-insensitive, minimum 2 characters).
- If no filters are active, all characters are exported.
- The **Save as CSV** dialog opens in a **separate window** independent of the main app window, so the main app remains usable while the dialog is open. The dialog window is resizable; resizing it causes the file-picker content to flex proportionally.
- The default suggested filename is `training.csv`.
- Only `.csv` files are shown in the save dialog.
- Keyboard shortcuts (Enter to confirm, Escape to cancel) are enabled in the save dialog via `kxdialog.AddDialogKeyHandler`.
- On a successful save, a snackbar notification confirms **"Training data saved"**.
- On a successful clipboard copy, a snackbar confirms **"Copied to clipboard"**.

---

## Screenshots

### Export button in the Training view toolbar

<img width="1908" height="979" alt="training_ui_update" src="https://github.com/user-attachments/assets/7fbe714d-8b93-4780-be26-9916fb301c84" />

### Export drop-down menu (Copy to clipboard / Save as CSV)

<img width="1905" height="981" alt="training_ui_export_options" src="https://github.com/user-attachments/assets/54f119a3-b62e-4854-ba5c-80110e89cb11" />

### Save as CSV file dialog (dedicated window)

<img width="1915" height="985" alt="training_ui_export_save_window" src="https://github.com/user-attachments/assets/70b5e5fd-87d8-4025-a352-ff39575f3488" />
