### PR TITLE
Fix: infoviewer nil crash

### DIFF
--- a/internal/app/ui/characters/characters_internal_test.go
+++ b/internal/app/ui/characters/characters_internal_test.go
@@ -1,0 +1,119 @@
+package characters
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/corporationservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/settings"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+)
+
+// fakeInfoViewer records Show calls and implements ui.InfoViewer.
+type fakeInfoViewer struct {
+	called bool
+	entity *app.EveEntity
+}
+
+func (f *fakeInfoViewer) Show(o *app.EveEntity) { f.called = true; f.entity = o }
+func (f *fakeInfoViewer) ShowLocation(_ int64)  {}
+func (f *fakeInfoViewer) ShowRace(_ int64)      {}
+func (f *fakeInfoViewer) ShowType(_, _ int64)   {}
+
+var _ ui.InfoViewer = (*fakeInfoViewer)(nil)
+
+// fakeCharactersUI is a minimal baseUI implementation for tests in this package.
+type fakeCharactersUI struct {
+	infoViewer ui.InfoViewer
+	eveImage   ui.EVEImageService
+	signals    *app.Signals
+	window     fyne.Window
+}
+
+func newFakeCharactersUI(a fyne.App) *fakeCharactersUI {
+	return &fakeCharactersUI{
+		eveImage:   testutil.NewEveImageServiceStub(),
+		infoViewer: &fakeInfoViewer{},
+		signals:    app.NewSignals(),
+		window:     a.NewWindow(""),
+	}
+}
+
+func (u *fakeCharactersUI) Character() *characterservice.CharacterService       { return nil }
+func (u *fakeCharactersUI) Corporation() *corporationservice.CorporationService { return nil }
+func (u *fakeCharactersUI) ErrorDisplay(err error) string                       { return err.Error() }
+func (u *fakeCharactersUI) EVEImage() ui.EVEImageService                        { return u.eveImage }
+func (u *fakeCharactersUI) EVEUniverse() *eveuniverseservice.EVEUniverseService { return nil }
+func (u *fakeCharactersUI) GetOrCreateWindow(id string, titles ...string) (fyne.Window, bool) {
+	return u.window, true
+}
+func (u *fakeCharactersUI) InfoViewer() ui.InfoViewer { return u.infoViewer }
+func (u *fakeCharactersUI) IsDeveloperMode() bool     { return false }
+func (u *fakeCharactersUI) IsMobile() bool            { return false }
+func (u *fakeCharactersUI) IsOffline() bool           { return false }
+func (u *fakeCharactersUI) IsUpdateDisabled() bool    { return false }
+func (u *fakeCharactersUI) MainWindow() fyne.Window   { return u.window }
+func (u *fakeCharactersUI) MakeWindowTitle(parts ...string) string {
+	return strings.Join(parts, " - ")
+}
+func (u *fakeCharactersUI) Settings() *settings.Settings             { return nil }
+func (u *fakeCharactersUI) ShowCharacter(_ context.Context, _ int64) {}
+func (u *fakeCharactersUI) ShowSnackbar(_ string)                    {}
+func (u *fakeCharactersUI) Signals() *app.Signals                    { return u.signals }
+func (u *fakeCharactersUI) UpdateMailIndicator(_ context.Context)    {}
+
+var _ baseUI = (*fakeCharactersUI)(nil)
+
+// Note: these tests must live in package characters (not package infoviewer) because they
+// access unexported fields that are only visible within this package:
+//   - communicationDetail.header  (*MailHeader, unexported field of unexported type)
+//   - mailDetail.header           (*MailHeader, unexported field of unexported type)
+//   - MailHeader.showInfo         (unexported field)
+// Moving them to another package would make those fields invisible and the tests
+// would need to be rewritten using a weaker approach that cannot verify the captured
+// method value directly.
+
+// TestNewCommunications_ShowInfoCapturesInfoViewer verifies that the Show method bound
+// from u.InfoViewer() at construction time is valid and callable. This is a regression
+// test for the bug where u.iw in newBaseUI was nil when NewCommunications was called:
+// the captured showInfo had a nil receiver and panicked the first time a notification
+// sender or recipient icon was tapped.
+func TestNewCommunications_ShowInfoCapturesInfoViewer(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newFakeCharactersUI(a)
+	comms := NewCommunications(u)
+	fakeIV := u.infoViewer.(*fakeInfoViewer)
+
+	entity := &app.EveEntity{ID: 1, Name: "Tester", Category: app.EveEntityCharacter}
+	// If u.InfoViewer() had returned nil at construction time, showInfo would be a
+	// nil-receiver method value. Calling it here would panic.
+	assert.NotPanics(t, func() {
+		comms.Detail.header.showInfo(entity)
+	})
+	assert.True(t, fakeIV.called, "showInfo must invoke InfoViewer.Show")
+	assert.Equal(t, entity, fakeIV.entity)
+}
+
+// TestNewMails_ShowInfoCapturesInfoViewer is the same regression test for NewMails.
+func TestNewMails_ShowInfoCapturesInfoViewer(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newFakeCharactersUI(a)
+	mails := NewMails(u)
+	fakeIV := u.infoViewer.(*fakeInfoViewer)
+
+	entity := &app.EveEntity{ID: 1, Name: "Tester", Category: app.EveEntityCharacter}
+	assert.NotPanics(t, func() {
+		mails.Detail.header.showInfo(entity)
+	})
+	assert.True(t, fakeIV.called, "showInfo must invoke InfoViewer.Show")
+	assert.Equal(t, entity, fakeIV.entity)
+}

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -404,6 +404,8 @@ func newBaseUI(arg UIParams) *baseUI {
 		slog.Debug("Signal: UpdateStarted", "section", s)
 	})
 
