### PR TITLE
refactor: remove parameter structs in storage methods

### DIFF
--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -244,25 +244,25 @@ func (st *Storage) GetCharacterContract(ctx context.Context, characterID, contra
 	if err != nil {
 		return nil, wrapErr(convertGetError(err))
 	}
-	c := r.CharacterContract
-	acceptor := nullEveEntry{id: c.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
-	assignee := nullEveEntry{id: c.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
-	o := characterContractFromDBModel(characterContractFromDBModelParams{
-		acceptor:                 acceptor,
-		assignee:                 assignee,
-		contract:                 c,
-		endLocationName:          r.EndLocationName,
-		endSolarSystemID:         r.EndSolarSystemID,
-		endSolarSystemName:       r.EndSolarSystemName,
-		endSolarSystemSecurity:   r.EndSolarSystemSecurityStatus,
-		issuer:                   r.EveEntity_2,
-		issuerCorporation:        r.EveEntity,
-		items:                    r.Items,
-		startLocationName:        r.StartLocationName,
-		startSolarSystemID:       r.StartSolarSystemID,
-		startSolarSystemName:     r.StartSolarSystemName,
-		startSolarSystemSecurity: r.StartSolarSystemSecurityStatus,
-	})
+	cc := r.CharacterContract
+	acceptor := nullAcceptor{id: cc.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
+	assignee := nullAssignee{id: cc.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
+	o := characterContractFromDBModel(
+		acceptor,
+		assignee,
+		cc,
+		endLocationName(r.EndLocationName),
+		endSolarSystemID(r.EndSolarSystemID),
+		endSolarSystemName(r.EndSolarSystemName),
+		endSolarSystemSecurity(r.EndSolarSystemSecurityStatus),
+		issuer(r.EveEntity_2),
+		issuerCorporation(r.EveEntity),
+		r.Items,
+		startLocationName(r.StartLocationName),
+		startSolarSystemID(r.StartSolarSystemID),
+		startSolarSystemName(r.StartSolarSystemName),
+		startSolarSystemSecurity(r.StartSolarSystemSecurityStatus),
+	)
 	return o, nil
 }
 
@@ -287,25 +287,25 @@ func (st *Storage) ListAllCharacterContracts(ctx context.Context) ([]*app.Charac
 	}
 	oo := make([]*app.CharacterContract, len(rows))
 	for i, r := range rows {
-		c := r.CharacterContract
-		acceptor := nullEveEntry{id: c.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
-		assignee := nullEveEntry{id: c.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
-		oo[i] = characterContractFromDBModel(characterContractFromDBModelParams{
-			acceptor:                 acceptor,
-			assignee:                 assignee,
-			contract:                 c,
-			endLocationName:          r.EndLocationName,
-			endSolarSystemID:         r.EndSolarSystemID,
-			endSolarSystemName:       r.EndSolarSystemName,
-			endSolarSystemSecurity:   r.EndSolarSystemSecurityStatus,
-			issuer:                   r.EveEntity_2,
-			issuerCorporation:        r.EveEntity,
-			items:                    r.Items,
-			startLocationName:        r.StartLocationName,
-			startSolarSystemID:       r.StartSolarSystemID,
-			startSolarSystemName:     r.StartSolarSystemName,
-			startSolarSystemSecurity: r.StartSolarSystemSecurityStatus,
-		})
+		cc := r.CharacterContract
+		acceptor := nullAcceptor{id: cc.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
+		assignee := nullAssignee{id: cc.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
+		oo[i] = characterContractFromDBModel(
+			acceptor,
+			assignee,
+			cc,
+			endLocationName(r.EndLocationName),
+			endSolarSystemID(r.EndSolarSystemID),
+			endSolarSystemName(r.EndSolarSystemName),
+			endSolarSystemSecurity(r.EndSolarSystemSecurityStatus),
+			issuer(r.EveEntity_2),
+			issuerCorporation(r.EveEntity),
+			r.Items,
+			startLocationName(r.StartLocationName),
+			startSolarSystemID(r.StartSolarSystemID),
+			startSolarSystemName(r.StartSolarSystemName),
+			startSolarSystemSecurity(r.StartSolarSystemSecurityStatus),
+		)
 	}
 	return oo, nil
 }
@@ -323,25 +323,25 @@ func (st *Storage) ListCharacterContracts(ctx context.Context, characterID int64
 	}
 	oo := make([]*app.CharacterContract, len(rows))
 	for i, r := range rows {
-		c := r.CharacterContract
-		acceptor := nullEveEntry{id: c.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
-		assignee := nullEveEntry{id: c.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
-		oo[i] = characterContractFromDBModel(characterContractFromDBModelParams{
-			acceptor:                 acceptor,
-			assignee:                 assignee,
-			contract:                 c,
-			endLocationName:          r.EndLocationName,
-			endSolarSystemID:         r.EndSolarSystemID,
-			endSolarSystemName:       r.EndSolarSystemName,
-			endSolarSystemSecurity:   r.EndSolarSystemSecurityStatus,
-			issuer:                   r.EveEntity_2,
-			issuerCorporation:        r.EveEntity,
-			items:                    r.Items,
-			startLocationName:        r.StartLocationName,
-			startSolarSystemID:       r.StartSolarSystemID,
-			startSolarSystemName:     r.StartSolarSystemName,
-			startSolarSystemSecurity: r.StartSolarSystemSecurityStatus,
-		})
+		cc := r.CharacterContract
+		acceptor := nullAcceptor{id: cc.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
+		assignee := nullAssignee{id: cc.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
+		oo[i] = characterContractFromDBModel(
+			acceptor,
+			assignee,
+			cc,
+			endLocationName(r.EndLocationName),
+			endSolarSystemID(r.EndSolarSystemID),
+			endSolarSystemName(r.EndSolarSystemName),
+			endSolarSystemSecurity(r.EndSolarSystemSecurityStatus),
+			issuer(r.EveEntity_2),
+			issuerCorporation(r.EveEntity),
+			r.Items,
+			startLocationName(r.StartLocationName),
+			startSolarSystemID(r.StartSolarSystemID),
+			startSolarSystemName(r.StartSolarSystemName),
+			startSolarSystemSecurity(r.StartSolarSystemSecurityStatus),
+		)
 	}
 	return oo, nil
 }
@@ -402,82 +402,80 @@ func (st *Storage) UpdateCharacterContractNotified(ctx context.Context, id int64
 	return nil
 }
 
-type characterContractFromDBModelParams struct {
-	acceptor                 nullEveEntry
-	assignee                 nullEveEntry
-	contract                 queries.CharacterContract
-	endLocationName          sql.NullString
-	endSolarSystemID         sql.NullInt64
-	endSolarSystemName       sql.NullString
-	endSolarSystemSecurity   sql.NullFloat64
-	issuer                   queries.EveEntity
-	issuerCorporation        queries.EveEntity
-	items                    any
-	startLocationName        sql.NullString
-	startSolarSystemID       sql.NullInt64
-	startSolarSystemName     sql.NullString
-	startSolarSystemSecurity sql.NullFloat64
-}
-
-func characterContractFromDBModel(arg characterContractFromDBModelParams) *app.CharacterContract {
-	i2, ok := arg.items.(string)
+func characterContractFromDBModel(
+	acceptor nullAcceptor,
+	assignee nullAssignee,
+	cc queries.CharacterContract,
+	endLocationName endLocationName,
+	endSolarSystemID endSolarSystemID,
+	endSolarSystemName endSolarSystemName,
+	endSolarSystemSecurity endSolarSystemSecurity,
+	issuer issuer,
+	issuerCorporation issuerCorporation,
+	items any,
+	startLocationName startLocationName,
+	startSolarSystemID startSolarSystemID,
+	startSolarSystemName startSolarSystemName,
+	startSolarSystemSecurity startSolarSystemSecurity,
+) *app.CharacterContract {
+	i2, ok := items.(string)
 	if !ok {
 		i2 = ""
 	}
-	o2 := &app.CharacterContract{
-		Acceptor:          eveEntityFromNullableDBModel(arg.acceptor),
-		Assignee:          eveEntityFromNullableDBModel(arg.assignee),
-		Availability:      characterContractAvailabilityFromDBValue[arg.contract.Availability],
-		Buyout:            optional.FromZeroValue(arg.contract.Buyout),
-		CharacterID:       arg.contract.CharacterID,
-		Collateral:        optional.FromZeroValue(arg.contract.Collateral),
-		ContractID:        arg.contract.ContractID,
-		DateAccepted:      optional.FromNullTime(arg.contract.DateAccepted),
-		DateCompleted:     optional.FromNullTime(arg.contract.DateCompleted),
-		DateExpired:       arg.contract.DateExpired,
-		DateIssued:        arg.contract.DateIssued,
-		DaysToComplete:    optional.FromZeroValue(arg.contract.DaysToComplete),
-		ForCorporation:    arg.contract.ForCorporation,
-		ID:                arg.contract.ID,
-		Issuer:            eveEntityFromDBModel(arg.issuer),
-		IssuerCorporation: eveEntityFromDBModel(arg.issuerCorporation),
+	o := &app.CharacterContract{
+		Acceptor:          eveEntityFromNullableDBModel(nullEveEntry(acceptor)),
+		Assignee:          eveEntityFromNullableDBModel(nullEveEntry(assignee)),
+		Availability:      characterContractAvailabilityFromDBValue[cc.Availability],
+		Buyout:            optional.FromZeroValue(cc.Buyout),
+		CharacterID:       cc.CharacterID,
+		Collateral:        optional.FromZeroValue(cc.Collateral),
+		ContractID:        cc.ContractID,
+		DateAccepted:      optional.FromNullTime(cc.DateAccepted),
+		DateCompleted:     optional.FromNullTime(cc.DateCompleted),
+		DateExpired:       cc.DateExpired,
+		DateIssued:        cc.DateIssued,
+		DaysToComplete:    optional.FromZeroValue(cc.DaysToComplete),
+		ForCorporation:    cc.ForCorporation,
+		ID:                cc.ID,
+		Issuer:            eveEntityFromDBModel(queries.EveEntity(issuer)),
+		IssuerCorporation: eveEntityFromDBModel(queries.EveEntity(issuerCorporation)),
 		Items:             strings.Split(i2, ","),
-		Price:             optional.FromZeroValue(arg.contract.Price),
-		Reward:            optional.FromZeroValue(arg.contract.Reward),
-		Status:            characterContractStatusFromDBValue[arg.contract.Status],
-		StatusNotified:    characterContractStatusFromDBValue[arg.contract.StatusNotified],
-		Title:             optional.FromZeroValue(arg.contract.Title),
-		Type:              characterContractTypeFromDBValue[arg.contract.Type],
-		UpdatedAt:         arg.contract.UpdatedAt,
-		Volume:            optional.FromZeroValue(arg.contract.Volume),
+		Price:             optional.FromZeroValue(cc.Price),
+		Reward:            optional.FromZeroValue(cc.Reward),
+		Status:            characterContractStatusFromDBValue[cc.Status],
+		StatusNotified:    characterContractStatusFromDBValue[cc.StatusNotified],
+		Title:             optional.FromZeroValue(cc.Title),
+		Type:              characterContractTypeFromDBValue[cc.Type],
+		UpdatedAt:         cc.UpdatedAt,
+		Volume:            optional.FromZeroValue(cc.Volume),
 	}
-	if arg.contract.EndLocationID.Valid {
-		o2.EndLocation = optional.New(&app.EveLocationShort{
-			ID:             arg.contract.EndLocationID.Int64,
-			Name:           optional.FromNullString(arg.endLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.endSolarSystemSecurity),
+	if cc.EndLocationID.Valid {
+		o.EndLocation = optional.New(&app.EveLocationShort{
+			ID:             cc.EndLocationID.Int64,
+			Name:           optional.FromNullString(sql.NullString(endLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(endSolarSystemSecurity)),
 		})
 	}
-	if arg.contract.StartLocationID.Valid {
-		o2.StartLocation = optional.New(&app.EveLocationShort{
-			ID:             arg.contract.StartLocationID.Int64,
-			Name:           optional.FromNullString(arg.startLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.startSolarSystemSecurity),
+	if cc.StartLocationID.Valid {
+		o.StartLocation = optional.New(&app.EveLocationShort{
+			ID:             cc.StartLocationID.Int64,
+			Name:           optional.FromNullString(sql.NullString(startLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(startSolarSystemSecurity)),
 		})
 	}
-	if arg.endSolarSystemID.Valid && arg.endSolarSystemName.Valid {
-		o2.EndSolarSystem = optional.New(&app.EntityShort{
-			ID:   arg.endSolarSystemID.Int64,
-			Name: arg.endSolarSystemName.String,
+	if endSolarSystemID.Valid && endSolarSystemName.Valid {
+		o.EndSolarSystem = optional.New(&app.EntityShort{
+			ID:   endSolarSystemID.Int64,
+			Name: endSolarSystemName.String,
 		})
 	}
-	if arg.startSolarSystemID.Valid && arg.startSolarSystemName.Valid {
-		o2.StartSolarSystem = optional.New(&app.EntityShort{
-			ID:   arg.startSolarSystemID.Int64,
-			Name: arg.startSolarSystemName.String,
+	if startSolarSystemID.Valid && startSolarSystemName.Valid {
+		o.StartSolarSystem = optional.New(&app.EntityShort{
+			ID:   startSolarSystemID.Int64,
+			Name: startSolarSystemName.String,
 		})
 	}
-	return o2
+	return o
 }
 
 type CreateCharacterContractBidParams struct {
@@ -617,7 +615,12 @@ func (st *Storage) ListCharacterContractItems(ctx context.Context, contractID in
 	return oo, nil
 }
 
-func characterContractItemFromDBModel(o queries.CharacterContractItem, t queries.EveType, g queries.EveGroup, c queries.EveCategory) *app.CharacterContractItem {
+func characterContractItemFromDBModel(
+	o queries.CharacterContractItem,
+	t queries.EveType,
+	g queries.EveGroup,
+	c queries.EveCategory,
+) *app.CharacterContractItem {
 	o2 := &app.CharacterContractItem{
 		ContractID:  o.ContractID,
 		IsIncluded:  o.IsIncluded,

--- a/internal/app/storage/characterimplant.go
+++ b/internal/app/storage/characterimplant.go
@@ -30,13 +30,13 @@ func (st *Storage) GetCharacterImplant(ctx context.Context, characterID int64, t
 	if err != nil {
 		return nil, fmt.Errorf("get implant %d for character %d: %w", typeID, characterID, convertGetError(err))
 	}
-	o := characterImplantFromDBModel(characterImplantFromDBModelParams{
-		ci: r.CharacterImplant,
-		et: r.EveType,
-		eg: r.EveGroup,
-		ec: r.EveCategory,
-		sn: r.SlotNum,
-	})
+	o := characterImplantFromDBModel(
+		r.CharacterImplant,
+		r.EveType,
+		r.EveGroup,
+		r.EveCategory,
+		r.SlotNum,
+	)
 	return o, nil
 }
 
@@ -58,13 +58,13 @@ func (st *Storage) ListCharacterImplants(ctx context.Context, characterID int64)
 	}
 	var oo []*app.CharacterImplant
 	for _, r := range rows {
-		oo = append(oo, characterImplantFromDBModel(characterImplantFromDBModelParams{
-			ci: r.CharacterImplant,
-			et: r.EveType,
-			eg: r.EveGroup,
-			ec: r.EveCategory,
-			sn: r.SlotNum,
-		}))
+		oo = append(oo, characterImplantFromDBModel(
+			r.CharacterImplant,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			r.SlotNum,
+		))
 	}
 	return oo, nil
 }
@@ -76,13 +76,13 @@ func (st *Storage) ListAllCharacterImplants(ctx context.Context) ([]*app.Charact
 	}
 	var oo []*app.CharacterImplant
 	for _, r := range rows {
-		oo = append(oo, characterImplantFromDBModel(characterImplantFromDBModelParams{
-			ci: r.CharacterImplant,
-			et: r.EveType,
-			eg: r.EveGroup,
-			ec: r.EveCategory,
-			sn: r.SlotNum,
-		}))
+		oo = append(oo, characterImplantFromDBModel(
+			r.CharacterImplant,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			r.SlotNum,
+		))
 	}
 	return oo, nil
 }
@@ -133,24 +133,25 @@ func createCharacterImplant(ctx context.Context, q *queries.Queries, arg CreateC
 }
 
 type characterImplantFromDBModelParams struct {
-	ci queries.CharacterImplant
-	et queries.EveType
-	eg queries.EveGroup
-	ec queries.EveCategory
-	sn sql.NullFloat64
 }
 
-func characterImplantFromDBModel(arg characterImplantFromDBModelParams) *app.CharacterImplant {
-	if arg.ci.CharacterID == 0 {
+func characterImplantFromDBModel(
+	ci queries.CharacterImplant,
+	et queries.EveType,
+	eg queries.EveGroup,
+	ec queries.EveCategory,
+	sn sql.NullFloat64,
+) *app.CharacterImplant {
+	if ci.CharacterID == 0 {
 		panic("missing character ID")
 	}
 	o2 := &app.CharacterImplant{
-		CharacterID: arg.ci.CharacterID,
-		EveType:     eveTypeFromDBModel(arg.et, arg.eg, arg.ec),
-		ID:          arg.ci.ID,
+		CharacterID: ci.CharacterID,
+		EveType:     eveTypeFromDBModel(et, eg, ec),
+		ID:          ci.ID,
 	}
-	if arg.sn.Valid {
-		o2.SlotNum = int(arg.sn.Float64)
+	if sn.Valid {
+		o2.SlotNum = int(sn.Float64)
 	}
 	return o2
 }

--- a/internal/app/storage/characterindustryjob.go
+++ b/internal/app/storage/characterindustryjob.go
@@ -64,21 +64,21 @@ func (st *Storage) GetCharacterIndustryJob(ctx context.Context, characterID, job
 	if err != nil {
 		return nil, fmt.Errorf("get industry job for character %d: %w", characterID, convertGetError(err))
 	}
-	o := characterIndustryJobFromDBModel(characterIndustryJobFromDBModelParams{
-		blueprintLocationName:     r.BlueprintLocationName,
-		blueprintLocationSecurity: r.BlueprintLocationSecurity,
-		blueprintTypeName:         r.BlueprintTypeName,
-		cij:                       r.CharacterIndustryJob,
-		completedCharacterName:    r.CompletedCharacterName,
-		facilityName:              r.FacilityName,
-		facilitySecurity:          r.FacilitySecurity,
-		installer:                 r.EveEntity,
-		outputLocationName:        r.OutputLocationName,
-		outputLocationSecurity:    r.OutputLocationSecurity,
-		productTypeName:           r.ProductTypeName,
-		stationName:               r.StationName,
-		stationSecurity:           r.StationSecurity,
-	})
+	o := characterIndustryJobFromDBModel(
+		blueprintLocationName(r.BlueprintLocationName),
+		blueprintLocationSecurity(r.BlueprintLocationSecurity),
+		blueprintTypeName(r.BlueprintTypeName),
+		r.CharacterIndustryJob,
+		completedCharacterName(r.CompletedCharacterName),
+		facilityName(r.FacilityName),
+		facilitySecurity(r.FacilitySecurity),
+		r.EveEntity,
+		outputLocationName(r.OutputLocationName),
+		outputLocationSecurity(r.OutputLocationSecurity),
+		productTypeName(r.ProductTypeName),
+		stationName(r.StationName),
+		stationSecurity(r.StationSecurity),
+	)
 	return o, err
 }
 
@@ -89,21 +89,21 @@ func (st *Storage) ListAllCharacterIndustryJob(ctx context.Context) ([]*app.Char
 	}
 	oo := make([]*app.CharacterIndustryJob, len(rows))
 	for i, r := range rows {
-		oo[i] = characterIndustryJobFromDBModel(characterIndustryJobFromDBModelParams{
-			blueprintLocationName:     r.BlueprintLocationName,
-			blueprintLocationSecurity: r.BlueprintLocationSecurity,
-			blueprintTypeName:         r.BlueprintTypeName,
-			cij:                       r.CharacterIndustryJob,
-			completedCharacterName:    r.CompletedCharacterName,
-			facilityName:              r.FacilityName,
-			facilitySecurity:          r.FacilitySecurity,
-			installer:                 r.EveEntity,
-			outputLocationName:        r.OutputLocationName,
-			outputLocationSecurity:    r.OutputLocationSecurity,
-			productTypeName:           r.ProductTypeName,
-			stationName:               r.StationName,
-			stationSecurity:           r.StationSecurity,
-		})
+		oo[i] = characterIndustryJobFromDBModel(
+			blueprintLocationName(r.BlueprintLocationName),
+			blueprintLocationSecurity(r.BlueprintLocationSecurity),
+			blueprintTypeName(r.BlueprintTypeName),
+			r.CharacterIndustryJob,
+			completedCharacterName(r.CompletedCharacterName),
+			facilityName(r.FacilityName),
+			facilitySecurity(r.FacilitySecurity),
+			r.EveEntity,
+			outputLocationName(r.OutputLocationName),
+			outputLocationSecurity(r.OutputLocationSecurity),
+			productTypeName(r.ProductTypeName),
+			stationName(r.StationName),
+			stationSecurity(r.StationSecurity),
+		)
 	}
 	return oo, nil
 }
@@ -115,21 +115,21 @@ func (st *Storage) ListCharacterIndustryJobs(ctx context.Context, characterID in
 	}
 	oo := make([]*app.CharacterIndustryJob, len(rows))
 	for i, r := range rows {
-		oo[i] = characterIndustryJobFromDBModel(characterIndustryJobFromDBModelParams{
-			blueprintLocationName:     r.BlueprintLocationName,
-			blueprintLocationSecurity: r.BlueprintLocationSecurity,
-			blueprintTypeName:         r.BlueprintTypeName,
-			cij:                       r.CharacterIndustryJob,
-			completedCharacterName:    r.CompletedCharacterName,
-			facilityName:              r.FacilityName,
-			facilitySecurity:          r.FacilitySecurity,
-			installer:                 r.EveEntity,
-			outputLocationName:        r.OutputLocationName,
-			outputLocationSecurity:    r.OutputLocationSecurity,
-			productTypeName:           r.ProductTypeName,
-			stationName:               r.StationName,
-			stationSecurity:           r.StationSecurity,
-		})
+		oo[i] = characterIndustryJobFromDBModel(
+			blueprintLocationName(r.BlueprintLocationName),
+			blueprintLocationSecurity(r.BlueprintLocationSecurity),
+			blueprintTypeName(r.BlueprintTypeName),
+			r.CharacterIndustryJob,
+			completedCharacterName(r.CompletedCharacterName),
+			facilityName(r.FacilityName),
+			facilitySecurity(r.FacilitySecurity),
+			r.EveEntity,
+			outputLocationName(r.OutputLocationName),
+			outputLocationSecurity(r.OutputLocationSecurity),
+			productTypeName(r.ProductTypeName),
+			stationName(r.StationName),
+			stationSecurity(r.StationSecurity),
+		)
 	}
 	return oo, nil
 }
@@ -151,77 +151,78 @@ func (st *Storage) ListAllCharacterIndustryJobActiveCounts(ctx context.Context) 
 	return result, nil
 }
 
-type characterIndustryJobFromDBModelParams struct {
-	blueprintLocationName     string
-	blueprintLocationSecurity sql.NullFloat64
-	blueprintTypeName         string
-	cij                       queries.CharacterIndustryJob
-	completedCharacterName    sql.NullString
-	facilityName              string
-	facilitySecurity          sql.NullFloat64
-	installer                 queries.EveEntity
-	outputLocationName        string
-	outputLocationSecurity    sql.NullFloat64
-	productTypeName           sql.NullString
-	stationName               string
-	stationSecurity           sql.NullFloat64
-}
 
-func characterIndustryJobFromDBModel(arg characterIndustryJobFromDBModelParams) *app.CharacterIndustryJob {
+
+func characterIndustryJobFromDBModel(
+	blueprintLocationName blueprintLocationName,
+	blueprintLocationSecurity blueprintLocationSecurity,
+	blueprintTypeName blueprintTypeName,
+	cij queries.CharacterIndustryJob,
+	completedCharacterName completedCharacterName,
+	facilityName facilityName,
+	facilitySecurity facilitySecurity,
+	installer queries.EveEntity,
+	outputLocationName outputLocationName,
+	outputLocationSecurity outputLocationSecurity,
+	productTypeName productTypeName,
+	stationName stationName,
+	stationSecurity stationSecurity,
+
+) *app.CharacterIndustryJob {
 	o2 := &app.CharacterIndustryJob{
-		Activity:    app.IndustryActivity(arg.cij.ActivityID),
-		BlueprintID: arg.cij.BlueprintID,
+		Activity:    app.IndustryActivity(cij.ActivityID),
+		BlueprintID: cij.BlueprintID,
 		BlueprintLocation: &app.EveLocationShort{
-			ID:             arg.cij.BlueprintLocationID,
-			Name:           optional.New(arg.blueprintLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.blueprintLocationSecurity),
+			ID:             cij.BlueprintLocationID,
+			Name:           optional.New(string(blueprintLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(blueprintLocationSecurity)),
 		},
 		BlueprintType: &app.EntityShort{
-			ID:   arg.cij.BlueprintTypeID,
-			Name: arg.blueprintTypeName,
+			ID:   cij.BlueprintTypeID,
+			Name: string(blueprintTypeName),
 		},
-		CharacterID:   arg.cij.CharacterID,
-		CompletedDate: optional.FromNullTime(arg.cij.CompletedDate),
-		Cost:          optional.FromNullFloat64(arg.cij.Cost),
-		Duration:      int(arg.cij.Duration),
-		EndDate:       arg.cij.EndDate,
+		CharacterID:   cij.CharacterID,
+		CompletedDate: optional.FromNullTime(cij.CompletedDate),
+		Cost:          optional.FromNullFloat64(cij.Cost),
+		Duration:      int(cij.Duration),
+		EndDate:       cij.EndDate,
 		Facility: &app.EveLocationShort{
-			ID:             arg.cij.FacilityID,
-			Name:           optional.New(arg.facilityName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.facilitySecurity),
+			ID:             cij.FacilityID,
+			Name:           optional.New(string(facilityName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(facilitySecurity)),
 		},
-		ID:           arg.cij.ID,
-		Installer:    eveEntityFromDBModel(arg.installer),
-		JobID:        arg.cij.JobID,
-		LicensedRuns: optional.FromNullInt64ToInteger[int](arg.cij.LicensedRuns),
+		ID:           cij.ID,
+		Installer:    eveEntityFromDBModel(installer),
+		JobID:        cij.JobID,
+		LicensedRuns: optional.FromNullInt64ToInteger[int](cij.LicensedRuns),
 		OutputLocation: &app.EveLocationShort{
-			ID:             arg.cij.OutputLocationID,
-			Name:           optional.New(arg.outputLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.outputLocationSecurity),
+			ID:             cij.OutputLocationID,
+			Name:           optional.New(string(outputLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(outputLocationSecurity)),
 		},
-		PauseDate:   optional.FromNullTime(arg.cij.PauseDate),
-		Probability: optional.FromNullFloat64ToFloat32(arg.cij.Probability),
-		Runs:        int(arg.cij.Runs),
+		PauseDate:   optional.FromNullTime(cij.PauseDate),
+		Probability: optional.FromNullFloat64ToFloat32(cij.Probability),
+		Runs:        int(cij.Runs),
 		Station: &app.EveLocationShort{
-			ID:             arg.cij.StationID,
-			Name:           optional.New(arg.stationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.stationSecurity),
+			ID:             cij.StationID,
+			Name:           optional.New(string(stationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(stationSecurity)),
 		},
-		StartDate:      arg.cij.StartDate,
-		Status:         jobStatusFromDBValue[arg.cij.Status],
-		SuccessfulRuns: optional.FromNullInt64ToInteger[int64](arg.cij.SuccessfulRuns),
+		StartDate:      cij.StartDate,
+		Status:         jobStatusFromDBValue[cij.Status],
+		SuccessfulRuns: optional.FromNullInt64ToInteger[int64](cij.SuccessfulRuns),
 	}
-	if arg.cij.CompletedCharacterID.Valid && arg.completedCharacterName.Valid {
+	if cij.CompletedCharacterID.Valid && completedCharacterName.Valid {
 		o2.CompletedCharacter = optional.New(&app.EveEntity{
-			ID:       arg.cij.CompletedCharacterID.Int64,
-			Name:     arg.completedCharacterName.String,
+			ID:       cij.CompletedCharacterID.Int64,
+			Name:     completedCharacterName.String,
 			Category: app.EveEntityCharacter,
 		})
 	}
-	if arg.cij.ProductTypeID.Valid && arg.productTypeName.Valid {
+	if cij.ProductTypeID.Valid && productTypeName.Valid {
 		o2.ProductType = optional.New(&app.EntityShort{
-			ID:   arg.cij.ProductTypeID.Int64,
-			Name: arg.productTypeName.String,
+			ID:   cij.ProductTypeID.Int64,
+			Name: productTypeName.String,
 		})
 	}
 	return o2

--- a/internal/app/storage/characterjumpclone.go
+++ b/internal/app/storage/characterjumpclone.go
@@ -36,13 +36,13 @@ func (st *Storage) GetCharacterJumpClone(ctx context.Context, characterID int64,
 	if err != nil {
 		return nil, wrapErr(convertGetError(err))
 	}
-	o := characterJumpCloneFromDBModel(characterJumpCloneFromDBModelParams{
-		jc:               r.CharacterJumpClone,
-		locationName:     r.LocationName,
-		regionID:         r.RegionID,
-		regionName:       r.RegionName,
-		locationSecurity: r.LocationSecurity,
-	})
+	o := characterJumpCloneFromDBModel(
+		r.CharacterJumpClone,
+		r.LocationName,
+		r.LocationSecurity,
+		r.RegionID,
+		r.RegionName,
+	)
 	x, err := listCharacterJumpCloneImplants(ctx, st.qRO, o.ID)
 	if err != nil {
 		return nil, err
@@ -61,35 +61,33 @@ func listCharacterJumpCloneImplants(ctx context.Context, q *queries.Queries, clo
 	}
 	var oo []*app.CharacterJumpCloneImplant
 	for _, r := range rows {
-		oo = append(oo, characterJumpCloneImplantFromDBModel(characterJumpCloneImplantFromDBModelParams{
-			jci:  r.CharacterJumpCloneImplant,
-			et:   r.EveType,
-			eg:   r.EveGroup,
-			ec:   r.EveCategory,
-			slot: r.SlotNum,
-		}))
+		oo = append(oo, characterJumpCloneImplantFromDBModel(
+			r.CharacterJumpCloneImplant,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			r.SlotNum,
+		))
 	}
 	return oo, nil
 }
 
-type characterJumpCloneImplantFromDBModelParams struct {
-	jci  queries.CharacterJumpCloneImplant
-	et   queries.EveType
-	eg   queries.EveGroup
-	ec   queries.EveCategory
-	slot sql.NullFloat64
-}
-
-func characterJumpCloneImplantFromDBModel(arg characterJumpCloneImplantFromDBModelParams) *app.CharacterJumpCloneImplant {
-	if arg.jci.CloneID == 0 {
+func characterJumpCloneImplantFromDBModel(
+	jci queries.CharacterJumpCloneImplant,
+	et queries.EveType,
+	eg queries.EveGroup,
+	ec queries.EveCategory,
+	slot sql.NullFloat64,
+) *app.CharacterJumpCloneImplant {
+	if jci.CloneID == 0 {
 		panic("missing clone ID")
 	}
 	o2 := &app.CharacterJumpCloneImplant{
-		EveType: eveTypeFromDBModel(arg.et, arg.eg, arg.ec),
-		ID:      arg.jci.ID,
+		EveType: eveTypeFromDBModel(et, eg, ec),
+		ID:      jci.ID,
 	}
-	if arg.slot.Valid {
-		o2.SlotNum = int(arg.slot.Float64)
+	if slot.Valid {
+		o2.SlotNum = int(slot.Float64)
 	}
 	return o2
 }
@@ -137,13 +135,13 @@ func (st *Storage) ListCharacterJumpClones(ctx context.Context, characterID int6
 	}
 	var oo []*app.CharacterJumpClone
 	for _, r := range rows {
-		o := characterJumpCloneFromDBModel(characterJumpCloneFromDBModelParams{
-			jc:               r.CharacterJumpClone,
-			locationName:     r.LocationName,
-			regionID:         r.RegionID,
-			regionName:       r.RegionName,
-			locationSecurity: r.LocationSecurity,
-		})
+		o := characterJumpCloneFromDBModel(
+			r.CharacterJumpClone,
+			r.LocationName,
+			r.LocationSecurity,
+			r.RegionID,
+			r.RegionName,
+		)
 		x, err := listCharacterJumpCloneImplants(ctx, st.qRO, r.CharacterJumpClone.ID)
 		if err != nil {
 			return nil, err
@@ -210,30 +208,29 @@ func createCharacterJumpClone(ctx context.Context, q *queries.Queries, arg Creat
 	return nil
 }
 
-type characterJumpCloneFromDBModelParams struct {
-	jc               queries.CharacterJumpClone
-	locationName     string
-	locationSecurity sql.NullFloat64
-	regionID         sql.NullInt64
-	regionName       sql.NullString
-}
+func characterJumpCloneFromDBModel(
+	jc queries.CharacterJumpClone,
+	locationName string,
+	locationSecurity sql.NullFloat64,
+	regionID sql.NullInt64,
+	regionName sql.NullString,
 
-func characterJumpCloneFromDBModel(arg characterJumpCloneFromDBModelParams) *app.CharacterJumpClone {
-	if arg.jc.CharacterID == 0 || arg.jc.JumpCloneID == 0 || arg.jc.LocationID == 0 {
+) *app.CharacterJumpClone {
+	if jc.CharacterID == 0 || jc.JumpCloneID == 0 || jc.LocationID == 0 {
 		panic("invalid IDs")
 	}
 	o2 := &app.CharacterJumpClone{
-		CharacterID: arg.jc.CharacterID,
-		ID:          arg.jc.ID,
-		CloneID:     arg.jc.JumpCloneID,
+		CharacterID: jc.CharacterID,
+		ID:          jc.ID,
+		CloneID:     jc.JumpCloneID,
 		Location: &app.EveLocationShort{
-			ID:             arg.jc.LocationID,
-			Name:           optional.New(arg.locationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.locationSecurity)},
-		Name: optional.FromZeroValue(arg.jc.Name),
+			ID:             jc.LocationID,
+			Name:           optional.New(locationName),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(locationSecurity)},
+		Name: optional.FromZeroValue(jc.Name),
 	}
-	if arg.regionID.Valid && arg.regionName.Valid {
-		o2.Region = &app.EntityShort{ID: arg.regionID.Int64, Name: arg.regionName.String}
+	if regionID.Valid && regionName.Valid {
+		o2.Region = &app.EntityShort{ID: regionID.Int64, Name: regionName.String}
 	}
 	return o2
 }

--- a/internal/app/storage/characterloyaltypoints.go
+++ b/internal/app/storage/characterloyaltypoints.go
@@ -41,15 +41,15 @@ func (st *Storage) GetCharacterLoyaltyPointEntry(ctx context.Context, characterI
 	if err != nil {
 		return nil, fmt.Errorf("GetCharacterLoyaltyPointEntry for character %d: %w", characterID, convertGetError(err))
 	}
-	o := characterLoyaltyPointEntryFromDBModel(characterLoyaltyPointEntryFromDBModelParams{
-		entry:           r.CharacterLoyaltyPointEntry,
-		corporationName: r.CorporationName,
-		faction: nullEveEntry{
+	o := characterLoyaltyPointEntryFromDBModel(
+		r.CharacterLoyaltyPointEntry,
+		r.CorporationName,
+		nullEveEntry{
 			id:       r.FactionID,
 			category: r.FactionCategory,
 			name:     r.FactionName,
 		},
-	})
+	)
 
 	return o, err
 }
@@ -61,15 +61,15 @@ func (st *Storage) ListAllCharacterLoyaltyPointEntries(ctx context.Context) ([]*
 	}
 	var oo []*app.CharacterLoyaltyPointEntry
 	for _, r := range rows {
-		oo = append(oo, characterLoyaltyPointEntryFromDBModel(characterLoyaltyPointEntryFromDBModelParams{
-			entry:           r.CharacterLoyaltyPointEntry,
-			corporationName: r.CorporationName,
-			faction: nullEveEntry{
+		oo = append(oo, characterLoyaltyPointEntryFromDBModel(
+			r.CharacterLoyaltyPointEntry,
+			r.CorporationName,
+			nullEveEntry{
 				id:       r.FactionID,
 				category: r.FactionCategory,
 				name:     r.FactionName,
 			},
-		}))
+		))
 	}
 	return oo, nil
 }
@@ -89,34 +89,33 @@ func (st *Storage) ListCharacterLoyaltyPointEntries(ctx context.Context, charact
 	}
 	var oo []*app.CharacterLoyaltyPointEntry
 	for _, r := range rows {
-		oo = append(oo, characterLoyaltyPointEntryFromDBModel(characterLoyaltyPointEntryFromDBModelParams{
-			entry:           r.CharacterLoyaltyPointEntry,
-			corporationName: r.CorporationName,
-			faction: nullEveEntry{
+		oo = append(oo, characterLoyaltyPointEntryFromDBModel(
+			r.CharacterLoyaltyPointEntry,
+			r.CorporationName,
+			nullEveEntry{
 				id:       r.FactionID,
 				category: r.FactionCategory,
 				name:     r.FactionName,
 			},
-		}))
+		))
 	}
 	return oo, nil
 }
 
-type characterLoyaltyPointEntryFromDBModelParams struct {
-	entry           queries.CharacterLoyaltyPointEntry
-	corporationName string
-	faction         nullEveEntry
-}
+func characterLoyaltyPointEntryFromDBModel(
+	entry queries.CharacterLoyaltyPointEntry,
+	corporationName string,
+	faction nullEveEntry,
 
-func characterLoyaltyPointEntryFromDBModel(arg characterLoyaltyPointEntryFromDBModelParams) *app.CharacterLoyaltyPointEntry {
+) *app.CharacterLoyaltyPointEntry {
 	o2 := &app.CharacterLoyaltyPointEntry{
-		CharacterID: arg.entry.CharacterID,
+		CharacterID: entry.CharacterID,
 		Corporation: &app.EntityShort{
-			ID:   arg.entry.CorporationID,
-			Name: arg.corporationName,
+			ID:   entry.CorporationID,
+			Name: corporationName,
 		},
-		Faction:       eveEntityFromNullableDBModel(arg.faction),
-		LoyaltyPoints: arg.entry.LoyaltyPoints,
+		Faction:       eveEntityFromNullableDBModel(faction),
+		LoyaltyPoints: entry.LoyaltyPoints,
 		ID:            0,
 	}
 	return o2

--- a/internal/app/storage/charactermarketorder.go
+++ b/internal/app/storage/charactermarketorder.go
@@ -107,14 +107,14 @@ func (st *Storage) GetCharacterMarketOrder(ctx context.Context, characterID int6
 	if err != nil {
 		return nil, fmt.Errorf("GetCharacterMarketOrder for character %d: %w", characterID, convertGetError(err))
 	}
-	o := characterMarketOrderFromDBModel(characterMarketOrderFromDBModelParams{
-		cmo:              r.CharacterMarketOrder,
-		locationName:     r.LocationName,
-		locationSecurity: r.LocationSecurity,
-		owner:            r.EveEntity,
-		regionName:       r.RegionName,
-		typeName:         r.TypeName,
-	})
+	o := characterMarketOrderFromDBModel(
+		r.CharacterMarketOrder,
+		r.LocationName,
+		r.LocationSecurity,
+		r.EveEntity,
+		regionName(r.RegionName),
+		typeName(r.TypeName),
+	)
 	return o, err
 }
 
@@ -125,14 +125,14 @@ func (st *Storage) ListAllCharacterMarketOrders(ctx context.Context, isBuyOrders
 	}
 	oo := make([]*app.CharacterMarketOrder, len(rows))
 	for i, r := range rows {
-		oo[i] = characterMarketOrderFromDBModel(characterMarketOrderFromDBModelParams{
-			cmo:              r.CharacterMarketOrder,
-			locationName:     r.LocationName,
-			locationSecurity: r.LocationSecurity,
-			owner:            r.EveEntity,
-			regionName:       r.RegionName,
-			typeName:         r.TypeName,
-		})
+		oo[i] = characterMarketOrderFromDBModel(
+			r.CharacterMarketOrder,
+			r.LocationName,
+			r.LocationSecurity,
+			r.EveEntity,
+			regionName(r.RegionName),
+			typeName(r.TypeName),
+		)
 	}
 	return oo, nil
 }
@@ -152,56 +152,55 @@ func (st *Storage) ListCharacterMarketOrders(ctx context.Context, characterID in
 	}
 	oo := make([]*app.CharacterMarketOrder, len(rows))
 	for i, r := range rows {
-		oo[i] = characterMarketOrderFromDBModel(characterMarketOrderFromDBModelParams{
-			cmo:              r.CharacterMarketOrder,
-			locationName:     r.LocationName,
-			locationSecurity: r.LocationSecurity,
-			owner:            r.EveEntity,
-			regionName:       r.RegionName,
-			typeName:         r.TypeName,
-		})
+		oo[i] = characterMarketOrderFromDBModel(
+			r.CharacterMarketOrder,
+			r.LocationName,
+			r.LocationSecurity,
+			r.EveEntity,
+			regionName(r.RegionName),
+			typeName(r.TypeName),
+		)
 	}
 	return oo, nil
 }
 
-type characterMarketOrderFromDBModelParams struct {
-	cmo              queries.CharacterMarketOrder
-	locationName     string
-	locationSecurity sql.NullFloat64
-	owner            queries.EveEntity
-	regionName       string
-	typeName         string
-}
 
-func characterMarketOrderFromDBModel(arg characterMarketOrderFromDBModelParams) *app.CharacterMarketOrder {
+func characterMarketOrderFromDBModel(
+	cmo queries.CharacterMarketOrder,
+	locationName string,
+	locationSecurity sql.NullFloat64,
+	owner queries.EveEntity,
+	regionName regionName,
+	typeName typeName,
+) *app.CharacterMarketOrder {
 	o2 := &app.CharacterMarketOrder{
-		CharacterID:   arg.cmo.CharacterID,
-		Duration:      arg.cmo.Duration,
-		Escrow:        optional.FromNullFloat64(arg.cmo.Escrow),
-		IsBuyOrder:    optional.FromZeroValue(arg.cmo.IsBuyOrder),
-		IsCorporation: arg.cmo.IsCorporation,
-		Issued:        arg.cmo.Issued,
+		CharacterID:   cmo.CharacterID,
+		Duration:      cmo.Duration,
+		Escrow:        optional.FromNullFloat64(cmo.Escrow),
+		IsBuyOrder:    optional.FromZeroValue(cmo.IsBuyOrder),
+		IsCorporation: cmo.IsCorporation,
+		Issued:        cmo.Issued,
 		Location: &app.EveLocationShort{
-			ID:             arg.cmo.LocationID,
-			Name:           optional.New(arg.locationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.locationSecurity),
+			ID:             cmo.LocationID,
+			Name:           optional.New(locationName),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(locationSecurity),
 		},
-		MinVolume: optional.FromNullInt64(arg.cmo.MinVolume),
-		OrderID:   arg.cmo.OrderID,
-		Owner:     eveEntityFromDBModel(arg.owner),
-		Price:     arg.cmo.Price,
-		Range:     arg.cmo.Range,
+		MinVolume: optional.FromNullInt64(cmo.MinVolume),
+		OrderID:   cmo.OrderID,
+		Owner:     eveEntityFromDBModel(owner),
+		Price:     cmo.Price,
+		Range:     cmo.Range,
 		Region: &app.EntityShort{
-			ID:   arg.cmo.RegionID,
-			Name: arg.regionName,
+			ID:   cmo.RegionID,
+			Name: string(regionName),
 		},
-		State: orderStatusFromDBValue[arg.cmo.State],
+		State: orderStatusFromDBValue[cmo.State],
 		Type: &app.EntityShort{
-			ID:   arg.cmo.TypeID,
-			Name: arg.typeName,
+			ID:   cmo.TypeID,
+			Name: string(typeName),
 		},
-		VolumeRemains: arg.cmo.VolumeRemains,
-		VolumeTotal:   arg.cmo.VolumeTotal,
+		VolumeRemains: cmo.VolumeRemains,
+		VolumeTotal:   cmo.VolumeTotal,
 	}
 	return o2
 }

--- a/internal/app/storage/characternotification.go
+++ b/internal/app/storage/characternotification.go
@@ -368,16 +368,16 @@ func (st *Storage) GetCharacterNotification(ctx context.Context, characterID int
 	if !found {
 		nt = app.UnknownNotification
 	}
-	o := characterNotificationFromDBModel(characterNotificationFromDBModelParams{
-		cn: r.CharacterNotification,
-		nt: nt,
-		recipient: nullEveEntry{
+	o := characterNotificationFromDBModel(
+		r.CharacterNotification,
+		r.EveEntity,
+		nt,
+		nullEveEntry{
 			category: r.RecipientCategory,
 			id:       r.CharacterNotification.RecipientID,
 			name:     r.RecipientName,
 		},
-		sender: r.EveEntity,
-	})
+	)
 	return o, err
 }
 
@@ -441,16 +441,16 @@ func (st *Storage) ListCharacterNotificationsForTypes(ctx context.Context, chara
 		if !found {
 			nt = app.UnknownNotification
 		}
-		ee[i] = characterNotificationFromDBModel(characterNotificationFromDBModelParams{
-			cn: r.CharacterNotification,
-			nt: nt,
-			recipient: nullEveEntry{
+		ee[i] = characterNotificationFromDBModel(
+			r.CharacterNotification,
+			r.EveEntity,
+			nt,
+			nullEveEntry{
 				category: r.RecipientCategory,
 				id:       r.CharacterNotification.RecipientID,
 				name:     r.RecipientName,
 			},
-			sender: r.EveEntity,
-		})
+		)
 
 	}
 	return ee, nil
@@ -467,16 +467,16 @@ func (st *Storage) ListCharacterNotificationsAll(ctx context.Context, characterI
 		if !found {
 			nt = app.UnknownNotification
 		}
-		ee[i] = characterNotificationFromDBModel(characterNotificationFromDBModelParams{
-			cn: r.CharacterNotification,
-			nt: nt,
-			recipient: nullEveEntry{
+		ee[i] = characterNotificationFromDBModel(
+			r.CharacterNotification,
+			r.EveEntity,
+			nt,
+			nullEveEntry{
 				category: r.RecipientCategory,
 				id:       r.CharacterNotification.RecipientID,
 				name:     r.RecipientName,
 			},
-			sender: r.EveEntity,
-		})
+		)
 	}
 	return ee, nil
 }
@@ -492,16 +492,16 @@ func (st *Storage) ListCharacterNotificationsUnread(ctx context.Context, charact
 		if !found {
 			nt = app.UnknownNotification
 		}
-		ee[i] = characterNotificationFromDBModel(characterNotificationFromDBModelParams{
-			cn: r.CharacterNotification,
-			nt: nt,
-			recipient: nullEveEntry{
+		ee[i] = characterNotificationFromDBModel(
+			r.CharacterNotification,
+			r.EveEntity,
+			nt,
+			nullEveEntry{
 				category: r.RecipientCategory,
 				id:       r.CharacterNotification.RecipientID,
 				name:     r.RecipientName,
 			},
-			sender: r.EveEntity,
-		})
+		)
 	}
 	return ee, nil
 }
@@ -524,41 +524,39 @@ func (st *Storage) ListCharacterNotificationsUnprocessed(ctx context.Context, ch
 		if !found {
 			nt = app.UnknownNotification
 		}
-		ee[i] = characterNotificationFromDBModel(characterNotificationFromDBModelParams{
-			cn: r.CharacterNotification,
-			nt: nt,
-			recipient: nullEveEntry{
+		ee[i] = characterNotificationFromDBModel(
+			r.CharacterNotification,
+			r.EveEntity,
+			nt,
+			nullEveEntry{
 				category: r.RecipientCategory,
 				id:       r.CharacterNotification.RecipientID,
 				name:     r.RecipientName,
 			},
-			sender: r.EveEntity,
-		})
+		)
 	}
 	return ee, nil
 }
 
-type characterNotificationFromDBModelParams struct {
-	cn        queries.CharacterNotification
-	sender    queries.EveEntity
-	nt        app.EveNotificationType
-	recipient nullEveEntry
-}
-
-func characterNotificationFromDBModel(arg characterNotificationFromDBModelParams) *app.CharacterNotification {
+func characterNotificationFromDBModel(
+	cn queries.CharacterNotification,
+	sender queries.EveEntity,
+	nt app.EveNotificationType,
+	recipient nullEveEntry,
+) *app.CharacterNotification {
 	o2 := &app.CharacterNotification{
-		ID:             arg.cn.ID,
-		Body:           optional.FromNullString(arg.cn.Body),
-		CharacterID:    arg.cn.CharacterID,
-		IsProcessed:    arg.cn.IsProcessed,
-		IsRead:         optional.FromZeroValue(arg.cn.IsRead),
-		NotificationID: arg.cn.NotificationID,
-		Recipient:      eveEntityFromNullableDBModel(arg.recipient),
-		Sender:         eveEntityFromDBModel(arg.sender),
-		Text:           optional.FromZeroValue(arg.cn.Text),
-		Timestamp:      arg.cn.Timestamp,
-		Title:          optional.FromNullString(arg.cn.Title),
-		Type:           arg.nt,
+		ID:             cn.ID,
+		Body:           optional.FromNullString(cn.Body),
+		CharacterID:    cn.CharacterID,
+		IsProcessed:    cn.IsProcessed,
+		IsRead:         optional.FromZeroValue(cn.IsRead),
+		NotificationID: cn.NotificationID,
+		Recipient:      eveEntityFromNullableDBModel(recipient),
+		Sender:         eveEntityFromDBModel(sender),
+		Text:           optional.FromZeroValue(cn.Text),
+		Timestamp:      cn.Timestamp,
+		Title:          optional.FromNullString(cn.Title),
+		Type:           nt,
 	}
 	return o2
 }

--- a/internal/app/storage/characterskillqueueitem.go
+++ b/internal/app/storage/characterskillqueueitem.go
@@ -85,12 +85,12 @@ func (st *Storage) GetCharacterSkillqueueItem(ctx context.Context, characterID i
 	if err != nil {
 		return nil, wrapErr(convertGetError(err))
 	}
-	o := skillqueueItemFromDBModel(skillqueueItemFromDBModelParams{
-		description: r.SkillDescription,
-		groupName:   r.GroupName,
-		it:          r.CharacterSkillqueueItem,
-		skillName:   r.SkillName,
-	})
+	o := skillqueueItemFromDBModel(
+		description(r.SkillDescription),
+		groupName(r.GroupName),
+		r.CharacterSkillqueueItem,
+		skillName(r.SkillName),
+	)
 	return o, nil
 }
 
@@ -108,12 +108,12 @@ func (st *Storage) ListCharacterSkillqueueItems(ctx context.Context, characterID
 	}
 	var oo []*app.CharacterSkillqueueItem
 	for _, r := range rows {
-		oo = append(oo, skillqueueItemFromDBModel(skillqueueItemFromDBModelParams{
-			description: r.SkillDescription,
-			groupName:   r.GroupName,
-			it:          r.CharacterSkillqueueItem,
-			skillName:   r.SkillName,
-		}))
+		oo = append(oo, skillqueueItemFromDBModel(
+			description(r.SkillDescription),
+			groupName(r.GroupName),
+			r.CharacterSkillqueueItem,
+			skillName(r.SkillName),
+		))
 	}
 	return oo, nil
 }
@@ -143,28 +143,27 @@ func (st *Storage) ReplaceCharacterSkillqueueItems(ctx context.Context, characte
 	return nil
 }
 
-type skillqueueItemFromDBModelParams struct {
-	description string
-	groupName   string
-	it          queries.CharacterSkillqueueItem
-	skillName   string
-}
+func skillqueueItemFromDBModel(
+	description description,
+	groupName groupName,
+	it queries.CharacterSkillqueueItem,
+	skillName skillName,
 
-func skillqueueItemFromDBModel(arg skillqueueItemFromDBModelParams) *app.CharacterSkillqueueItem {
+) *app.CharacterSkillqueueItem {
 	o := &app.CharacterSkillqueueItem{
-		CharacterID:      arg.it.CharacterID,
-		FinishDate:       optional.FromNullTime(arg.it.FinishDate),
-		FinishedLevel:    arg.it.FinishedLevel,
-		GroupName:        arg.groupName,
-		ID:               arg.it.ID,
-		LevelEndSP:       optional.FromNullInt64(arg.it.LevelEndSp),
-		LevelStartSP:     optional.FromNullInt64(arg.it.LevelStartSp),
-		QueuePosition:    arg.it.QueuePosition,
-		SkillDescription: arg.description,
-		SkillID:          arg.it.EveTypeID,
-		SkillName:        arg.skillName,
-		StartDate:        optional.FromNullTime(arg.it.StartDate),
-		TrainingStartSP:  optional.FromNullInt64(arg.it.TrainingStartSp),
+		CharacterID:      it.CharacterID,
+		FinishDate:       optional.FromNullTime(it.FinishDate),
+		FinishedLevel:    it.FinishedLevel,
+		GroupName:        string(groupName),
+		ID:               it.ID,
+		LevelEndSP:       optional.FromNullInt64(it.LevelEndSp),
+		LevelStartSP:     optional.FromNullInt64(it.LevelStartSp),
+		QueuePosition:    it.QueuePosition,
+		SkillDescription: string(description),
+		SkillID:          it.EveTypeID,
+		SkillName:        string(skillName),
+		StartDate:        optional.FromNullTime(it.StartDate),
+		TrainingStartSP:  optional.FromNullInt64(it.TrainingStartSp),
 	}
 	return o
 }

--- a/internal/app/storage/corporation.go
+++ b/internal/app/storage/corporation.go
@@ -83,34 +83,34 @@ func (st *Storage) GetAnyCorporation(ctx context.Context) (*app.Corporation, err
 }
 
 func corporationFromDBModel(r queries.GetCorporationRow) *app.Corporation {
-	ec := eveCorporationFromDBModel(eveCorporationFromDBModelParams{
-		corporation: r.EveCorporation,
-		ceo: nullEveEntry{
+	ec := eveCorporationFromDBModel(
+		r.EveCorporation,
+		nullCEO{
 			id:       r.EveCorporation.CeoID,
 			name:     r.CeoName,
 			category: r.CeoCategory,
 		},
-		creator: nullEveEntry{
+		nullCreator{
 			id:       r.EveCorporation.CreatorID,
 			name:     r.CreatorName,
 			category: r.CreatorCategory,
 		},
-		alliance: nullEveEntry{
+		nullAlliance{
 			id:       r.EveCorporation.AllianceID,
 			name:     r.AllianceName,
 			category: r.AllianceCategory,
 		},
-		faction: nullEveEntry{
+		nullFaction{
 			id:       r.EveCorporation.FactionID,
 			name:     r.FactionName,
 			category: r.FactionCategory,
 		},
-		station: nullEveEntry{
+		nullStation{
 			id:       r.EveCorporation.HomeStationID,
 			name:     r.StationName,
 			category: r.StationCategory,
 		},
-	})
+	)
 	o := &app.Corporation{
 		ID:             r.EveCorporation.ID,
 		EveCorporation: ec,

--- a/internal/app/storage/corporationcontract.go
+++ b/internal/app/storage/corporationcontract.go
@@ -166,25 +166,25 @@ func (st *Storage) GetCorporationContract(ctx context.Context, corporationID, co
 	if err != nil {
 		return nil, wrapErr(convertGetError(err))
 	}
-	c := r.CorporationContract
-	acceptor := nullEveEntry{id: c.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
-	assignee := nullEveEntry{id: c.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
-	o := corporationContractFromDBModel(corporationContractFromDBModelParams{
-		acceptor:                 acceptor,
-		assignee:                 assignee,
-		contract:                 c,
-		endLocationName:          r.EndLocationName,
-		endSolarSystemID:         r.EndSolarSystemID,
-		endSolarSystemName:       r.EndSolarSystemName,
-		endSolarSystemSecurity:   r.EndSolarSystemSecurityStatus,
-		issuer:                   r.EveEntity_2,
-		issuerCorporation:        r.EveEntity,
-		items:                    r.Items,
-		startLocationName:        r.StartLocationName,
-		startSolarSystemID:       r.StartSolarSystemID,
-		startSolarSystemName:     r.StartSolarSystemName,
-		startSolarSystemSecurity: r.StartSolarSystemSecurityStatus,
-	})
+	cc := r.CorporationContract
+	acceptor := nullAcceptor{id: cc.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
+	assignee := nullAssignee{id: cc.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
+	o := corporationContractFromDBModel(
+		acceptor,
+		assignee,
+		cc,
+		endLocationName(r.EndLocationName),
+		endSolarSystemID(r.EndSolarSystemID),
+		endSolarSystemName(r.EndSolarSystemName),
+		endSolarSystemSecurity(r.EndSolarSystemSecurityStatus),
+		issuer(r.EveEntity_2),
+		issuerCorporation(r.EveEntity),
+		r.Items,
+		startLocationName(r.StartLocationName),
+		startSolarSystemID(r.StartSolarSystemID),
+		startSolarSystemName(r.StartSolarSystemName),
+		startSolarSystemSecurity(r.StartSolarSystemSecurityStatus),
+	)
 	return o, nil
 }
 
@@ -203,25 +203,25 @@ func (st *Storage) ListCorporationContracts(ctx context.Context, corporationID i
 	}
 	oo := make([]*app.CorporationContract, len(rows))
 	for i, r := range rows {
-		c := r.CorporationContract
-		acceptor := nullEveEntry{id: c.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
-		assignee := nullEveEntry{id: c.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
-		oo[i] = corporationContractFromDBModel(corporationContractFromDBModelParams{
-			acceptor:                 acceptor,
-			assignee:                 assignee,
-			contract:                 c,
-			endLocationName:          r.EndLocationName,
-			endSolarSystemID:         r.EndSolarSystemID,
-			endSolarSystemName:       r.EndSolarSystemName,
-			endSolarSystemSecurity:   r.EndSolarSystemSecurityStatus,
-			issuer:                   r.EveEntity_2,
-			issuerCorporation:        r.EveEntity,
-			items:                    r.Items,
-			startLocationName:        r.StartLocationName,
-			startSolarSystemID:       r.StartSolarSystemID,
-			startSolarSystemName:     r.StartSolarSystemName,
-			startSolarSystemSecurity: r.StartSolarSystemSecurityStatus,
-		})
+		cc := r.CorporationContract
+		acceptor := nullAcceptor{id: cc.AcceptorID, name: r.AcceptorName, category: r.AcceptorCategory}
+		assignee := nullAssignee{id: cc.AssigneeID, name: r.AssigneeName, category: r.AssigneeCategory}
+		oo[i] = corporationContractFromDBModel(
+			acceptor,
+			assignee,
+			cc,
+			endLocationName(r.EndLocationName),
+			endSolarSystemID(r.EndSolarSystemID),
+			endSolarSystemName(r.EndSolarSystemName),
+			endSolarSystemSecurity(r.EndSolarSystemSecurityStatus),
+			issuer(r.EveEntity_2),
+			issuerCorporation(r.EveEntity),
+			r.Items,
+			startLocationName(r.StartLocationName),
+			startSolarSystemID(r.StartSolarSystemID),
+			startSolarSystemName(r.StartSolarSystemName),
+			startSolarSystemSecurity(r.StartSolarSystemSecurityStatus),
+		)
 	}
 	return oo, nil
 }
@@ -282,79 +282,77 @@ func (st *Storage) UpdateCorporationContractNotified(ctx context.Context, id int
 	return nil
 }
 
-type corporationContractFromDBModelParams struct {
-	acceptor                 nullEveEntry
-	assignee                 nullEveEntry
-	contract                 queries.CorporationContract
-	endLocationName          sql.NullString
-	endSolarSystemID         sql.NullInt64
-	endSolarSystemName       sql.NullString
-	endSolarSystemSecurity   sql.NullFloat64
-	issuer                   queries.EveEntity
-	issuerCorporation        queries.EveEntity
-	items                    any
-	startLocationName        sql.NullString
-	startSolarSystemID       sql.NullInt64
-	startSolarSystemName     sql.NullString
-	startSolarSystemSecurity sql.NullFloat64
-}
-
-func corporationContractFromDBModel(arg corporationContractFromDBModelParams) *app.CorporationContract {
-	i2, ok := arg.items.(string)
+func corporationContractFromDBModel(
+	acceptor nullAcceptor,
+	assignee nullAssignee,
+	cc queries.CorporationContract,
+	endLocationName endLocationName,
+	endSolarSystemID endSolarSystemID,
+	endSolarSystemName endSolarSystemName,
+	endSolarSystemSecurity endSolarSystemSecurity,
+	issuer issuer,
+	issuerCorporation issuerCorporation,
+	items any,
+	startLocationName startLocationName,
+	startSolarSystemID startSolarSystemID,
+	startSolarSystemName startSolarSystemName,
+	startSolarSystemSecurity startSolarSystemSecurity,
+) *app.CorporationContract {
+	i2, ok := items.(string)
 	if !ok {
 		i2 = ""
 	}
 	o2 := &app.CorporationContract{
-		Acceptor:          eveEntityFromNullableDBModel(arg.acceptor),
-		Assignee:          eveEntityFromNullableDBModel(arg.assignee),
-		Availability:      corporationContractAvailabilityFromDBValue[arg.contract.Availability],
-		Buyout:            optional.FromZeroValue(arg.contract.Buyout),
-		CorporationID:     arg.contract.CorporationID,
-		Collateral:        optional.FromZeroValue(arg.contract.Collateral),
-		ContractID:        arg.contract.ContractID,
-		DateAccepted:      optional.FromNullTime(arg.contract.DateAccepted),
-		DateCompleted:     optional.FromNullTime(arg.contract.DateCompleted),
-		DateExpired:       arg.contract.DateExpired,
-		DateIssued:        arg.contract.DateIssued,
-		DaysToComplete:    optional.FromZeroValue(arg.contract.DaysToComplete),
-		ForCorporation:    arg.contract.ForCorporation,
-		ID:                arg.contract.ID,
-		Issuer:            eveEntityFromDBModel(arg.issuer),
-		IssuerCorporation: eveEntityFromDBModel(arg.issuerCorporation),
+		Acceptor:          eveEntityFromNullableDBModel(nullEveEntry(acceptor)),
+		Assignee:          eveEntityFromNullableDBModel(nullEveEntry(assignee)),
+		Availability:      corporationContractAvailabilityFromDBValue[cc.Availability],
+		Buyout:            optional.FromZeroValue(cc.Buyout),
+		CorporationID:     cc.CorporationID,
+		Collateral:        optional.FromZeroValue(cc.Collateral),
+		ContractID:        cc.ContractID,
+		DateAccepted:      optional.FromNullTime(cc.DateAccepted),
+		DateCompleted:     optional.FromNullTime(cc.DateCompleted),
+		DateExpired:       cc.DateExpired,
+		DateIssued:        cc.DateIssued,
+		DaysToComplete:    optional.FromZeroValue(cc.DaysToComplete),
+		ForCorporation:    cc.ForCorporation,
+		ID:                cc.ID,
+		Issuer:            eveEntityFromDBModel(queries.EveEntity(issuer)),
+		IssuerCorporation: eveEntityFromDBModel(queries.EveEntity(issuerCorporation)),
 		Items:             strings.Split(i2, ","),
-		Price:             optional.FromZeroValue(arg.contract.Price),
-		Reward:            optional.FromZeroValue(arg.contract.Reward),
-		Status:            corporationContractStatusFromDBValue[arg.contract.Status],
-		StatusNotified:    corporationContractStatusFromDBValue[arg.contract.StatusNotified],
-		Title:             optional.FromZeroValue(arg.contract.Title),
-		Type:              corporationContractTypeFromDBValue[arg.contract.Type],
-		UpdatedAt:         arg.contract.UpdatedAt,
-		Volume:            optional.FromZeroValue(arg.contract.Volume),
+		Price:             optional.FromZeroValue(cc.Price),
+		Reward:            optional.FromZeroValue(cc.Reward),
+		Status:            corporationContractStatusFromDBValue[cc.Status],
+		StatusNotified:    corporationContractStatusFromDBValue[cc.StatusNotified],
+		Title:             optional.FromZeroValue(cc.Title),
+		Type:              corporationContractTypeFromDBValue[cc.Type],
+		UpdatedAt:         cc.UpdatedAt,
+		Volume:            optional.FromZeroValue(cc.Volume),
 	}
-	if arg.contract.EndLocationID.Valid {
+	if cc.EndLocationID.Valid {
 		o2.EndLocation = optional.New(&app.EveLocationShort{
-			ID:             arg.contract.EndLocationID.Int64,
-			Name:           optional.FromNullString(arg.endLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.endSolarSystemSecurity),
+			ID:             cc.EndLocationID.Int64,
+			Name:           optional.FromNullString(sql.NullString(endLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(endSolarSystemSecurity)),
 		})
 	}
-	if arg.contract.StartLocationID.Valid {
+	if cc.StartLocationID.Valid {
 		o2.StartLocation = optional.New(&app.EveLocationShort{
-			ID:             arg.contract.StartLocationID.Int64,
-			Name:           optional.FromNullString(arg.startLocationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.startSolarSystemSecurity),
+			ID:             cc.StartLocationID.Int64,
+			Name:           optional.FromNullString(sql.NullString(startLocationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(sql.NullFloat64(startSolarSystemSecurity)),
 		})
 	}
-	if arg.endSolarSystemID.Valid && arg.endSolarSystemName.Valid {
+	if endSolarSystemID.Valid && endSolarSystemName.Valid {
 		o2.EndSolarSystem = optional.New(&app.EntityShort{
-			ID:   arg.endSolarSystemID.Int64,
-			Name: arg.endSolarSystemName.String,
+			ID:   endSolarSystemID.Int64,
+			Name: endSolarSystemName.String,
 		})
 	}
-	if arg.startSolarSystemID.Valid && arg.startSolarSystemName.Valid {
+	if startSolarSystemID.Valid && startSolarSystemName.Valid {
 		o2.StartSolarSystem = optional.New(&app.EntityShort{
-			ID:   arg.startSolarSystemID.Int64,
-			Name: arg.startSolarSystemName.String,
+			ID:   startSolarSystemID.Int64,
+			Name: startSolarSystemName.String,
 		})
 	}
 	return o2

--- a/internal/app/storage/corporationindustryjob.go
+++ b/internal/app/storage/corporationindustryjob.go
@@ -59,15 +59,15 @@ func (st *Storage) GetCorporationIndustryJob(ctx context.Context, corporationID,
 	if err != nil {
 		return nil, fmt.Errorf("get industry job for corporation %d: %w", corporationID, convertGetError(err))
 	}
-	o := corporationIndustryJobFromDBModel(corporationIndustryJobFromDBModelParams{
-		blueprintTypeName:      r.BlueprintTypeName,
-		cij:                    r.CorporationIndustryJob,
-		completedCharacterName: r.CompletedCharacterName,
-		installer:              r.EveEntity,
-		locationName:           r.LocationName,
-		locationSecurity:       r.StationSecurity,
-		productTypeName:        r.ProductTypeName,
-	})
+	o := corporationIndustryJobFromDBModel(
+		blueprintTypeName(r.BlueprintTypeName),
+		r.CorporationIndustryJob,
+		completedCharacterName(r.CompletedCharacterName),
+		r.EveEntity,
+		locationName(r.LocationName),
+		r.StationSecurity,
+		productTypeName(r.ProductTypeName),
+	)
 	return o, err
 }
 
@@ -84,15 +84,15 @@ func (st *Storage) ListCorporationIndustryJobs(ctx context.Context, corporationI
 	}
 	oo := make([]*app.CorporationIndustryJob, len(rows))
 	for i, r := range rows {
-		oo[i] = corporationIndustryJobFromDBModel(corporationIndustryJobFromDBModelParams{
-			blueprintTypeName:      r.BlueprintTypeName,
-			cij:                    r.CorporationIndustryJob,
-			completedCharacterName: r.CompletedCharacterName,
-			installer:              r.EveEntity,
-			locationName:           r.LocationName,
-			locationSecurity:       r.StationSecurity,
-			productTypeName:        r.ProductTypeName,
-		})
+		oo[i] = corporationIndustryJobFromDBModel(
+			blueprintTypeName(r.BlueprintTypeName),
+			r.CorporationIndustryJob,
+			completedCharacterName(r.CompletedCharacterName),
+			r.EveEntity,
+			locationName(r.LocationName),
+			r.StationSecurity,
+			productTypeName(r.ProductTypeName),
+		)
 	}
 	return oo, nil
 }
@@ -104,72 +104,71 @@ func (st *Storage) ListAllCorporationIndustryJobs(ctx context.Context) ([]*app.C
 	}
 	oo := make([]*app.CorporationIndustryJob, len(rows))
 	for i, r := range rows {
-		oo[i] = corporationIndustryJobFromDBModel(corporationIndustryJobFromDBModelParams{
-			blueprintTypeName:      r.BlueprintTypeName,
-			cij:                    r.CorporationIndustryJob,
-			completedCharacterName: r.CompletedCharacterName,
-			installer:              r.EveEntity,
-			locationName:           r.LocationName,
-			locationSecurity:       r.StationSecurity,
-			productTypeName:        r.ProductTypeName,
-		})
+		oo[i] = corporationIndustryJobFromDBModel(
+			blueprintTypeName(r.BlueprintTypeName),
+			r.CorporationIndustryJob,
+			completedCharacterName(r.CompletedCharacterName),
+			r.EveEntity,
+			locationName(r.LocationName),
+			r.StationSecurity,
+			productTypeName(r.ProductTypeName),
+		)
 	}
 	return oo, nil
 }
 
-type corporationIndustryJobFromDBModelParams struct {
-	blueprintTypeName      string
-	cij                    queries.CorporationIndustryJob
-	completedCharacterName sql.NullString
-	installer              queries.EveEntity
-	locationName           string
-	locationSecurity       sql.NullFloat64
-	productTypeName        sql.NullString
-}
 
-func corporationIndustryJobFromDBModel(arg corporationIndustryJobFromDBModelParams) *app.CorporationIndustryJob {
+func corporationIndustryJobFromDBModel(
+	blueprintTypeName blueprintTypeName,
+	cij queries.CorporationIndustryJob,
+	completedCharacterName completedCharacterName,
+	installer queries.EveEntity,
+	locationName locationName,
+	locationSecurity sql.NullFloat64,
+	productTypeName productTypeName,
+) *app.CorporationIndustryJob {
 	o2 := &app.CorporationIndustryJob{
-		Activity:            app.IndustryActivity(arg.cij.ActivityID),
-		BlueprintID:         arg.cij.BlueprintID,
-		BlueprintLocationID: arg.cij.BlueprintLocationID,
+		Activity:            app.IndustryActivity(cij.ActivityID),
+		BlueprintID:         cij.BlueprintID,
+		BlueprintLocationID: cij.BlueprintLocationID,
 		BlueprintType: &app.EntityShort{
-			ID:   arg.cij.BlueprintTypeID,
-			Name: arg.blueprintTypeName,
+			ID:   cij.BlueprintTypeID,
+			Name: string(blueprintTypeName),
 		},
-		CorporationID: arg.cij.CorporationID,
-		CompletedDate: optional.FromNullTime(arg.cij.CompletedDate),
-		Cost:          optional.FromNullFloat64(arg.cij.Cost),
-		Duration:      int(arg.cij.Duration),
-		EndDate:       arg.cij.EndDate,
-		FacilityID:    arg.cij.FacilityID,
-		ID:            arg.cij.ID,
-		Installer:     eveEntityFromDBModel(arg.installer),
-		JobID:         arg.cij.JobID,
-		LicensedRuns:  optional.FromNullInt64ToInteger[int](arg.cij.LicensedRuns),
-		PauseDate:     optional.FromNullTime(arg.cij.PauseDate),
-		Probability:   optional.FromNullFloat64ToFloat32(arg.cij.Probability),
-		Runs:          int(arg.cij.Runs),
+		CorporationID: cij.CorporationID,
+		CompletedDate: optional.FromNullTime(cij.CompletedDate),
+		Cost:          optional.FromNullFloat64(cij.Cost),
+		Duration:      int(cij.Duration),
+		EndDate:       cij.EndDate,
+		FacilityID:    cij.FacilityID,
+		ID:            cij.ID,
+		Installer:     eveEntityFromDBModel(installer),
+		JobID:         cij.JobID,
+		LicensedRuns:  optional.FromNullInt64ToInteger[int](cij.LicensedRuns),
+		PauseDate:     optional.FromNullTime(cij.PauseDate),
+		Probability:   optional.FromNullFloat64ToFloat32(cij.Probability),
+		Runs:          int(cij.Runs),
 		Location: &app.EveLocationShort{
-			ID:             arg.cij.LocationID,
-			Name:           optional.New(arg.locationName),
-			SecurityStatus: optional.FromNullFloat64ToFloat32(arg.locationSecurity),
+			ID:             cij.LocationID,
+			Name:           optional.New(string(locationName)),
+			SecurityStatus: optional.FromNullFloat64ToFloat32(locationSecurity),
 		},
-		OutputLocationID: arg.cij.OutputLocationID,
-		StartDate:        arg.cij.StartDate,
-		Status:           jobStatusFromDBValue[arg.cij.Status],
-		SuccessfulRuns:   optional.FromNullInt64ToInteger[int64](arg.cij.SuccessfulRuns),
+		OutputLocationID: cij.OutputLocationID,
+		StartDate:        cij.StartDate,
+		Status:           jobStatusFromDBValue[cij.Status],
+		SuccessfulRuns:   optional.FromNullInt64ToInteger[int64](cij.SuccessfulRuns),
 	}
-	if arg.cij.CompletedCharacterID.Valid && arg.completedCharacterName.Valid {
+	if cij.CompletedCharacterID.Valid && completedCharacterName.Valid {
 		o2.CompletedCharacter = optional.New(&app.EveEntity{
-			ID:       arg.cij.CompletedCharacterID.Int64,
-			Name:     arg.completedCharacterName.String,
+			ID:       cij.CompletedCharacterID.Int64,
+			Name:     completedCharacterName.String,
 			Category: app.EveEntityCharacter,
 		})
 	}
-	if arg.cij.ProductTypeID.Valid && arg.productTypeName.Valid {
+	if cij.ProductTypeID.Valid && productTypeName.Valid {
 		o2.ProductType = optional.New(&app.EntityShort{
-			ID:   arg.cij.ProductTypeID.Int64,
-			Name: arg.productTypeName.String,
+			ID:   cij.ProductTypeID.Int64,
+			Name: productTypeName.String,
 		})
 	}
 	return o2

--- a/internal/app/storage/corporationstructure.go
+++ b/internal/app/storage/corporationstructure.go
@@ -63,7 +63,7 @@ func (st *Storage) DeleteCorporationStructures(ctx context.Context, corporationI
 		return nil
 	}
 	err := st.qRW.DeleteCorporationStructures(ctx, queries.DeleteCorporationStructuresParams{
-		CorporationID:corporationID,
+		CorporationID: corporationID,
 		StructureIds:  slices.Collect(structureIDs.All()),
 	})
 	if err != nil {
@@ -81,7 +81,7 @@ func (st *Storage) GetCorporationStructure(ctx context.Context, corporationID in
 		return nil, wrapErr(app.ErrInvalid)
 	}
 	r, err := st.qRO.GetCorporationStructure(ctx, queries.GetCorporationStructureParams{
-		CorporationID:corporationID,
+		CorporationID: corporationID,
 		StructureID:   structureID,
 	})
 	if err != nil {
@@ -91,16 +91,17 @@ func (st *Storage) GetCorporationStructure(ctx context.Context, corporationID in
 	if err != nil {
 		return nil, wrapErr(convertGetError(err))
 	}
-	return corporationStructureFromDBModel(corporationStructureFromDBModelParams{
-		corporationStructure: r.CorporationStructure,
-		eveSolarSystem:       r.EveSolarSystem,
-		eveConstellation:     r.EveConstellation,
-		eveRegion:            r.EveRegion,
-		eveType:              r.EveType,
-		eveGroup:             r.EveGroup,
-		eveCategory:          r.EveCategory,
-		services:             services,
-	}), nil
+	o := corporationStructureFromDBModel(
+		r.CorporationStructure,
+		r.EveSolarSystem,
+		r.EveConstellation,
+		r.EveRegion,
+		r.EveType,
+		r.EveGroup,
+		r.EveCategory,
+		services,
+	)
+	return o, nil
 }
 
 func (st *Storage) ListCorporationStructures(ctx context.Context, corporationID int64) ([]*app.CorporationStructure, error) {
@@ -110,7 +111,7 @@ func (st *Storage) ListCorporationStructures(ctx context.Context, corporationID 
 	if corporationID == 0 {
 		return nil, wrapErr(app.ErrInvalid)
 	}
-	rows, err := st.qRO.ListCorporationStructures(ctx,corporationID)
+	rows, err := st.qRO.ListCorporationStructures(ctx, corporationID)
 	if err != nil {
 		return nil, wrapErr(err)
 	}
@@ -120,16 +121,16 @@ func (st *Storage) ListCorporationStructures(ctx context.Context, corporationID 
 		if err != nil {
 			return nil, wrapErr(convertGetError(err))
 		}
-		oo[i] = corporationStructureFromDBModel(corporationStructureFromDBModelParams{
-			corporationStructure: r.CorporationStructure,
-			eveSolarSystem:       r.EveSolarSystem,
-			eveConstellation:     r.EveConstellation,
-			eveRegion:            r.EveRegion,
-			eveType:              r.EveType,
-			eveGroup:             r.EveGroup,
-			eveCategory:          r.EveCategory,
-			services:             services,
-		})
+		oo[i] = corporationStructureFromDBModel(
+			r.CorporationStructure,
+			r.EveSolarSystem,
+			r.EveConstellation,
+			r.EveRegion,
+			r.EveType,
+			r.EveGroup,
+			r.EveCategory,
+			services,
+		)
 	}
 	return oo, nil
 }
@@ -141,44 +142,42 @@ func (st *Storage) ListCorporationStructureIDs(ctx context.Context, corporationI
 	if corporationID == 0 {
 		return set.Set[int64]{}, wrapErr(app.ErrInvalid)
 	}
-	ids, err := st.qRO.ListCorporationStructureIDs(ctx,corporationID)
+	ids, err := st.qRO.ListCorporationStructureIDs(ctx, corporationID)
 	if err != nil {
 		return set.Set[int64]{}, wrapErr(err)
 	}
 	return set.Collect(slices.Values(ids)), nil
 }
 
-type corporationStructureFromDBModelParams struct {
-	corporationStructure queries.CorporationStructure
-	eveSolarSystem       queries.EveSolarSystem
-	eveConstellation     queries.EveConstellation
-	eveRegion            queries.EveRegion
-	eveType              queries.EveType
-	eveGroup             queries.EveGroup
-	eveCategory          queries.EveCategory
-	services             []*app.StructureService
-}
-
-func corporationStructureFromDBModel(arg corporationStructureFromDBModelParams) *app.CorporationStructure {
-	o2 := &app.CorporationStructure{
-		CorporationID:     arg.corporationStructure.CorporationID,
-		FuelExpires:        optional.FromNullTime(arg.corporationStructure.FuelExpires),
-		ID:                 arg.corporationStructure.ID,
-		Name:               optional.FromZeroValue(arg.corporationStructure.Name),
-		NextReinforceApply: optional.FromNullTime(arg.corporationStructure.NextReinforceApply),
-		NextReinforceHour:  optional.FromNullInt64(arg.corporationStructure.NextReinforceHour),
-		ProfileID:          arg.corporationStructure.ProfileID,
-		ReinforceHour:      optional.FromNullInt64(arg.corporationStructure.ReinforceHour),
-		Services:           arg.services,
-		State:              structureStateFromDBValue[arg.corporationStructure.State],
-		StateTimerEnd:      optional.FromNullTime(arg.corporationStructure.StateTimerEnd),
-		StateTimerStart:    optional.FromNullTime(arg.corporationStructure.StateTimerStart),
-		StructureID:        arg.corporationStructure.StructureID,
-		System:             eveSolarSystemFromDBModel(arg.eveSolarSystem, arg.eveConstellation, arg.eveRegion),
-		Type:               eveTypeFromDBModel(arg.eveType, arg.eveGroup, arg.eveCategory),
-		UnanchorsAt:        optional.FromNullTime(arg.corporationStructure.UnanchorsAt),
+func corporationStructureFromDBModel(
+	corporationStructure queries.CorporationStructure,
+	eveSolarSystem queries.EveSolarSystem,
+	eveConstellation queries.EveConstellation,
+	eveRegion queries.EveRegion,
+	eveType queries.EveType,
+	eveGroup queries.EveGroup,
+	eveCategory queries.EveCategory,
+	services []*app.StructureService,
+) *app.CorporationStructure {
+	o := &app.CorporationStructure{
+		CorporationID:      corporationStructure.CorporationID,
+		FuelExpires:        optional.FromNullTime(corporationStructure.FuelExpires),
+		ID:                 corporationStructure.ID,
+		Name:               optional.FromZeroValue(corporationStructure.Name),
+		NextReinforceApply: optional.FromNullTime(corporationStructure.NextReinforceApply),
+		NextReinforceHour:  optional.FromNullInt64(corporationStructure.NextReinforceHour),
+		ProfileID:          corporationStructure.ProfileID,
+		ReinforceHour:      optional.FromNullInt64(corporationStructure.ReinforceHour),
+		Services:           services,
+		State:              structureStateFromDBValue[corporationStructure.State],
+		StateTimerEnd:      optional.FromNullTime(corporationStructure.StateTimerEnd),
+		StateTimerStart:    optional.FromNullTime(corporationStructure.StateTimerStart),
+		StructureID:        corporationStructure.StructureID,
+		System:             eveSolarSystemFromDBModel(eveSolarSystem, eveConstellation, eveRegion),
+		Type:               eveTypeFromDBModel(eveType, eveGroup, eveCategory),
+		UnanchorsAt:        optional.FromNullTime(corporationStructure.UnanchorsAt),
 	}
-	return o2
+	return o
 }
 
 type StructureServiceParams struct {
@@ -220,7 +219,7 @@ func (st *Storage) UpdateOrCreateCorporationStructure(ctx context.Context, arg U
 		return wrapErr(app.ErrInvalid)
 	}
 	id, err := st.qRW.UpdateOrCreateCorporationStructure(ctx, queries.UpdateOrCreateCorporationStructureParams{
-		CorporationID:     arg.CorporationID,
+		CorporationID:      arg.CorporationID,
 		FuelExpires:        optional.ToNullTime(arg.FuelExpires),
 		Name:               arg.Name.ValueOrZero(),
 		NextReinforceApply: optional.ToNullTime(arg.NextReinforceApply),
@@ -231,8 +230,8 @@ func (st *Storage) UpdateOrCreateCorporationStructure(ctx context.Context, arg U
 		StateTimerEnd:      optional.ToNullTime(arg.StateTimerEnd),
 		StateTimerStart:    optional.ToNullTime(arg.StateTimerStart),
 		StructureID:        arg.StructureID,
-		SystemID:          arg.SystemID,
-		TypeID:            arg.TypeID,
+		SystemID:           arg.SystemID,
+		TypeID:             arg.TypeID,
 		UnanchorsAt:        optional.ToNullTime(arg.UnanchorsAt),
 	})
 	if err != nil {

--- a/internal/app/storage/evecorporation.go
+++ b/internal/app/storage/evecorporation.go
@@ -18,63 +18,61 @@ func (st *Storage) GetEveCorporation(ctx context.Context, corporationID int64) (
 	if err != nil {
 		return nil, fmt.Errorf("get EveCorporation %d: %w", corporationID, convertGetError(err))
 	}
-	c := eveCorporationFromDBModel(eveCorporationFromDBModelParams{
-		corporation: r.EveCorporation,
-		ceo: nullEveEntry{
+	c := eveCorporationFromDBModel(
+		r.EveCorporation,
+		nullCEO{
 			id:       r.EveCorporation.CeoID,
 			name:     r.CeoName,
 			category: r.CeoCategory,
 		},
-		creator: nullEveEntry{
+		nullCreator{
 			id:       r.EveCorporation.CreatorID,
 			name:     r.CreatorName,
 			category: r.CreatorCategory,
 		},
-		alliance: nullEveEntry{
+		nullAlliance{
 			id:       r.EveCorporation.AllianceID,
 			name:     r.AllianceName,
 			category: r.AllianceCategory,
 		},
-		faction: nullEveEntry{
+		nullFaction{
 			id:       r.EveCorporation.FactionID,
 			name:     r.FactionName,
 			category: r.FactionCategory,
 		},
-		station: nullEveEntry{
+		nullStation{
 			id:       r.EveCorporation.HomeStationID,
 			name:     r.StationName,
 			category: r.StationCategory,
 		},
-	})
+	)
 	return c, nil
 }
 
-type eveCorporationFromDBModelParams struct {
-	corporation queries.EveCorporation
-	ceo         nullEveEntry
-	creator     nullEveEntry
-	alliance    nullEveEntry
-	faction     nullEveEntry
-	station     nullEveEntry
-}
-
-func eveCorporationFromDBModel(arg eveCorporationFromDBModelParams) *app.EveCorporation {
+func eveCorporationFromDBModel(
+	corporation queries.EveCorporation,
+	ceo nullCEO,
+	creator nullCreator,
+	alliance nullAlliance,
+	faction nullFaction,
+	station nullStation,
+) *app.EveCorporation {
 	o := &app.EveCorporation{
-		ID:          arg.corporation.ID,
-		Alliance:    eveEntityFromNullableDBModel(arg.alliance),
-		Ceo:         eveEntityFromNullableDBModel(arg.ceo),
-		Creator:     eveEntityFromNullableDBModel(arg.creator),
-		DateFounded: optional.FromNullTime(arg.corporation.DateFounded),
-		Description: arg.corporation.Description,
-		Faction:     eveEntityFromNullableDBModel(arg.faction),
-		HomeStation: eveEntityFromNullableDBModel(arg.station),
-		MemberCount: arg.corporation.MemberCount,
-		Name:        arg.corporation.Name,
-		Shares:      optional.FromNullInt64(arg.corporation.Shares),
-		TaxRate:     arg.corporation.TaxRate,
-		Ticker:      arg.corporation.Ticker,
-		URL:         optional.FromZeroValue(arg.corporation.Url),
-		WarEligible: optional.FromZeroValue(arg.corporation.WarEligible),
+		ID:          corporation.ID,
+		Alliance:    eveEntityFromNullableDBModel(nullEveEntry(alliance)),
+		Ceo:         eveEntityFromNullableDBModel(nullEveEntry(ceo)),
+		Creator:     eveEntityFromNullableDBModel(nullEveEntry(creator)),
+		DateFounded: optional.FromNullTime(corporation.DateFounded),
+		Description: corporation.Description,
+		Faction:     eveEntityFromNullableDBModel(nullEveEntry(faction)),
+		HomeStation: eveEntityFromNullableDBModel(nullEveEntry(station)),
+		MemberCount: corporation.MemberCount,
+		Name:        corporation.Name,
+		Shares:      optional.FromNullInt64(corporation.Shares),
+		TaxRate:     corporation.TaxRate,
+		Ticker:      corporation.Ticker,
+		URL:         optional.FromZeroValue(corporation.Url),
+		WarEligible: optional.FromZeroValue(corporation.WarEligible),
 	}
 	return o
 }

--- a/internal/app/storage/types.go
+++ b/internal/app/storage/types.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"database/sql"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage/queries"
+)
+
+// helper types
+// used to ensure the correct parameter is passed to a function
+// when multiple parameters have the same real type
+
+type blueprintLocationName string
+type blueprintLocationSecurity sql.NullFloat64
+type blueprintTypeName string
+type completedCharacterName sql.NullString
+type description string
+type endLocationName sql.NullString
+type endSolarSystemID sql.NullInt64
+type endSolarSystemName sql.NullString
+type endSolarSystemSecurity sql.NullFloat64
+type facilityName string
+type facilitySecurity sql.NullFloat64
+type groupName string
+type issuer queries.EveEntity
+type issuerCorporation queries.EveEntity
+type locationName string
+type nullAcceptor nullEveEntry
+type nullAlliance nullEveEntry
+type nullAssignee nullEveEntry
+type nullCEO nullEveEntry
+type nullCreator nullEveEntry
+type nullFaction nullEveEntry
+type nullStation nullEveEntry
+type outputLocationName string
+type outputLocationSecurity sql.NullFloat64
+type productTypeName sql.NullString
+type regionName string
+type skillName string
+type startLocationName sql.NullString
+type startSolarSystemID sql.NullInt64
+type startSolarSystemName sql.NullString
+type startSolarSystemSecurity sql.NullFloat64
+type stationName string
+type stationSecurity sql.NullFloat64
+type typeName string


### PR DESCRIPTION
- Many instances of the factory function that convert database rows into entity structs use a parameter struct. 
- This PR removes those structs and adds the parameters back to the function.
- Reasoning: parameters in structs are optional which can cause subtle errors.
- When there are multiple parameters with the same type we add type aliases. This allows the compiler to recognize when a parameter is in the wrong position. That way the correctness of the function call can be checked at compile time vs. checking for valid parameters in a parameter struct at runtime