+	u.iw = infoviewer.New(u)
+
 	u.assetSearchAll = assets.NewSearchForAll(u)
 	u.augmentations = clones.NewAugmentations(u)
 	u.characterAssetBrowser = assets.NewCharacterBrowser(u)
@@ -446,8 +448,6 @@ func newBaseUI(arg UIParams) *baseUI {
 	u.snackbar = xwidget.NewSnackbar(u.window)
 	u.training = skills.NewTraining(u)
 	u.wealth = wallets.NewWealth(u)
-
-	u.iw = infoviewer.New(u)
 
 	u.MainWindow().SetMaster()
 

--- a/internal/app/ui/core/core_internal_test.go
+++ b/internal/app/ui/core/core_internal_test.go
@@ -207,6 +207,18 @@ func MakeFakeBaseUI(st *storage.Storage, fyneApp fyne.App, _ bool) *baseUI {
 	return bu
 }
 
+// TestNewBaseUI_InfoViewerInitializedBeforeWidgets is a regression test for the bug where
+// u.iw was initialized after the widget constructors. NewCommunications and NewMails both
+// call u.InfoViewer().Show to bind a method value at construction time. When u.iw was nil
+// at that point, the bound method had a nil receiver and panicked on the first tap of any
+// sender, recipient, or icon in the mail or notification detail views.
+func TestNewBaseUI_InfoViewerInitializedBeforeWidgets(t *testing.T) {
+	db, st, _ := testutil.NewDBInMemory()
+	defer db.Close()
+	u := MakeFakeBaseUI(st, test.NewTempApp(t), false)
+	assert.NotNil(t, u.iw)
+}
+
 func TestMakeOrFindWindow(t *testing.T) {
 	db, st, _ := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/ui/infoviewer/infoviewer.go
+++ b/internal/app/ui/infoviewer/infoviewer.go
@@ -122,8 +122,15 @@ type showParams struct {
 }
 
 func (iw *InfoViewer) show2(arg showParams) {
+	// iw.w is nil after an info window has been closed; fall back to the main window
+	// so that error/informational dialogs always have a valid parent.
+	parentW := iw.w
+	if parentW == nil {
+		parentW = iw.u.MainWindow()
+	}
+
 	if arg.entityID == 0 || arg.variant == infoNotSupported {
-		ui.ShowErrorAndLog("Can't show info window", app.ErrInvalid, iw.u.IsDeveloperMode(), iw.w)
+		ui.ShowErrorAndLog("Can't show info window", app.ErrInvalid, iw.u.IsDeveloperMode(), parentW)
 		return
 	}
 
@@ -131,7 +138,7 @@ func (iw *InfoViewer) show2(arg showParams) {
 		ui.ShowInformation(
 			"Offline",
 			"Can't show info window when offline",
-			iw.w,
+			parentW,
 		)
 		return
 	}
@@ -161,7 +168,7 @@ func (iw *InfoViewer) show2(arg showParams) {
 			ui.ShowInformation(
 				"Unknown location",
 				"Can't show info window for an unknown location",
-				iw.w,
+				parentW,
 			)
 			return
 		}
@@ -204,7 +211,7 @@ func (iw *InfoViewer) show2(arg showParams) {
 		ui.ShowInformation(
 			"Warning",
 			"Can't show info window for unknown category",
-			iw.w,
+			parentW,
 		)
 		return
 	}

--- a/internal/app/ui/infoviewer/infoviewer_internal_test.go
+++ b/internal/app/ui/infoviewer/infoviewer_internal_test.go
@@ -2,42 +2,66 @@ package infoviewer
 
 import (
 	"strings"
+	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/settings"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/janiceservice"
 )
 
+// UIServiceFake is a minimal coreUI implementation for unit tests.
 type UIServiceFake struct {
-	app fyne.App
+	app        fyne.App
+	mainWindow fyne.Window
 }
 
-func (u *UIServiceFake) GetOrCreateWindow(id string, titles ...string) (window fyne.Window, created bool) {
-	return u.app.NewWindow("Dunmy"), true
+func newUIServiceFake(a fyne.App) *UIServiceFake {
+	return &UIServiceFake{app: a, mainWindow: a.NewWindow("Main")}
 }
 
-func (u *UIServiceFake) HumanizeError(err error) string {
-	return err.Error()
+func (u *UIServiceFake) Character() *characterservice.CharacterService       { return nil }
+func (u *UIServiceFake) EVEImage() ui.EVEImageService                        { return nil }
+func (u *UIServiceFake) EVEUniverse() *eveuniverseservice.EVEUniverseService { return nil }
+func (u *UIServiceFake) GetOrCreateWindow(id string, titles ...string) (fyne.Window, bool) {
+	return u.app.NewWindow(strings.Join(titles, " - ")), true
 }
-
-func (u *UIServiceFake) IsDeveloperMode() bool {
-	return false
+func (u *UIServiceFake) GetOrCreateWindowWithOnClosed(id string, titles ...string) (fyne.Window, bool, func()) {
+	return u.app.NewWindow(strings.Join(titles, " - ")), true, func() {}
 }
+func (u *UIServiceFake) ErrorDisplay(err error) string        { return err.Error() }
+func (u *UIServiceFake) IsDeveloperMode() bool                { return false }
+func (u *UIServiceFake) IsMobile() bool                       { return false }
+func (u *UIServiceFake) IsOffline() bool                      { return false }
+func (u *UIServiceFake) Janice() *janiceservice.JaniceService { return nil }
+func (u *UIServiceFake) MainWindow() fyne.Window              { return u.mainWindow }
+func (u *UIServiceFake) Settings() *settings.Settings         { return nil }
 
-func (u *UIServiceFake) IsOffline() bool {
-	return false
-}
+var _ coreUI = (*UIServiceFake)(nil)
 
-func (u *UIServiceFake) MainWindow() fyne.Window {
-	return u.app.NewWindow("Dummy")
-}
-
-func (u *UIServiceFake) MakeWindowTitle(parts ...string) string {
-	return strings.Join(parts, " - ")
-}
-
-type SettingsFake struct{}
-
-func (s *SettingsFake) PreferMarketTab() bool {
-	return false
+// TestInfoViewer_show2_UsesMainWindowAsFallbackWhenInfoWindowClosed is a regression test
+// for the bug where show2 used iw.w directly as the dialog parent. After an info window is
+// opened and then closed, its OnClosed handler sets iw.w = nil. Any subsequent show2 call
+// (e.g. tapping an unsupported entity type) would then pass nil to a Fyne dialog, causing
+// a nil-pointer panic. The fix adds a fallback to iw.u.MainWindow() when iw.w is nil.
+func TestInfoViewer_show2_UsesMainWindowAsFallbackWhenInfoWindowClosed(t *testing.T) {
+	a := test.NewTempApp(t)
+	// iw.w is nil here, simulating the state after an info window was opened and closed.
+	iw := &InfoViewer{
+		u: newUIServiceFake(a),
+		w: nil,
+	}
+	// entityID=0 takes the early-return error path which passes parentW to a dialog.
+	// Before the fix, parentW was iw.w (nil) here, causing a panic.
+	// After the fix, parentW falls back to iw.u.MainWindow(), which is always valid.
+	assert.NotPanics(t, func() {
+		iw.show2(showParams{variant: infoNotSupported, entityID: 0})
+	})
 }
 
 // FIXME


### PR DESCRIPTION
# fix: crash when clicking sender/recipient/icon in mail and notification details

Closes #459

## What changed

| File | Change |
|---|---|
| `internal/app/ui/core/core.go` | Move `u.iw = infoviewer.New(u)` before all widget constructors |
| `internal/app/ui/infoviewer/infoviewer.go` | Fall back to `MainWindow()` when `iw.w` is nil in `show2` |

## Root cause

`u.iw` (`*InfoViewer`) was assigned on line 450 of `newBaseUI`, but `NewCommunications` (line 414) and `NewMails` (line 417) both call `u.InfoViewer().Show` to capture a bound method value at construction time — **before `u.iw` was ever assigned**.

The nil pointer was baked into every sender/recipient/icon `OnTapped` closure from that point on. Every click called `Show` on a nil `*InfoViewer` receiver and panicked accessing `iw.w` at memory offset `0x40`.

Stack trace from `crash.txt`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x40]

(*InfoViewer).Show(0x0, ...)          ← receiver is nil
(*MailHeader).Set.func2()
(*TappableLabel).Tapped(...)
```

## Fix

### `core.go` — primary fix

Move the one line that initialises `u.iw` to the top of the widget-construction block so every subsequent constructor receives a valid receiver:

```go
// before
u.characterCommunications = characters.NewCommunications(u) // iw is nil here
u.characterMails = characters.NewMails(u)                   // iw is nil here
...
u.iw = infoviewer.New(u)  // too late

// after
u.iw = infoviewer.New(u)  // valid from here on
u.characterCommunications = characters.NewCommunications(u)
u.characterMails = characters.NewMails(u)
```

### `infoviewer.go` — secondary fix

`iw.w` is intentionally set to `nil` in `SetOnClosed` whenever the info window is closed. If a user then clicks an entity with an unsupported category (e.g. a faction-sent notification) before opening a new info window, `show2` would pass a nil parent to `ShowErrorAndLog` / `ShowInformation` and crash. Fix uses `MainWindow()` as a fallback:

```go
parentW := iw.w
if parentW == nil {
    parentW = iw.u.MainWindow()
}
```

## Testing

Manually verified on Windows 11:

- Clicking sender name, recipient name, and portrait icon in mail detail no longer crashes.
- Clicking sender name, recipient name, and portrait icon in notification (Communications) detail no longer crashes.
- Info window opens correctly for characters, corporations, and alliances.
- Clicking a faction sender shows an error dialog instead of crashing.
