### PR TITLE
feat: show communications with rich text and links

### DIFF
--- a/internal/app/characterservice/communications_internal_test.go
+++ b/internal/app/characterservice/communications_internal_test.go
@@ -30,7 +30,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		const notificationID = 42
 		sender := factory.CreateEveEntityCorporation()
@@ -77,7 +77,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 	// 	testutil.TruncateTables(db)
 	// 	httpmock.Reset()
 	// 	c := factory.CreateCharacter()
-	// 	factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+	// 	factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 	// 	factory.CreateEveEntityCharacter(app.EveEntity{ID: 1234})
 	// 	factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 	// 	sender := factory.CreateEveEntityCorporation(app.EveEntity{ID: 54321})
@@ -125,7 +125,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		httpmock.Reset()
 		c := factory.CreateCharacter()
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		n1 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
 		factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID}) // this should be removed
 		sender := factory.CreateEveEntityCorporation()
@@ -180,7 +180,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
 			CharacterID:    c.ID,
 			NotificationID: 42,
@@ -224,7 +224,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		recruit := factory.CreateEveEntityCharacter()
 		corporation := c.EveCharacter.Corporation
@@ -270,7 +270,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		httpmock.RegisterResponder(
 			"GET",
@@ -310,7 +310,7 @@ func TestUpdateCharacterNotificationsESI(t *testing.T) {
 		testutil.MustTruncateTables(db)
 		httpmock.Reset()
 		c := factory.CreateCharacter()
-		factory.CreateEveEntityCharacter(*c.EveCharacter.EveEntity())
+		factory.CreateEveEntityCharacter(*c.EveCharacter.ToEveEntity())
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
 		corporation := c.EveCharacter.Corporation
 		text := fmt.Sprintf("charID: %d\ncorpID: %d\n", recruitID, corporation.ID)

--- a/internal/app/characterservice/token.go
+++ b/internal/app/characterservice/token.go
@@ -75,7 +75,7 @@ func (s *CharacterService) TokenSourceForCorporation(ctx context.Context, corpor
 }
 
 // TokenSource returns a valid token source for a character.
-// The token source will automatically refresh a token when needed.
+// The token source will automatically refresh when needed.
 func (s *CharacterService) TokenSource(ctx context.Context, characterID int64, scopes set.Set[string]) (oauth2.TokenSource, error) {
 	token, err := s.st.GetCharacterToken(ctx, characterID)
 	if err != nil {

--- a/internal/app/corporationservice/corporation.go
+++ b/internal/app/corporationservice/corporation.go
@@ -35,7 +35,7 @@ func (s *CorporationService) getOrCreateCorporation(ctx context.Context, corpora
 	if err != nil {
 		return nil, err
 	}
-	if isNPC, ok := corporation.EveEntity().IsNPC().Value(); !ok || isNPC {
+	if isNPC, ok := corporation.ToEveEntity().IsNPC().Value(); !ok || isNPC {
 		return nil, app.ErrNotFound
 	}
 	o, err := s.st.GetOrCreateCorporation(ctx, corporationID)

--- a/internal/app/eveentity.go
+++ b/internal/app/eveentity.go
@@ -22,10 +22,16 @@ type EveEntity struct {
 	Name     string
 }
 
-// EveEntity returns itself.
-// Needed to comply with the same interface as many other eve universe models.
-func (ee *EveEntity) EveEntity() *EveEntity {
-	return ee
+// ToEveEntity returns a clone of itself.
+func (ee *EveEntity) ToEveEntity() *EveEntity {
+	if ee == nil {
+		return nil
+	}
+	return &EveEntity{
+		Category: ee.Category,
+		ID:       ee.ID,
+		Name:     ee.Name,
+	}
 }
 
 func (ee *EveEntity) IDOrZero() int64 {
@@ -88,7 +94,7 @@ func (ee *EveEntity) Compare(other *EveEntity) int {
 	return cmp.Compare(ee.Name, other.Name)
 }
 
-// InfoLink returns a link to show information in Eve format.
+// InfoLink returns a showinfo schema link for this object.
 func (ee *EveEntity) InfoLink() (string, error) {
 	if ee == nil {
 		return "", fmt.Errorf("no value: %w", ErrInvalid)

--- a/internal/app/eveentity.go
+++ b/internal/app/eveentity.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"cmp"
+	"fmt"
 
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xstrings"
@@ -21,24 +22,56 @@ type EveEntity struct {
 	Name     string
 }
 
-func (ee EveEntity) CategoryDisplay() string {
+// EveEntity returns itself.
+// Needed to comply with the same interface as many other eve universe models.
+func (ee *EveEntity) EveEntity() *EveEntity {
+	return ee
+}
+
+func (ee *EveEntity) IDOrZero() int64 {
+	if ee == nil {
+		return 0
+	}
+	return ee.ID
+}
+
+func (ee *EveEntity) NameOrZero() string {
+	if ee == nil {
+		return ""
+	}
+	return ee.Name
+}
+
+func (ee *EveEntity) CategoryDisplay() string {
+	if ee == nil {
+		return "?"
+	}
 	return xstrings.Title(ee.Category.String())
 }
 
 // IsValid reports whether an entity is valid.
-func (ee EveEntity) IsValid() bool {
+func (ee *EveEntity) IsValid() bool {
+	if ee == nil {
+		return false
+	}
 	return ee.Category.IsKnown()
 }
 
 // IsCharacter reports whether an entity is a character.
-func (ee EveEntity) IsCharacter() bool {
+func (ee *EveEntity) IsCharacter() bool {
+	if ee == nil {
+		return false
+	}
 	return ee.Category == EveEntityCharacter
 }
 
 // IsNPC reports whether an entity is a NPC.
 //
 // This function only works for characters and corporations and returns an empty value for anything else..
-func (ee EveEntity) IsNPC() optional.Optional[bool] {
+func (ee *EveEntity) IsNPC() optional.Optional[bool] {
+	if ee == nil {
+		return optional.Optional[bool]{}
+	}
 	switch ee.Category {
 	case EveEntityCharacter:
 		return optional.New(IsNPCCharacter(ee.ID))
@@ -49,7 +82,47 @@ func (ee EveEntity) IsNPC() optional.Optional[bool] {
 }
 
 func (ee *EveEntity) Compare(other *EveEntity) int {
+	if ee == nil {
+		return 0
+	}
 	return cmp.Compare(ee.Name, other.Name)
+}
+
+// InfoLink returns a link to show information in Eve format.
+func (ee *EveEntity) InfoLink() (string, error) {
+	if ee == nil {
+		return "", fmt.Errorf("no value: %w", ErrInvalid)
+	}
+
+	makeLink := func(typeID int64, itemID int64) string {
+		x := fmt.Sprintf("showinfo:%d", typeID)
+		if itemID > 0 {
+			x += fmt.Sprintf("//%d", itemID)
+		}
+		return x
+	}
+
+	switch ee.Category {
+	case EveEntityAlliance:
+		return makeLink(EveTypeAlliance, ee.ID), nil
+	case EveEntityCharacter:
+		return makeLink(EveTypeCharacter, ee.ID), nil
+	case EveEntityConstellation:
+		return makeLink(EveTypeConstellation, ee.ID), nil
+	case EveEntityCorporation:
+		return makeLink(EveTypeCorporation, ee.ID), nil
+	case EveEntityFaction:
+		return makeLink(EveTypeFaction, ee.ID), nil
+	case EveEntityInventoryType:
+		return makeLink(ee.ID, 0), nil
+	case EveEntityRegion:
+		return makeLink(EveTypeRegion, ee.ID), nil
+	case EveEntitySolarSystem:
+		return makeLink(EveTypeSolarSystem, ee.ID), nil
+	case EveEntityStation:
+		return makeLink(EveTypeCaldariLogisticsStation, ee.ID), nil
+	}
+	return "", fmt.Errorf("not defined for category %s: %w", ee.Category, ErrInvalid)
 }
 
 type EveEntityCategory int

--- a/internal/app/eveentity_test.go
+++ b/internal/app/eveentity_test.go
@@ -10,24 +10,24 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
-func TestEveCorporationDescription(t *testing.T) {
+func TestEveCorporation_DescriptionPlain(t *testing.T) {
 	x := &app.EveCorporation{Description: "alpha<br>bravo"}
-xassert.Equal(t, "alpha\nbravo", x.DescriptionPlain())
+	xassert.Equal(t, "alpha\nbravo", x.DescriptionPlain())
 }
 
-func TestEveEntityCategory(t *testing.T) {
+func TestEveEntity_Category(t *testing.T) {
 	x := &app.EveEntity{Category: app.EveEntityAlliance}
-xassert.Equal(t, "Alliance", x.CategoryDisplay())
+	xassert.Equal(t, "Alliance", x.CategoryDisplay())
 }
 
-func TestEveEntityIsCharacter(t *testing.T) {
+func TestEveEntity_IsCharacter(t *testing.T) {
 	x1 := &app.EveEntity{Category: app.EveEntityCharacter}
 	assert.True(t, x1.IsCharacter())
 	x2 := &app.EveEntity{Category: app.EveEntityAlliance}
 	assert.False(t, x2.IsCharacter())
 }
 
-func TestEveEntityIsNPC(t *testing.T) {
+func TestEveEntity_IsNPC(t *testing.T) {
 	cases := []struct {
 		name     string
 		id       int64
@@ -45,7 +45,41 @@ func TestEveEntityIsNPC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ee := &app.EveEntity{ID: tc.id, Category: tc.category}
 			got := ee.IsNPC()
-		xassert.Equal(t, tc.want, got)
+			xassert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEveEntity_InfoLink(t *testing.T) {
+	cases := []struct {
+		category app.EveEntityCategory
+		wantLink string
+		wantErr  bool
+	}{
+		{app.EveEntityAlliance, "showinfo:16159//42", false},
+		{app.EveEntityCharacter, "showinfo:1373//42", false},
+		{app.EveEntityConstellation, "showinfo:4//42", false},
+		{app.EveEntityCorporation, "showinfo:2//42", false},
+		{app.EveEntityFaction, "showinfo:19//42", false},
+		{app.EveEntityInventoryType, "showinfo:42", false},
+		{app.EveEntityRegion, "showinfo:3//42", false},
+		{app.EveEntitySolarSystem, "showinfo:5//42", false},
+		{app.EveEntityStation, "showinfo:54//42", false},
+		{app.EveEntityMailList, "", true},
+		{app.EveEntityUndefined, "", true},
+		{app.EveEntityUnknown, "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.category.String(), func(t *testing.T) {
+			ee := &app.EveEntity{ID: 42, Category: tc.category}
+			gotLink, gotErr := ee.InfoLink()
+			if !tc.wantErr {
+				assert.Nil(t, gotErr)
+				xassert.Equal(t, tc.wantLink, gotLink)
+			} else {
+				assert.Error(t, gotErr)
+			}
 		})
 	}
 }

--- a/internal/app/evelocation.go
+++ b/internal/app/evelocation.go
@@ -114,7 +114,7 @@ func LocationVariantFromID(id int64) EveLocationVariant {
 	}
 }
 
-func (el EveLocation) EveEntity() *EveEntity {
+func (el EveLocation) ToEveEntity() *EveEntity {
 	switch el.Variant() {
 	case EveLocationSolarSystem:
 		return &EveEntity{ID: el.ID, Name: el.SolarSystemName(), Category: EveEntitySolarSystem}

--- a/internal/app/evelocation_test.go
+++ b/internal/app/evelocation_test.go
@@ -175,7 +175,7 @@ func TestEveLocation_EveEntity(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			xassert.Equal(t, tc.want, tc.in.EveEntity())
+			xassert.Equal(t, tc.want, tc.in.ToEveEntity())
 		})
 	}
 }

--- a/internal/app/evemap.go
+++ b/internal/app/evemap.go
@@ -21,7 +21,7 @@ type EveConstellation struct {
 	Region *EveRegion
 }
 
-func (ec EveConstellation) EveEntity() *EveEntity {
+func (ec EveConstellation) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityConstellation}
 }
 
@@ -36,7 +36,7 @@ func (er EveRegion) DescriptionPlain() string {
 	return evehtml.ToPlain(er.Description.ValueOrZero())
 }
 
-func (er EveRegion) EveEntity() *EveEntity {
+func (er EveRegion) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: er.ID, Name: er.Name, Category: EveEntityRegion}
 }
 
@@ -116,7 +116,7 @@ func (es EveSolarSystem) SecurityStatusRichText() []widget.RichTextSegment {
 	}}
 }
 
-func (es EveSolarSystem) EveEntity() *EveEntity {
+func (es EveSolarSystem) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: es.ID, Name: es.Name, Category: EveEntitySolarSystem}
 }
 

--- a/internal/app/evemap_test.go
+++ b/internal/app/evemap_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEveConstellationEveEntity(t *testing.T) {
 	x1 := &app.EveConstellation{ID: 42, Name: "name"}
-	x2 := x1.EveEntity()
+	x2 := x1.ToEveEntity()
 	xassert.Equal(t, 42, x2.ID)
 	xassert.Equal(t, "name", x2.Name)
 	xassert.Equal(t, app.EveEntityConstellation, x2.Category)

--- a/internal/app/evenotification/billing.go
+++ b/internal/app/evenotification/billing.go
@@ -114,24 +114,24 @@ func (n corpAllBillMsg) render(ctx context.Context, text string, _ time.Time) (s
 	}
 	var external1 string
 	if x, ok := entities[data.ExternalID]; ok && x.Name != "" {
-		external1 = x.Name
+		external1 = makeInfoLink(x)
 	} else {
 		external1 = "?"
 	}
 	var external2 string
 	if x, ok := entities[data.ExternalID2]; ok && x.Name != "" {
-		external2 = x.Name
+		external2 = makeInfoLink(x)
 	} else {
 		external2 = "?"
 	}
 	var billPurpose string
 	switch data.BillTypeID {
 	case billTypeLease:
-		billPurpose = fmt.Sprintf("extending the lease of **%s** at **%s**", external1, external2)
+		billPurpose = fmt.Sprintf("extending the lease of %s at %s", external1, external2)
 	case billTypeAlliance:
-		billPurpose = fmt.Sprintf("maintenance of **%s**", external1)
+		billPurpose = fmt.Sprintf("maintenance of %s", external1)
 	case billTypeInfrastructureHub:
-		billPurpose = fmt.Sprintf("maintenance of infrastructure hub in **%s**", external1)
+		billPurpose = fmt.Sprintf("maintenance of infrastructure hub in %s", external1)
 	default:
 		billPurpose = "?"
 	}

--- a/internal/app/evenotification/billing.go
+++ b/internal/app/evenotification/billing.go
@@ -112,28 +112,36 @@ func (n corpAllBillMsg) render(ctx context.Context, text string, _ time.Time) (s
 	if err != nil {
 		return title, body, err
 	}
-	var external1 string
+	var external1Link, external1Name string
 	if x, ok := entities[data.ExternalID]; ok && x.Name != "" {
-		external1 = makeInfoLink(x)
+		external1Link = makeInfoLink(x)
+		external1Name = x.Name
 	} else {
-		external1 = "?"
+		external1Link = "?"
+		external1Name = "?"
 	}
-	var external2 string
+	var external2Link, external2Name string
 	if x, ok := entities[data.ExternalID2]; ok && x.Name != "" {
-		external2 = makeInfoLink(x)
+		external2Link = makeInfoLink(x)
+		external2Name = x.Name
 	} else {
-		external2 = "?"
+		external2Link = "?"
+		external2Name = "?"
 	}
-	var billPurpose string
+	var purposeShort, purposeLong string
 	switch data.BillTypeID {
 	case billTypeLease:
-		billPurpose = fmt.Sprintf("extending the lease of %s at %s", external1, external2)
+		purposeShort = fmt.Sprintf("extending lease at %s", external2Name)
+		purposeLong = fmt.Sprintf("extending the lease of %s at %s", external1Link, external2Link)
 	case billTypeAlliance:
-		billPurpose = fmt.Sprintf("maintenance of %s", external1)
+		purposeShort = fmt.Sprintf("maintenance of %s", external2Name)
+		purposeLong = fmt.Sprintf("maintenance of %s", external1Link)
 	case billTypeInfrastructureHub:
-		billPurpose = fmt.Sprintf("maintenance of infrastructure hub in %s", external1)
+		purposeShort = fmt.Sprintf("maintenance of infrastructure hub in %s", external1Name)
+		purposeLong = fmt.Sprintf("maintenance of infrastructure hub in %s", external1Link)
 	default:
-		billPurpose = "?"
+		purposeShort = "?"
+		purposeLong = "?"
 	}
 	body = fmt.Sprintf(
 		"A bill of **%s** ISK, due **%s** owed by %s to %s was issued on %s. This bill is for %s.",
@@ -142,9 +150,9 @@ func (n corpAllBillMsg) render(ctx context.Context, text string, _ time.Time) (s
 		makeInfoLink(entities[data.DebtorID]),
 		makeInfoLink(entities[data.CreditorID]),
 		fromLDAPTime(data.CurrentDate).Format(app.DateTimeFormat),
-		billPurpose,
+		purposeLong,
 	)
-	title = fmt.Sprintf("Bill issued for %s", billTypeName(data.BillTypeID))
+	title = fmt.Sprintf("Bill issued for %s", purposeShort)
 	return title, body, err
 }
 

--- a/internal/app/evenotification/billing.go
+++ b/internal/app/evenotification/billing.go
@@ -139,8 +139,8 @@ func (n corpAllBillMsg) render(ctx context.Context, text string, _ time.Time) (s
 		"A bill of **%s** ISK, due **%s** owed by %s to %s was issued on %s. This bill is for %s.",
 		humanize.Commaf(data.Amount),
 		fromLDAPTime(data.DueDate).Format(app.DateTimeFormat),
-		makeEveEntityProfileLink(entities[data.DebtorID]),
-		makeEveEntityProfileLink(entities[data.CreditorID]),
+		makeInfoLink(entities[data.DebtorID]),
+		makeInfoLink(entities[data.CreditorID]),
 		fromLDAPTime(data.CurrentDate).Format(app.DateTimeFormat),
 		billPurpose,
 	)
@@ -165,7 +165,7 @@ func (n infrastructureHubBillAboutToExpire) render(ctx context.Context, text str
 	}
 	out := fmt.Sprintf("Maintenance bill for Infrastructure Hub in %s expires at %s, "+
 		"if not paid in time this Infrastructure Hub will self-destruct.",
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(solarSystem),
 		fromLDAPTime(data.DueDate).Format(app.DateTimeFormat),
 	)
 	body = out
@@ -192,11 +192,11 @@ func (n iHubDestroyedByBillFailure) render(ctx context.Context, text string, _ t
 	}
 	title = fmt.Sprintf(
 		"%s has self-destructed due to unpaid maintenance bills",
-		structureType.Name,
+		makeInfoLink(structureType),
 	)
 	out := fmt.Sprintf("%s in %s has self-destructed, as the standard maintenance bills where not paid.",
-		structureType.Name,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(structureType),
+		makeInfoLink(solarSystem),
 	)
 	body = out
 	return title, body, nil

--- a/internal/app/evenotification/billing_test.go
+++ b/internal/app/evenotification/billing_test.go
@@ -1,7 +1,6 @@
 package evenotification_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -25,7 +24,7 @@ func TestBilling_RenderESI(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	eus := evenotification.NewEveUniverseService(st)
 	en := evenotification.New(eus)
-	ctx := context.Background()
+
 	t.Run("CorpAllBillMsg full data", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -43,14 +42,15 @@ debtorID: 98267621
 dueDate: 133704743590000000
 externalID: 27
 externalID2: 60003760`
-		title, body, err := en.RenderESI(ctx, app.CorpAllBillMsg, optional.New(text), time.Now())
+		title, body, err := en.RenderESI(t.Context(), app.CorpAllBillMsg, optional.New(text), time.Now())
 		require.NoError(t, err)
-		xassert.Equal(t, "Bill issued for lease", title)
+		xassert.Equal(t, "Bill issued for extending lease at station #60003760", title)
 		assert.Contains(t, body, creditor.Name)
 		assert.Contains(t, body, debtor.Name)
 		assert.Contains(t, body, office.Name)
 		assert.Contains(t, body, station.Name)
 	})
+
 	t.Run("CorpAllBillMsg partial data", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -66,9 +66,9 @@ debtorID: 98267621
 dueDate: 133704743590000000
 externalID: 0
 externalID2: 0`
-		title, body, err := en.RenderESI(ctx, app.CorpAllBillMsg, optional.New(text), time.Now())
+		title, body, err := en.RenderESI(t.Context(), app.CorpAllBillMsg, optional.New(text), time.Now())
 		require.NoError(t, err)
-		xassert.Equal(t, "Bill issued for lease", title)
+		xassert.Equal(t, "Bill issued for extending lease at ?", title)
 		assert.Contains(t, body, creditor.Name)
 		assert.Contains(t, body, debtor.Name)
 		assert.Contains(t, body, "?")

--- a/internal/app/evenotification/corporate.go
+++ b/internal/app/evenotification/corporate.go
@@ -48,8 +48,8 @@ func (n charAppAcceptMsg) render(ctx context.Context, text string, _ time.Time) 
 	)
 	out := fmt.Sprintf(
 		"%s is now a member of %s.",
-		makeEveEntityProfileLink(entities[data.CorpID]),
-		makeEveEntityProfileLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
 	)
 	body = out
 	return title, body, nil
@@ -89,8 +89,8 @@ func (n corpAppNewMsg) render(ctx context.Context, text string, _ time.Time) (st
 	title = fmt.Sprintf("New application from %s", entities[data.CharID].Name)
 	out := fmt.Sprintf(
 		"New application from %s to join %s:\n\n> %s",
-		makeEveEntityProfileLink(entities[data.CharID]),
-		makeEveEntityProfileLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
 		data.ApplicationText,
 	)
 	body = out
@@ -131,9 +131,9 @@ func (n corpAppInvitedMsg) render(ctx context.Context, text string, _ time.Time)
 	title = fmt.Sprintf("%s has been invited", entities[data.CharID].Name)
 	out := fmt.Sprintf(
 		"%s has been invited to join %s by %s:\n\n> %s",
-		makeEveEntityProfileLink(entities[data.CharID]),
-		makeEveEntityProfileLink(entities[data.CorpID]),
-		makeEveEntityProfileLink(entities[data.InvokingCharID]),
+		makeInfoLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.InvokingCharID]),
 		data.ApplicationText,
 	)
 	body = out
@@ -174,8 +174,8 @@ func (n charAppRejectMsg) render(ctx context.Context, text string, _ time.Time) 
 	title = fmt.Sprintf("%s rejected invitation", entities[data.CharID].Name)
 	out := fmt.Sprintf(
 		"Application from %s to join %s has been rejected:\n\n> %s",
-		makeEveEntityProfileLink(entities[data.CharID]),
-		makeEveEntityProfileLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
 		data.ApplicationText,
 	)
 	body = out
@@ -216,8 +216,8 @@ func (n corpAppRejectCustomMsg) render(ctx context.Context, text string, _ time.
 	title = fmt.Sprintf("Application from %s rejected", entities[data.CharID].Name)
 	out := fmt.Sprintf(
 		"%s has rejected application from %s:\n\n> %s",
-		makeEveEntityProfileLink(entities[data.CorpID]),
-		makeEveEntityProfileLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
 		data.ApplicationText,
 	)
 	if data.CustomMessage != "" {
@@ -261,8 +261,8 @@ func (n charAppWithdrawMsg) render(ctx context.Context, text string, _ time.Time
 	title = fmt.Sprintf("%s withdrew application", entities[data.CharID].Name)
 	out := fmt.Sprintf(
 		"%s has withdrawn application to join %s:\n\n>%s",
-		makeEveEntityProfileLink(entities[data.CorpID]),
-		makeEveEntityProfileLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
 		data.ApplicationText,
 	)
 	body = out
@@ -306,8 +306,8 @@ func (n charLeftCorpMsg) render(ctx context.Context, text string, _ time.Time) (
 	)
 	out := fmt.Sprintf(
 		"%s is no longer a member of %s.",
-		makeEveEntityProfileLink(entities[data.CorpID]),
-		makeEveEntityProfileLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CorpID]),
+		makeInfoLink(entities[data.CharID]),
 	)
 	body = out
 	return title, body, nil

--- a/internal/app/evenotification/evenotification.go
+++ b/internal/app/evenotification/evenotification.go
@@ -6,8 +6,6 @@ package evenotification
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -228,89 +226,4 @@ func (s *EVENotificationService) makeRenderer(nt app.EveNotificationType) (notif
 	}
 	r.setEveUniverse(s.eus)
 	return r, true
-}
-
-// fromLDAPTime converts an ldap time to golang time
-func fromLDAPTime(ldapTime int64) time.Time {
-	return time.Unix((ldapTime/10000000)-11644473600, 0).UTC()
-}
-
-// fromLDAPDuration converts an ldap duration to golang duration
-func fromLDAPDuration(ldapDuration int64) time.Duration {
-	return time.Duration(ldapDuration/10) * time.Microsecond
-}
-
-type dotlanType = uint
-
-const (
-	dotlanAlliance dotlanType = iota
-	dotlanCorporation
-	dotlanSolarSystem
-	dotlanRegion
-)
-
-func makeDotLanProfileURL(name string, typ dotlanType) string {
-	const baseURL = "https://evemaps.dotlan.net"
-	var path string
-	m := map[dotlanType]string{
-		dotlanAlliance:    "alliance",
-		dotlanCorporation: "corp",
-		dotlanSolarSystem: "system",
-		dotlanRegion:      "region",
-	}
-	path, ok := m[typ]
-	if !ok {
-		return name
-	}
-	name2 := strings.ReplaceAll(name, " ", "_")
-	return fmt.Sprintf("%s/%s/%s", baseURL, path, name2)
-}
-
-func makeSolarSystemLink(ess *app.EveSolarSystem) string {
-	x := fmt.Sprintf(
-		"%s (%s)",
-		makeMarkDownLink(ess.Name, makeDotLanProfileURL(ess.Name, dotlanSolarSystem)),
-		ess.Constellation.Region.Name,
-	)
-	return x
-}
-
-func makeCorporationLink(name string) string {
-	if name == "" {
-		return ""
-	}
-	return makeMarkDownLink(name, makeDotLanProfileURL(name, dotlanCorporation))
-}
-
-func makeAllianceLink(name string) string {
-	if name == "" {
-		return ""
-	}
-	return makeMarkDownLink(name, makeDotLanProfileURL(name, dotlanAlliance))
-}
-
-func makeEveWhoCharacterURL(id int64) string {
-	return fmt.Sprintf("https://evewho.com/character/%d", id)
-}
-
-func makeEveEntityProfileLink(o *app.EveEntity) string {
-	if o == nil {
-		return "?"
-	}
-	var url string
-	switch o.Category {
-	case app.EveEntityAlliance:
-		url = makeDotLanProfileURL(o.Name, dotlanAlliance)
-	case app.EveEntityCharacter:
-		url = makeEveWhoCharacterURL(o.ID)
-	case app.EveEntityCorporation:
-		url = makeDotLanProfileURL(o.Name, dotlanCorporation)
-	default:
-		return o.Name
-	}
-	return makeMarkDownLink(o.Name, url)
-}
-
-func makeMarkDownLink(label, url string) string {
-	return fmt.Sprintf("[%s](%s)", label, url)
 }

--- a/internal/app/evenotification/helpers.go
+++ b/internal/app/evenotification/helpers.go
@@ -1,0 +1,70 @@
+package evenotification
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+)
+
+// fromLDAPTime converts an ldap time to golang time
+func fromLDAPTime(ldapTime int64) time.Time {
+	return time.Unix((ldapTime/10000000)-11644473600, 0).UTC()
+}
+
+// fromLDAPDuration converts an ldap duration to golang duration
+func fromLDAPDuration(ldapDuration int64) time.Duration {
+	return time.Duration(ldapDuration/10) * time.Microsecond
+}
+
+// makeInfoLink2 returns an info link from link data.
+// It returns just the name if a link can not be constructed.
+func makeInfoLink2(name string, linkData []any) string {
+	if len(linkData) != 2 && len(linkData) != 3 {
+		return name
+	}
+	if linkData[0] != "showinfo" {
+		return name
+	}
+	var link string
+	switch len(linkData) {
+	case 2:
+		link = fmt.Sprintf("showinfo:%d", linkData[1])
+	case 3:
+		link = fmt.Sprintf("showinfo:%d//%d", linkData[1], linkData[2])
+
+	}
+	return makeMarkDownLink(name, link)
+}
+
+type eveEntityConvertible interface {
+	EveEntity() *app.EveEntity
+}
+
+// makeInfoLink returns an info link for an entity.
+// It returns the name if a link can not be constructed.
+func makeInfoLink(x eveEntityConvertible) string {
+	o := x.EveEntity()
+	if o == nil {
+		return "?"
+	}
+	link, err := o.InfoLink()
+	if err != nil {
+		slog.Warn("Failed to resolve link for entity in notification", "entityID", o.ID, "error", err)
+		if o.Name == "" {
+			return "?"
+		}
+		return o.Name
+	}
+	return makeMarkDownLink(o.Name, link)
+}
+
+// makeMarkDownLink returns a link in markdown syntax.
+// It returns just the label when url is empty.
+func makeMarkDownLink(label, url string) string {
+	if url == "" {
+		return label
+	}
+	return fmt.Sprintf("[%s](%s)", label, url)
+}

--- a/internal/app/evenotification/helpers.go
+++ b/internal/app/evenotification/helpers.go
@@ -39,13 +39,13 @@ func makeInfoLink2(name string, linkData []any) string {
 }
 
 type eveEntityConvertible interface {
-	EveEntity() *app.EveEntity
+	ToEveEntity() *app.EveEntity
 }
 
 // makeInfoLink returns an info link for an entity.
 // It returns the name if a link can not be constructed.
 func makeInfoLink(x eveEntityConvertible) string {
-	o := x.EveEntity()
+	o := x.ToEveEntity()
 	if o == nil {
 		return "?"
 	}

--- a/internal/app/evenotification/moonmining.go
+++ b/internal/app/evenotification/moonmining.go
@@ -31,7 +31,7 @@ func makeMoonMiningBaseText(ctx context.Context, moonID int64, structureName str
 		"for **%s** at %s in %s",
 		structureName,
 		moon.Name,
-		makeSolarSystemLink(moon.SolarSystem),
+		makeInfoLink(moon.SolarSystem),
 	)
 	x := moonMiningInfo{
 		moon: moon,
@@ -252,7 +252,7 @@ func (n moonminingExtractionCancelled) render(ctx context.Context, text string, 
 		if err != nil {
 			return title, body, err
 		}
-		cancelledBy = fmt.Sprintf(" by %s", makeEveEntityProfileLink(x))
+		cancelledBy = fmt.Sprintf(" by %s", makeInfoLink(x))
 	}
 	out := fmt.Sprintf(
 		"An ongoing extraction for %s has been cancelled%s.",
@@ -303,7 +303,7 @@ func (n moonminingLaserFired) render(ctx context.Context, text string, _ time.Ti
 		if err != nil {
 			return title, body, err
 		}
-		firedBy = fmt.Sprintf("by %s ", makeEveEntityProfileLink(x))
+		firedBy = fmt.Sprintf("by %s ", makeInfoLink(x))
 	}
 	ores, err := makeOreText(ctx, data.OreVolumeByType, n.eus)
 	if err != nil {

--- a/internal/app/evenotification/orbital.go
+++ b/internal/app/evenotification/orbital.go
@@ -56,13 +56,13 @@ func (n orbitalAttacked) render(ctx context.Context, text string, _ time.Time) (
 		"Aggressing Pilot: %s\n\n"+
 		"Aggressing Pilot's Corporation: %s",
 		o.intro,
-		makeEveEntityProfileLink(entities[data.AggressorID]),
-		makeEveEntityProfileLink(entities[data.AggressorCorpID]),
+		makeInfoLink(entities[data.AggressorID]),
+		makeInfoLink(entities[data.AggressorCorpID]),
 	)
 	if data.AggressorAllianceID != 0 {
 		t += fmt.Sprintf(
 			"\n\nAggressing Pilot's Alliance: %s",
-			makeEveEntityProfileLink(entities[data.AggressorAllianceID]),
+			makeInfoLink(entities[data.AggressorAllianceID]),
 		)
 	}
 	body = t
@@ -113,13 +113,13 @@ func (n orbitalReinforced) render(ctx context.Context, text string, _ time.Time)
 		"Aggressing Pilot: %s\n\n"+
 		"Aggressing Pilot's Corporation: %s",
 		fromLDAPTime(data.ReinforceExitTime).Format(app.DateTimeFormat),
-		makeEveEntityProfileLink(entities[data.AggressorID]),
-		makeEveEntityProfileLink(entities[data.AggressorCorpID]),
+		makeInfoLink(entities[data.AggressorID]),
+		makeInfoLink(entities[data.AggressorCorpID]),
 	)
 	if data.AggressorAllianceID != 0 {
 		t += fmt.Sprintf(
 			"\n\nAggressing Pilot's Alliance: %s",
-			makeEveEntityProfileLink(entities[data.AggressorAllianceID]),
+			makeInfoLink(entities[data.AggressorAllianceID]),
 		)
 	}
 	body = t
@@ -143,9 +143,9 @@ func makeOrbitalBaseText(ctx context.Context, planetID, typeID int64, eus EVEUni
 	}
 	intro := fmt.Sprintf(
 		"The %s at %s in %s",
-		structureType.Name,
+		makeInfoLink(structureType),
 		planet.Name,
-		makeSolarSystemLink(planet.SolarSystem),
+		makeInfoLink(planet.SolarSystem),
 	)
 	x := orbitalInfo{
 		structureType: structureType,

--- a/internal/app/evenotification/sov.go
+++ b/internal/app/evenotification/sov.go
@@ -55,8 +55,8 @@ func (n entosisCaptureStarted) render(ctx context.Context, text string, _ time.T
 	title = fmt.Sprintf("%s in %s is being captured", structureType.Name, solarSystem.Name)
 	body = fmt.Sprintf(
 		"A capsuleer has started to influence the **%s** in %s with an Entosis Link.",
-		structureType.Name,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(structureType),
+		makeInfoLink(solarSystem),
 	)
 	return title, body, nil
 }
@@ -101,8 +101,8 @@ func (n sovAllClaimAcquiredMsg) render(ctx context.Context, text string, _ time.
 		"This mail is your confirmation that DED now officially acknowledges "+
 			"that your member organization %s has claimed sovereignty "+
 			"on your behalf in the system %s.",
-		makeEveEntityProfileLink(corporation),
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(corporation),
+		makeInfoLink(solarSystem),
 	)
 	return title, body, nil
 }
@@ -146,8 +146,8 @@ func (n sovAllClaimLostMsg) render(ctx context.Context, text string, _ time.Time
 	body = fmt.Sprintf(
 		"DED acknowledges that your member organization %s has lost its claim "+
 			"to sovereignty on your behalf in the system %s.",
-		makeEveEntityProfileLink(corporation),
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(corporation),
+		makeInfoLink(solarSystem),
 	)
 	return title, body, nil
 }
@@ -189,8 +189,8 @@ func (n sovCommandNodeEventStarted) render(ctx context.Context, text string, _ t
 	body = fmt.Sprintf(
 		"Command nodes for %s in %s can now be found throughout the **%s** constellation",
 		structureTypeName,
-		makeSolarSystemLink(solarSystem),
-		solarSystem.Constellation.Name,
+		makeInfoLink(solarSystem),
+		makeInfoLink(solarSystem.Constellation),
 	)
 	return title, body, nil
 }
@@ -234,7 +234,7 @@ func (n sovStructureDestroyed) render(ctx context.Context, text string, _ time.T
 	body = fmt.Sprintf(
 		"The command nodes for %s in %s have been destroyed by hostile forces.",
 		structureType.Name,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(solarSystem),
 	)
 	return title, body, nil
 }
@@ -260,7 +260,7 @@ func (n sovStructureReinforced) render(ctx context.Context, text string, _ time.
 		if err != nil {
 			return title, body, err
 		}
-		structureTypeName = ee.Name
+		structureTypeName = makeInfoLink(ee)
 	} else {
 		structureTypeName = "?"
 	}
@@ -273,7 +273,7 @@ func (n sovStructureReinforced) render(ctx context.Context, text string, _ time.
 		"The %s in %s has been reinforced by hostile forces "+
 			"and command nodes will begin decloaking at **%s**.",
 		structureTypeName,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(solarSystem),
 		fromLDAPTime(data.DecloakTime).Format(app.DateTimeFormat),
 	)
 	return title, body, nil

--- a/internal/app/evenotification/structure.go
+++ b/internal/app/evenotification/structure.go
@@ -59,13 +59,13 @@ func makeStructureBaseText(ctx context.Context, typeID, systemID int64, structur
 			structureName = structure.DisplayName2()
 			if v, ok := structure.Owner.Value(); ok {
 				owner = v
-				ownerLink = makeEveEntityProfileLink(v)
+				ownerLink = makeInfoLink(v)
 			}
 		}
 	}
 	if structureName == "" {
 		if eveType != nil {
-			structureName = eveType.Name
+			structureName = makeInfoLink(eveType)
 		} else {
 			structureName = "???"
 		}
@@ -75,9 +75,9 @@ func makeStructureBaseText(ctx context.Context, typeID, systemID int64, structur
 	if eveType != nil {
 		isOrbital := eveType.Group.Category.ID == app.EveCategoryOrbitals
 		if isOrbital && structureName != "" {
-			name = fmt.Sprintf("**%s**", structureName)
+			name = structureName
 		} else if structureName != "" {
-			name = fmt.Sprintf("%s **%s**", eveType.Name, structureName)
+			name = fmt.Sprintf("%s **%s**", makeInfoLink(eveType), structureName)
 		} else {
 			name = eveType.Name
 		}
@@ -86,7 +86,7 @@ func makeStructureBaseText(ctx context.Context, typeID, systemID int64, structur
 	} else {
 		name = "unknown"
 	}
-	text := fmt.Sprintf("The %s in %s", name, makeSolarSystemLink(system))
+	text := fmt.Sprintf("The %s in %s", name, makeInfoLink(system))
 	if ownerLink != "" {
 		text += fmt.Sprintf(" belonging to %s", ownerLink)
 	}
@@ -163,9 +163,9 @@ func (n ownershipTransferred) render(ctx context.Context, text string, _ time.Ti
 	body = fmt.Sprintf(
 		"%s has been transferred from %s to %s by %s.",
 		o.intro,
-		makeEveEntityProfileLink(entities[d.OldOwnerCorpID]),
-		makeEveEntityProfileLink(entities[d.NewOwnerCorpID]),
-		makeEveEntityProfileLink(entities[d.CharID]),
+		makeInfoLink(entities[d.OldOwnerCorpID]),
+		makeInfoLink(entities[d.NewOwnerCorpID]),
+		makeInfoLink(entities[d.CharID]),
 	)
 	return title, body, nil
 }
@@ -259,11 +259,11 @@ func (n structureImpendingAbandonmentAssetsAtRisk) render(ctx context.Context, t
 	name := evehtml.Strip(data.StructureLink)
 	title = fmt.Sprintf("Your assets located in %s are at risk", name)
 	body = fmt.Sprintf(
-		"You have assets located at **%s** in %s. "+
+		"You have assets located at %s in %s. "+
 			"These assets are at risk of loss as the structure is close to becoming abandoned.\n\n"+
 			"In approximately %d days this structure will become abandoned.",
-		name,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink2(name, data.StructureShowInfoData),
+		makeInfoLink(solarSystem),
 		data.DaysUntilAbandon,
 	)
 	return title, body, nil
@@ -316,13 +316,13 @@ func (n structureItemsDelivered) render(ctx context.Context, text string, _ time
 	if structure.Name != "" {
 		location = fmt.Sprintf("**%s**", structure.Name)
 	} else {
-		location = fmt.Sprintf("a %s", makeEveEntityProfileLink(entities[data.StructureTypeID]))
+		location = fmt.Sprintf("a %s", makeInfoLink(entities[data.StructureTypeID]))
 	}
 	body = fmt.Sprintf(
 		"%s has delivered the following items to %s in %s:\n\n",
-		makeEveEntityProfileLink(entities[data.CharID]),
+		makeInfoLink(entities[data.CharID]),
 		location,
-		makeSolarSystemLink(solarSystem),
+		makeInfoLink(solarSystem),
 	)
 	var p []string
 	for _, r := range data.ListOfTypesAndQty {
@@ -370,13 +370,13 @@ func (n structureItemsMovedToSafety) render(ctx context.Context, text string, _ 
 	name := evehtml.Strip(data.StructureLink)
 	title = fmt.Sprintf("Your assets located in %s have been moved to asset safety", name)
 	body = fmt.Sprintf(
-		"You assets located at **%s** in %s have been moved to asset safety.\n\n"+
+		"You assets located at %s in %s have been moved to asset safety.\n\n"+
 			"They can be moved to a location of your choosing earliest at %s.\n\n"+
-			"They will be moved automatically to %s by %s.",
-		name,
-		makeSolarSystemLink(solarSystem),
+			"They will be moved automatically to %s by **%s**.",
+		makeInfoLink2(name, data.StructureShowInfoData),
+		makeInfoLink(solarSystem),
 		fromLDAPTime(data.AssetSafetyMinimumTimestamp).Format(app.DateTimeFormat),
-		station.Name,
+		makeInfoLink(station),
 		fromLDAPTime(data.AssetSafetyFullTimestamp).Format(app.DateTimeFormat),
 	)
 	return title, body, nil
@@ -653,13 +653,13 @@ func (n structureUnderAttack) render(ctx context.Context, text string, _ time.Ti
 		"Aggressing Pilot: %s\n\n"+
 		"Aggressing Pilot's Corporation: %s",
 		o.intro,
-		makeEveEntityProfileLink(attackChar),
-		makeCorporationLink(data.CorpName),
+		makeInfoLink(attackChar),
+		makeInfoLink2(data.CorpName, data.CorpLinkData),
 	)
 	if data.AllianceName != "" {
 		t += fmt.Sprintf(
 			"\n\nAggressing Pilot's Alliance: %s",
-			makeAllianceLink(data.AllianceName),
+			makeInfoLink2(data.AllianceName, data.AllianceLinkData),
 		)
 	}
 	body = t
@@ -758,8 +758,8 @@ func (n mercenaryDenAttacked) render(ctx context.Context, text string, _ time.Ti
 		data.ShieldPercentage,
 		data.ArmorPercentage,
 		data.HullPercentage,
-		makeEveEntityProfileLink(entities[data.AggressorCharacterID]),
-		makeEveEntityProfileLink(corporation),
+		makeInfoLink(entities[data.AggressorCharacterID]),
+		makeInfoLink(corporation),
 	)
 	if data.AggressorAllianceName != "" {
 		alliance, err := eveEntityFromHTMLLink(data.AggressorAllianceName)
@@ -768,7 +768,7 @@ func (n mercenaryDenAttacked) render(ctx context.Context, text string, _ time.Ti
 		}
 		t += fmt.Sprintf(
 			"\n\nAggressing Pilot's Alliance: %s",
-			makeEveEntityProfileLink(alliance),
+			makeInfoLink(alliance),
 		)
 	}
 	body = t
@@ -825,8 +825,8 @@ func (n mercenaryDenReinforced) render(ctx context.Context, text string, _ time.
 		o.intro,
 		fromLDAPTime(data.TimestampEntered).Format(app.DateTimeFormat),
 		fromLDAPTime(data.TimestampExited).Format(app.DateTimeFormat),
-		makeEveEntityProfileLink(entities[data.AggressorCharacterID]),
-		makeEveEntityProfileLink(corporation),
+		makeInfoLink(entities[data.AggressorCharacterID]),
+		makeInfoLink(corporation),
 	)
 	if data.AggressorAllianceName != "" {
 		alliance, err := eveEntityFromHTMLLink(data.AggressorAllianceName)
@@ -835,7 +835,7 @@ func (n mercenaryDenReinforced) render(ctx context.Context, text string, _ time.
 		}
 		b += fmt.Sprintf(
 			"\n\nAggressing Pilots' Alliance: %s",
-			makeEveEntityProfileLink(alliance),
+			makeInfoLink(alliance),
 		)
 	}
 	body = b

--- a/internal/app/evenotification/tower.go
+++ b/internal/app/evenotification/tower.go
@@ -28,7 +28,7 @@ func makeTowerBaseText(ctx context.Context, moonID, typeID int64, eus EVEUnivers
 	if err != nil {
 		return towerInfo{}, err
 	}
-	intro := fmt.Sprintf("The %s at %s in %s ", structureType.Name, moon.Name, makeSolarSystemLink(moon.SolarSystem))
+	intro := fmt.Sprintf("The %s at %s in %s ", makeInfoLink(structureType), moon.Name, makeInfoLink(moon.SolarSystem))
 	x := towerInfo{
 		et:    structureType,
 		moon:  moon,
@@ -78,13 +78,13 @@ func (n towerAlertMsg) render(ctx context.Context, text string, _ time.Time) (st
 			"Aggressing Pilot: %s\n\n"+
 			"Aggressing Pilot's Corporation: %s",
 		o.intro,
-		makeEveEntityProfileLink(entities[data.AggressorID]),
-		makeEveEntityProfileLink(entities[data.AggressorCorpID]),
+		makeInfoLink(entities[data.AggressorID]),
+		makeInfoLink(entities[data.AggressorCorpID]),
 	)
 	if data.AggressorAllianceID != 0 {
 		b += fmt.Sprintf(
 			"\n\nAggressing Pilot's Alliance: %s",
-			makeEveEntityProfileLink(entities[data.AggressorAllianceID]),
+			makeInfoLink(entities[data.AggressorAllianceID]),
 		)
 	}
 	body = b

--- a/internal/app/evenotification/war.go
+++ b/internal/app/evenotification/war.go
@@ -50,8 +50,8 @@ func (n allWarSurrenderMsg) render(ctx context.Context, text string, _ time.Time
 	body := fmt.Sprintf(
 		"%s has surrendered in the war against %s.\n\n"+
 			"The war will be declared as being over after approximately %d hours.",
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 		data.DelayHours,
 	)
 	return title, body, nil
@@ -92,8 +92,8 @@ func (n corpWarSurrenderMsg) render(ctx context.Context, text string, _ time.Tim
 	out := fmt.Sprintf(
 		"The war between %s and %s is coming to an end as one party has surrendered.\n\n"+
 			"The war will be declared as being over after approximately 24 hours.",
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 	)
 	body = out
 	return title, body, nil
@@ -133,9 +133,9 @@ func (n declareWar) render(ctx context.Context, text string, _ time.Time) (strin
 	title = fmt.Sprintf("%s declared war", entities[data.EntityID].Name)
 	out := fmt.Sprintf(
 		"%s has declared war on %s on behalf of %s.",
-		makeEveEntityProfileLink(entities[data.CharID]),
-		makeEveEntityProfileLink(entities[data.DefenderID]),
-		makeEveEntityProfileLink(entities[data.EntityID]),
+		makeInfoLink(entities[data.CharID]),
+		makeInfoLink(entities[data.DefenderID]),
+		makeInfoLink(entities[data.EntityID]),
 	)
 	body = out
 	return title, body, nil
@@ -177,9 +177,9 @@ func (n warAdopted) render(ctx context.Context, text string, _ time.Time) (strin
 		entities[data.AgainstID].Name,
 		entities[data.AllianceID].Name,
 	)
-	declaredBy := makeEveEntityProfileLink(entities[data.DeclaredByID])
-	alliance := makeEveEntityProfileLink(entities[data.AllianceID])
-	against := makeEveEntityProfileLink(entities[data.AgainstID])
+	declaredBy := makeInfoLink(entities[data.DeclaredByID])
+	alliance := makeInfoLink(entities[data.AllianceID])
+	against := makeInfoLink(entities[data.AgainstID])
 	out := fmt.Sprintf(
 		"There has been a development in the war between %s and %s.\n"+
 			"%s is no longer a member of %s, "+
@@ -235,8 +235,8 @@ func (n warDeclared) render(ctx context.Context, text string, _ time.Time) (stri
 		"%s has declared war on %s with **%s** "+
 			"as the designated war headquarters.\n\n"+
 			"Within **%d** hours fighting can legally occur between those involved.",
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 		data.WarHQ,
 		data.DelayHours,
 	)
@@ -281,8 +281,8 @@ func (n warHQRemovedFromSpace) render(ctx context.Context, text string, _ time.T
 			"As a consequence, the war declared by %s against %s on %s "+
 			"has been declared invalid by CONCORD and has entered its cooldown period.",
 		data.WarHQ,
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 		fromLDAPTime(data.TimeDeclared).Format(app.DateTimeFormat),
 	)
 	body = out
@@ -331,9 +331,9 @@ func (n warInherited) render(ctx context.Context, text string, _ time.Time) (str
 		entities[data.QuitterID].Name,
 		entities[data.AllianceID].Name,
 	)
-	alliance := makeEveEntityProfileLink(entities[data.AllianceID])
-	against := makeEveEntityProfileLink(entities[data.AgainstID])
-	quitter := makeEveEntityProfileLink(entities[data.QuitterID])
+	alliance := makeInfoLink(entities[data.AllianceID])
+	against := makeInfoLink(entities[data.AgainstID])
+	quitter := makeInfoLink(entities[data.QuitterID])
 	out := fmt.Sprintf(
 		"There has been a development in the war between %s and %s.\n\n"+
 			"%s is no longer a member of %s, and therefore a new war between %s and %s has begun.",
@@ -386,8 +386,8 @@ func (n warInvalid) render(ctx context.Context, text string, _ time.Time) (strin
 			"because at least one of the involved parties "+
 			"has become ineligible for war declarations.\n\n"+
 			"Fighting must cease on %s.",
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 		fromLDAPTime(data.EndDate).Format(app.DateTimeFormat),
 	)
 	body = out
@@ -431,8 +431,8 @@ func (n warRetractedByConcord) render(ctx context.Context, text string, _ time.T
 			"has been retracted by CONCORD.\n\n"+
 			"After %s CONCORD will again respond to any hostilities "+
 			"between those involved with full force.",
-		makeEveEntityProfileLink(entities[data.DeclaredByID]),
-		makeEveEntityProfileLink(entities[data.AgainstID]),
+		makeInfoLink(entities[data.DeclaredByID]),
+		makeInfoLink(entities[data.AgainstID]),
 		fromLDAPTime(data.EndDate).Format(app.DateTimeFormat),
 	)
 	body = out

--- a/internal/app/evetype.go
+++ b/internal/app/evetype.go
@@ -186,7 +186,7 @@ func (et EveType) Icon() (fyne.Resource, bool) {
 	return res, true
 }
 
-func (et EveType) EveEntity() *EveEntity {
+func (et EveType) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: et.ID, Name: et.Name, Category: EveEntityInventoryType}
 }
 

--- a/internal/app/evetype.go
+++ b/internal/app/evetype.go
@@ -39,6 +39,7 @@ const (
 	EveGroupCapitalIndustrialShip   = 883
 	EveGroupCargoContainer          = 12
 	EveGroupCarrier                 = 547
+	EveGroupCharacter               = 1
 	EveGroupCommandCenters          = 1027
 	EveGroupDreadnought             = 485
 	EveGroupExtractorControlUnits   = 1063
@@ -49,6 +50,7 @@ const (
 	EveGroupProcessors              = 1028
 	EveGroupSecureCargoContainer    = 340
 	EveGroupSpaceports              = 1030
+	EveGroupStation                 = 15
 	EveGroupStorageFacilities       = 1029
 	EveGroupSuperCarrier            = 659
 	EveGroupTitan                   = 30
@@ -75,8 +77,12 @@ const (
 	EveTypeAdvancedMassReactions       = 45749
 	EveTypeAlliance                    = 16159
 	EveTypeAssetSafetyWrap             = 60
+	EveTypeAstroidBelt                 = 9
+	EveTypeCharacter                   = 1373
+	EveTypeConstellation               = 4
 	EveTypeCorporation                 = 2
 	EveTypeCustomsOffice               = 2233
+	EveTypeFaction                     = 19
 	EveTypeIHUB                        = 32458
 	EveTypeIndustry                    = 3380
 	EveTypeInfomorphSynchronizing      = 33399
@@ -85,11 +91,14 @@ const (
 	EveTypeLargeSkillInjector          = 40520
 	EveTypeMassProduction              = 3387
 	EveTypeMassReactions               = 45748
+	EveTypeMoon                        = 8
 	EveTypeOffice                      = 27
 	EveTypePlanetTemperate             = 11
+	EveTypeRegion                      = 3
 	EveTypeSkillExtractor              = 40519
 	EveTypeSolarSystem                 = 5
 	EveTypeTCU                         = 32226
+	EveTypeCaldariLogisticsStation     = 54
 )
 
 // EveType is a type in EVE Online.

--- a/internal/app/eveuniverse.go
+++ b/internal/app/eveuniverse.go
@@ -27,7 +27,7 @@ type EveAlliance struct {
 	Ticker              string
 }
 
-func (ea EveAlliance) EveEntity() *EveEntity {
+func (ea EveAlliance) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ea.ID, Name: ea.Name, Category: EveEntityAlliance}
 }
 
@@ -148,7 +148,7 @@ func (ec EveCharacter) Hash() string {
 	return h2
 }
 
-func (ec EveCharacter) EveEntity() *EveEntity {
+func (ec EveCharacter) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCharacter}
 }
 
@@ -176,7 +176,7 @@ func (ec EveCorporation) DescriptionPlain() string {
 	return evehtml.ToPlain(ec.Description)
 }
 
-func (ec EveCorporation) EveEntity() *EveEntity {
+func (ec EveCorporation) ToEveEntity() *EveEntity {
 	return &EveEntity{ID: ec.ID, Name: ec.Name, Category: EveEntityCorporation}
 }
 

--- a/internal/app/eveuniverse_test.go
+++ b/internal/app/eveuniverse_test.go
@@ -16,7 +16,7 @@ func TestEveAlliance(t *testing.T) {
 		ID:   42,
 		Name: "name",
 	}
-	ee := x.EveEntity()
+	ee := x.ToEveEntity()
 	xassert.Equal(t, 42, ee.ID)
 	xassert.Equal(t, "name", ee.Name)
 	xassert.Equal(t, app.EveEntityAlliance, ee.Category)
@@ -31,7 +31,7 @@ func TestEveCharacter_Description(t *testing.T) {
 
 func TestEveCharacter_EveEntity(t *testing.T) {
 	x1 := &app.EveCharacter{ID: 42, Name: "name"}
-	x2 := x1.EveEntity()
+	x2 := x1.ToEveEntity()
 	xassert.Equal(t, 42, x2.ID)
 	xassert.Equal(t, "name", x2.Name)
 	xassert.Equal(t, app.EveEntityCharacter, x2.Category)
@@ -79,7 +79,7 @@ func TestEveCharacter_IsIdentical(t *testing.T) {
 
 func TestEveCorporation_EveEntity(t *testing.T) {
 	x1 := &app.EveCorporation{ID: 42, Name: "name"}
-	x2 := x1.EveEntity()
+	x2 := x1.ToEveEntity()
 	xassert.Equal(t, 42, x2.ID)
 	xassert.Equal(t, "name", x2.Name)
 	xassert.Equal(t, app.EveEntityCorporation, x2.Category)

--- a/internal/app/eveuniverseservice/location.go
+++ b/internal/app/eveuniverseservice/location.go
@@ -108,7 +108,7 @@ func (s *EVEUniverseService) UpdateOrCreateLocationESI(ctx context.Context, id i
 			}
 		case app.EveLocationStructure:
 			if !xgoesi.ContextHasAccessToken(ctx) {
-				return nil, fmt.Errorf("eve location: token not set for fetching structure: %d", id)
+				return nil, fmt.Errorf("eve location: token not set for fetching structure: %d: %w", id, app.ErrTokenError)
 			}
 			ctx2 := xgoesi.NewContextWithOperationID(ctx, "GetUniverseStructuresStructureId")
 			structure, r, err := s.esiClient.UniverseAPI.GetUniverseStructuresStructureId(ctx2, id).Execute()

--- a/internal/app/eveuniverseservice/map_test.go
+++ b/internal/app/eveuniverseservice/map_test.go
@@ -684,7 +684,7 @@ func TestGetSolarSystemInfoESI(t *testing.T) {
 	ctx := context.Background()
 	system := factory.CreateEveSolarSystem()
 	constellation := factory.CreateEveEntity(app.EveEntity{Category: app.EveEntityConstellation})
-	factory.CreateEveEntity(*system.EveEntity())
+	factory.CreateEveEntity(*system.ToEveEntity())
 	station := factory.CreateEveEntity(app.EveEntity{Category: app.EveEntityStation})
 	structure := factory.CreateEveLocationStructure(storage.UpdateOrCreateLocationParams{
 		SolarSystemID: optional.New(system.ID),

--- a/internal/app/ui/charactermanager/training.go
+++ b/internal/app/ui/charactermanager/training.go
@@ -101,7 +101,7 @@ func (a *training) makeList() *widget.List {
 			r := a.characters[id]
 			border := co.(*fyne.Container).Objects
 
-			border[0].(*ui.EveEntityListItem).Set(r.EveCharacter.EveEntity())
+			border[0].(*ui.EveEntityListItem).Set(r.EveCharacter.ToEveEntity())
 
 			sw := border[1].(*kxwidget.Switch)
 			sw.On = r.IsTrainingWatched

--- a/internal/app/ui/characters/characters_internal_test.go
+++ b/internal/app/ui/characters/characters_internal_test.go
@@ -25,6 +25,7 @@ type fakeInfoViewer struct {
 }
 
 func (f *fakeInfoViewer) Show(o *app.EveEntity) { f.called = true; f.entity = o }
+func (f *fakeInfoViewer) Show2(_, _, _ int64)   {}
 func (f *fakeInfoViewer) ShowBloodline(_ int64) {}
 func (f *fakeInfoViewer) ShowLocation(_ int64)  {}
 func (f *fakeInfoViewer) ShowRace(_ int64)      {}

--- a/internal/app/ui/characters/charactersheet.go
+++ b/internal/app/ui/characters/charactersheet.go
@@ -181,7 +181,7 @@ func (a *CharacterSheet) update(ctx context.Context) {
 	fyne.Do(func() {
 		a.name.SetText(c.EveCharacter.Name)
 		a.name.OnTapped = func() {
-			a.u.InfoViewer().Show(c.EveCharacter.EveEntity())
+			a.u.InfoViewer().Show(c.EveCharacter.ToEveEntity())
 		}
 		a.portrait.OnTapped = a.name.OnTapped
 
@@ -235,7 +235,7 @@ func (a *CharacterSheet) update(ctx context.Context) {
 		}
 		a.ship.SetText(ship.Name)
 		a.ship.OnTapped = func() {
-			a.u.InfoViewer().Show(ship.EveEntity())
+			a.u.InfoViewer().Show(ship.ToEveEntity())
 		}
 	})
 	fyne.Do(func() {

--- a/internal/app/ui/characters/communications.go
+++ b/internal/app/ui/characters/communications.go
@@ -3,6 +3,7 @@ package characters
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -16,11 +17,11 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
+	"github.com/goccy/go-yaml"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
-	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
@@ -50,7 +51,7 @@ type Communications struct {
 	notificationList       *widget.List
 	notifications          []*app.CharacterNotification
 	notificationsTop       *widget.Label
-	sendNotificationAction *widget.ToolbarAction
+	developerToolbarAction *widget.ToolbarAction
 	u                      baseUI
 }
 
@@ -196,9 +197,9 @@ func (a *Communications) setDetail(n *app.CharacterNotification) {
 		return
 	}
 	if a.u.IsDeveloperMode() {
-		a.sendNotificationAction.ToolbarObject().Show()
+		a.developerToolbarAction.ToolbarObject().Show()
 	} else {
-		a.sendNotificationAction.ToolbarObject().Hide()
+		a.developerToolbarAction.ToolbarObject().Hide()
 	}
 	a.current = n
 	a.Toolbar.Show()
@@ -211,14 +212,7 @@ func (a *Communications) makeToolbar() *widget.Toolbar {
 			if a.current == nil {
 				return
 			}
-			processErr := func(err error) {
-				ui.ShowErrorAndLog(
-					"Failed to generated notification for clipboard",
-					err,
-					a.u.IsDeveloperMode(),
-					a.u.MainWindow(),
-				)
-			}
+
 			cn := a.current
 			recipient := notificationRecipient(cn, a.character.Load().NameOrZero())
 			header := fmt.Sprintf(
@@ -230,7 +224,12 @@ func (a *Communications) makeToolbar() *widget.Toolbar {
 			s := cn.TitleDisplay() + "\n" + header
 			b, err := cn.BodyPlain()
 			if err != nil {
-				processErr(err)
+				ui.ShowErrorAndLog(
+					"Failed to copy notification to clipboard",
+					err,
+					a.u.IsDeveloperMode(),
+					a.u.MainWindow(),
+				)
 				return
 			}
 			s += "\n\n"
@@ -240,19 +239,58 @@ func (a *Communications) makeToolbar() *widget.Toolbar {
 				s += "(no body)"
 			}
 			fyne.CurrentApp().Clipboard().SetContent(s)
+			a.u.ShowSnackbar("Communication copied to clipboard")
 		}),
 	)
-	a.sendNotificationAction = widget.NewToolbarAction(theme.NewThemedResource(icons.TeddyBearSvg), func() {
-		if a.current == nil {
-			return
-		}
-		if a.character.Load() == nil {
-			return
-		}
-		go a.u.Character().SendDesktopNotification(context.Background(), a.current)
-	})
-	a.sendNotificationAction.ToolbarObject().Hide()
-	toolbar.Append(a.sendNotificationAction)
+	items := []*fyne.MenuItem{
+		fyne.NewMenuItem(
+			"Send test notification",
+			func() {
+				if a.current == nil {
+					return
+				}
+				if a.character.Load() == nil {
+					return
+				}
+				go a.u.Character().SendDesktopNotification(context.Background(), a.current)
+			},
+		),
+		fyne.NewMenuItem(
+			"Copy data to clipboard",
+			func() {
+				if a.current == nil {
+					return
+				}
+
+				processErr := func(err error) {
+					slog.Error("Failed to convert notification data", "characterID", a.current.CharacterID, "notificationID", a.current.NotificationID, "error", err)
+					a.u.ShowSnackbar("ERROR: Failed to convert data: " + err.Error())
+				}
+
+				v, ok := a.current.Text.Value()
+				if !ok {
+					a.u.ShowSnackbar("ERROR: Notification has no data")
+					return
+				}
+				var data any
+				if err := yaml.Unmarshal([]byte(v), &data); err != nil {
+					processErr(err)
+					return
+				}
+				b, err := json.MarshalIndent(data, "", "    ")
+				if err != nil {
+					processErr(err)
+					return
+				}
+				fyne.CurrentApp().Clipboard().SetContent(string(b))
+				a.u.ShowSnackbar("Notification data copied to clipboard")
+			},
+		),
+	}
+	a.developerToolbarAction = kxwidget.NewToolbarActionMenu(theme.MoreHorizontalIcon(), fyne.NewMenu("", items...))
+	a.developerToolbarAction.ToolbarObject().Hide()
+	toolbar.Append(widget.NewToolbarSpacer())
+	toolbar.Append(a.developerToolbarAction)
 	return toolbar
 }
 

--- a/internal/app/ui/characters/communications.go
+++ b/internal/app/ui/characters/communications.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"fyne.io/fyne/v2"
@@ -21,6 +23,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
 type notificationFolder struct {
@@ -61,7 +64,9 @@ func NewCommunications(u baseUI) *Communications {
 	a.Toolbar = a.makeToolbar()
 	a.Toolbar.Hide()
 	a.folderList = a.makeFolderList()
-	a.Detail = newCommunicationDetail(u.EVEImage().EveEntityLogoAsync, u.InfoViewer().Show)
+	a.Detail = newCommunicationDetail(u.EVEImage().EveEntityLogoAsync, u.InfoViewer().Show, func(typeID, itemID int64) {
+		u.InfoViewer().Show2(typeID, itemID, a.character.Load().IDOrZero())
+	})
 	a.notificationList = a.makeNotificationList()
 	a.Notifications = container.NewBorder(a.notificationsTop, nil, nil, nil, a.notificationList)
 	a.u.Signals().CurrentCharacterExchanged.AddListener(func(ctx context.Context, c *app.Character) {
@@ -501,23 +506,23 @@ func notificationRecipient(cn *app.CharacterNotification, characterName string) 
 type communicationDetail struct {
 	widget.BaseWidget
 
-	body    *widget.Label
+	body    *xwidget.RichText
 	header  *MailHeader
 	subject *widget.Label
+	show2   func(int64, int64)
 }
 
-func newCommunicationDetail(loadIcon ui.EveEntityIconLoader, show func(*app.EveEntity)) *communicationDetail {
+func newCommunicationDetail(loadIcon ui.EveEntityIconLoader, show func(*app.EveEntity), show2 func(int64, int64)) *communicationDetail {
 	subject := widget.NewLabel("")
 	subject.SizeName = theme.SizeNameSubHeadingText
 	subject.Wrapping = fyne.TextWrapWord
-	subject.Selectable = true
-	body := widget.NewLabel("")
+	body := xwidget.NewRichText()
 	body.Wrapping = fyne.TextWrapWord
-	body.Selectable = true
 	w := &communicationDetail{
 		body:    body,
 		header:  NewMailHeader(loadIcon, show),
 		subject: subject,
+		show2:   show2,
 	}
 	w.ExtendBaseWidget(w)
 	return w
@@ -531,22 +536,54 @@ func (w *communicationDetail) CreateRenderer() fyne.WidgetRenderer {
 func (w *communicationDetail) set(n *app.CharacterNotification, recipient *app.EveEntity) error {
 	w.subject.SetText(n.TitleDisplay())
 	w.header.Set(n.Sender, n.Timestamp, recipient)
-	b, err := n.BodyPlain() // using markdown blocked by #61
-	if err != nil {
-		return fmt.Errorf("failed to convert markdown for notification %+v: %w", n, err)
+	v, ok := n.Body.Value()
+	if !ok {
+		w.body.SetWithText("[This notification type is not fully supported yet]", widget.RichTextStyle{
+			ColorName: theme.ColorNameDisabled,
+		})
+		return nil
 	}
-	w.body.Text = b.StringFunc("[This notification type is not fully supported yet]", func(v string) string {
-		return v
-	})
-	w.body.Importance = widget.MediumImportance
-	w.body.Refresh()
+	w.body.ParseMarkdown(v)
+	for _, s := range w.body.Segments {
+		s2, ok := s.(*widget.HyperlinkSegment)
+		if !ok {
+			continue
+		}
+		if s2.URL.Scheme != "showinfo" {
+			continue
+		}
+		typeID, itemID, err := parseIDs(s2.URL.Opaque)
+		if err != nil {
+			slog.Warn("Failed to parse showinfo link in communication", "error", err)
+			continue
+		}
+		s2.OnTapped = func() {
+			w.show2(typeID, itemID)
+		}
+	}
 	return nil
+}
+
+func parseIDs(input string) (int64, int64, error) {
+	parts := strings.SplitN(input, "//", 2)
+	id1, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid first ID %q: %w", parts[0], err)
+	}
+	if len(parts) < 2 {
+		return id1, 0, nil
+	}
+	id2, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid second ID %q: %w", parts[1], err)
+	}
+	return id1, id2, nil
 }
 
 func (w *communicationDetail) setError(text string) {
 	w.subject.SetText("ERROR")
 	w.header.Clear()
-	w.body.Text = text
-	w.body.Importance = widget.DangerImportance
-	w.body.Refresh()
+	w.body.SetWithText(text, widget.RichTextStyle{
+		ColorName: theme.ColorNameError,
+	})
 }

--- a/internal/app/ui/characters/communications_internal_test.go
+++ b/internal/app/ui/characters/communications_internal_test.go
@@ -1,0 +1,83 @@
+package characters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIDs(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedID1 int64
+		expectedID2 int64
+		wantErr     bool
+	}{
+		{
+			name:        "single ID without separator",
+			input:       "12345",
+			expectedID1: 12345,
+			expectedID2: 0,
+			wantErr:     false,
+		},
+		{
+			name:        "two IDs with separator",
+			input:       "12345//6789",
+			expectedID1: 12345,
+			expectedID2: 6789,
+			wantErr:     false,
+		},
+		{
+			name:        "zero values",
+			input:       "0//0",
+			expectedID1: 0,
+			expectedID2: 0,
+			wantErr:     false,
+		},
+		{
+			name:    "invalid first ID",
+			input:   "abc//6789",
+			wantErr: true,
+		},
+		{
+			name:    "invalid second ID",
+			input:   "12345//xyz",
+			wantErr: true,
+		},
+		{
+			name:    "missing second ID after separator",
+			input:   "12345//",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "integer overflow for int64",
+			input:   "9223372036854775808", // MaxInt64 + 1
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id1, id2, err := parseIDs(tt.input)
+
+			if tt.wantErr {
+				// Assert that an error occurred and IDs return zero values on failure
+				require.Error(t, err)
+				assert.Equal(t, int64(0), id1)
+				assert.Equal(t, int64(0), id2)
+			} else {
+				// Assert that no error occurred and IDs match expectations
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedID1, id1)
+				assert.Equal(t, tt.expectedID2, id2)
+			}
+		})
+	}
+}

--- a/internal/app/ui/clones/clonedetail.go
+++ b/internal/app/ui/clones/clonedetail.go
@@ -48,7 +48,7 @@ func showCloneDetailWindow(u baseUI, r cloneRow, origin *app.EveSolarSystem, rou
 	var originInfo fyne.CanvasObject
 	if hasOrigin {
 		originInfo = xwidget.NewTappableRichText(origin.DisplayRichText(), func() {
-			u.InfoViewer().Show(origin.EveEntity())
+			u.InfoViewer().Show(origin.ToEveEntity())
 		})
 	} else {
 		l := widget.NewLabel("No origin")
@@ -151,7 +151,7 @@ func makeImplantsList(u baseUI, characterID, cloneID int64, IsDeveloperMode bool
 				return
 			}
 			r := implants[id]
-			co.(*ui.EveEntityListItem).Set(r.EveType.EveEntity())
+			co.(*ui.EveEntityListItem).Set(r.EveType.ToEveEntity())
 		},
 	)
 	list.HideSeparators = true
@@ -202,7 +202,7 @@ func makeRoute(u baseUI, r cloneRow) *widget.List {
 			return
 		}
 		s := r.route[id]
-		u.InfoViewer().Show(s.EveEntity())
+		u.InfoViewer().Show(s.ToEveEntity())
 	}
 	return list
 }

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -485,7 +485,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		fyne.Do(func() {
 			characterHeader.SetTitle(s)
 			characterHeader.SetTitleAction(func() {
-				u.InfoViewer().Show(c.EveCharacter.EveEntity())
+				u.InfoViewer().Show(c.EveCharacter.ToEveEntity())
 			})
 		})
 		go func() {
@@ -557,7 +557,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		fyne.Do(func() {
 			corporationHeader.SetTitle(s)
 			corporationHeader.SetTitleAction(func() {
-				u.InfoViewer().Show(c.EveCorporation.EveEntity())
+				u.InfoViewer().Show(c.EveCorporation.ToEveEntity())
 			})
 		})
 		go func() {
@@ -716,7 +716,7 @@ func (u *DesktopUI) defineShortcuts() {
 					u.ShowSnackbar("ERROR: No character selected")
 					return
 				}
-				u.InfoViewer().Show(c.EveCharacter.EveEntity())
+				u.InfoViewer().Show(c.EveCharacter.ToEveEntity())
 			}},
 		"currentLocation": {
 			&desktop.CustomShortcut{

--- a/internal/app/ui/corporations/corporationsheet.go
+++ b/internal/app/ui/corporations/corporationsheet.go
@@ -194,7 +194,7 @@ func (a *CorporationSheet) update(ctx context.Context) {
 	fyne.Do(func() {
 		a.name.SetText(corporation.Name)
 		a.name.OnTapped = func() {
-			a.u.InfoViewer().Show(corporation.EveEntity())
+			a.u.InfoViewer().Show(corporation.ToEveEntity())
 		}
 		a.logo.OnTapped = a.name.OnTapped
 		a.members.SetText(humanize.Comma(corporation.MemberCount))

--- a/internal/app/ui/corporations/structures.go
+++ b/internal/app/ui/corporations/structures.go
@@ -508,7 +508,7 @@ func showCorporationStructureWindowAsync(ctx context.Context, u baseUI, corporat
 				})),
 				widget.NewFormItem("System", makeSolarSystemLabel(structure.System, u.InfoViewer().Show)),
 				widget.NewFormItem("Region", ui.MakeLinkLabel(structure.System.Constellation.Region.Name, func() {
-					u.InfoViewer().Show(structure.System.Constellation.Region.EveEntity())
+					u.InfoViewer().Show(structure.System.Constellation.Region.ToEveEntity())
 				})),
 				widget.NewFormItem("Services", widget.NewRichText(services...)),
 				widget.NewFormItem("Fuel Expires", widget.NewRichText(xwidget.RichTextSegmentsFromText(fuelText, widget.RichTextStyle{

--- a/internal/app/ui/industry/colonydetails.go
+++ b/internal/app/ui/industry/colonydetails.go
@@ -367,12 +367,12 @@ func (a *colonyDetails) Update(ctx context.Context) error {
 		a.security.Set(cp.EvePlanet.SolarSystem.SecurityStatusRichText())
 		a.planet.Set(cp.NameRichText())
 		a.planet.OnTapped = func() {
-			a.u.InfoViewer().Show(cp.EvePlanet.SolarSystem.EveEntity())
+			a.u.InfoViewer().Show(cp.EvePlanet.SolarSystem.ToEveEntity())
 		}
 		a.region.SetText(fmt.Sprintf("(%s)", cp.EvePlanet.SolarSystem.Constellation.Region.Name))
 		a.planetType.SetText(cp.EvePlanet.TypeDisplay())
 		a.planetType.OnTapped = func() {
-			a.u.InfoViewer().Show(cp.EvePlanet.Type.EveEntity())
+			a.u.InfoViewer().Show(cp.EvePlanet.Type.ToEveEntity())
 		}
 		a.owner.SetText(c.NameOrZero())
 		a.owner.OnTapped = func() {

--- a/internal/app/ui/infoviewer/characterinfo.go
+++ b/internal/app/ui/infoviewer/characterinfo.go
@@ -276,7 +276,7 @@ func (a *characterInfo) makeAttributes(ctx context.Context, o *app.EveCharacter,
 		attributes = append(attributes, newAttributeItem("Faction", v))
 	}
 	var u any
-	if v, ok := o.EveEntity().IsNPC().Value(); ok {
+	if v, ok := o.ToEveEntity().IsNPC().Value(); ok {
 		u = v
 	} else {
 		u = "?"

--- a/internal/app/ui/infoviewer/constellationinfo.go
+++ b/internal/app/ui/infoviewer/constellationinfo.go
@@ -72,7 +72,7 @@ func (a *constellationInfo) update(ctx context.Context) error {
 		a.name.SetText(o.Name)
 		a.region.SetText(o.Region.Name)
 		a.region.OnTapped = func() {
-			a.iw.Show(o.Region.EveEntity())
+			a.iw.Show(o.Region.ToEveEntity())
 		}
 
 		if a.iw.u.IsDeveloperMode() {

--- a/internal/app/ui/infoviewer/corporationinfo.go
+++ b/internal/app/ui/infoviewer/corporationinfo.go
@@ -196,7 +196,7 @@ func (a *corporationInfo) makeAttributes(o *app.EveCorporation) []attributeItem 
 		attributes = append(attributes, newAttributeItem("Faction", v))
 	}
 	var u any
-	if v, ok := o.EveEntity().IsNPC().Value(); ok {
+	if v, ok := o.ToEveEntity().IsNPC().Value(); ok {
 		u = v
 	} else {
 		u = "?"

--- a/internal/app/ui/infoviewer/infoviewer.go
+++ b/internal/app/ui/infoviewer/infoviewer.go
@@ -147,10 +147,13 @@ func (iw *InfoViewer) Show(o *app.EveEntity) {
 	iw.show(eveEntity2InfoVariant(o), o.ID)
 }
 
-// Show2 displays the info window for an object.
-// itemID and characterID are optional and can be 0.
+// Show2 displays an info window for an object.
+//
+// It is designed to take IDs from a showinfo scheme link.
+// The typeID is mandatory, itemID and characterID are optional.
+// The characterID is used to fetch a token when trying to show a structure location.
 func (iw *InfoViewer) Show2(typeID, itemID, characterID int64) {
-	slog.Info("Showing info window", "typeID", typeID, "itemID", itemID)
+	slog.Debug("Showing info window", "typeID", typeID, "itemID", itemID)
 	w := iw.w
 	if w == nil {
 		w = iw.u.MainWindow()

--- a/internal/app/ui/infoviewer/infoviewer.go
+++ b/internal/app/ui/infoviewer/infoviewer.go
@@ -36,6 +36,69 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
+type infoVariant uint
+
+const (
+	infoNotSupported infoVariant = iota
+	infoAlliance
+	infoBloodline
+	infoCharacter
+	infoConstellation
+	infoCorporation
+	infoInventoryType
+	infoLocation
+	infoRace
+	infoRegion
+	infoSolarSystem
+)
+
+func (iv infoVariant) String() string {
+	m := map[infoVariant]string{
+		infoAlliance:      "alliance",
+		infoBloodline:     "bloodline",
+		infoCharacter:     "character",
+		infoConstellation: "constellation",
+		infoCorporation:   "corporation",
+		infoInventoryType: "type",
+		infoLocation:      "location",
+		infoRegion:        "region",
+		infoRace:          "race",
+		infoSolarSystem:   "solar system",
+	}
+
+	s, ok := m[iv]
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+var eveEntityCategory2InfoVariant = map[app.EveEntityCategory]infoVariant{
+	app.EveEntityAlliance:      infoAlliance,
+	app.EveEntityCharacter:     infoCharacter,
+	app.EveEntityConstellation: infoConstellation,
+	app.EveEntityCorporation:   infoCorporation,
+	app.EveEntityRegion:        infoRegion,
+	app.EveEntitySolarSystem:   infoSolarSystem,
+	app.EveEntityStation:       infoLocation,
+	app.EveEntityInventoryType: infoInventoryType,
+}
+
+func eveEntity2InfoVariant(ee *app.EveEntity) infoVariant {
+	v, ok := eveEntityCategory2InfoVariant[ee.Category]
+	if !ok {
+		return infoNotSupported
+	}
+	return v
+
+}
+
+// SupportedCategories returns which EveEntity categories are supported.
+func SupportedCategories() set.Set[app.EveEntityCategory] {
+	return set.Collect(maps.Keys(eveEntityCategory2InfoVariant))
+
+}
+
 type coreUI interface {
 	Character() *characterservice.CharacterService
 	EVEImage() ui.EVEImageService
@@ -82,6 +145,76 @@ func New(u coreUI) *InfoViewer {
 
 func (iw *InfoViewer) Show(o *app.EveEntity) {
 	iw.show(eveEntity2InfoVariant(o), o.ID)
+}
+
+// Show2 displays the info window for an object.
+// itemID and characterID are optional and can be 0.
+func (iw *InfoViewer) Show2(typeID, itemID, characterID int64) {
+	slog.Info("Showing info window", "typeID", typeID, "itemID", itemID)
+	w := iw.w
+	if w == nil {
+		w = iw.u.MainWindow()
+	}
+	showError := func(err error) {
+		ui.ShowErrorAndLog("Can't show info window", err, iw.u.IsDeveloperMode(), w)
+	}
+	if typeID == 0 {
+		showError(fmt.Errorf("missing type ID"))
+		return
+	}
+	if itemID == 0 {
+		iw.show(infoInventoryType, typeID)
+		return
+	}
+	switch typeID {
+	case app.EveTypeAlliance:
+		iw.show(infoAlliance, itemID)
+		return
+	case app.EveTypeCharacter:
+		iw.show(infoCharacter, itemID)
+		return
+	case app.EveTypeConstellation:
+		iw.show(infoConstellation, itemID)
+		return
+	case app.EveTypeCorporation:
+		iw.show(infoCorporation, itemID)
+		return
+	case app.EveTypeRegion:
+		iw.show(infoRegion, itemID)
+		return
+	case app.EveTypeSolarSystem:
+		iw.show(infoSolarSystem, itemID)
+		return
+	case app.EveTypeCaldariLogisticsStation:
+		iw.show(infoLocation, itemID)
+		return
+	}
+
+	ctx := context.Background()
+	et, err := iw.u.EVEUniverse().GetOrCreateTypeESI(ctx, typeID)
+	if err != nil {
+		ui.ShowErrorAndLog("Can't show info window", err, iw.u.IsDeveloperMode(), w)
+		return
+	}
+	switch et.Group.Category.ID {
+	case app.EveCategoryStation:
+		iw.show(infoLocation, itemID)
+		return
+	case app.EveCategoryStructure:
+		iw.show2(showParams{
+			variant:     infoLocation,
+			entityID:    itemID,
+			characterID: characterID,
+		})
+		return
+	}
+	switch et.Group.ID {
+	case app.EveGroupCharacter:
+		iw.show(infoCharacter, itemID)
+		return
+	}
+
+	iw.show(infoNotSupported, 0)
 }
 
 func (iw *InfoViewer) ShowBloodline(id int64) {
@@ -132,8 +265,13 @@ func (iw *InfoViewer) show2(arg showParams) {
 		parentW = iw.u.MainWindow()
 	}
 
-	if arg.entityID == 0 || arg.variant == infoNotSupported {
-		ui.ShowErrorAndLog("Can't show info window", app.ErrInvalid, iw.u.IsDeveloperMode(), parentW)
+	if arg.entityID == 0 {
+		ui.ShowErrorAndLog("Can't show info window", fmt.Errorf("no ID provided"), iw.u.IsDeveloperMode(), parentW)
+		return
+	}
+
+	if arg.variant == infoNotSupported {
+		ui.ShowErrorAndLog("Can't show info window", fmt.Errorf("not supported"), iw.u.IsDeveloperMode(), parentW)
 		return
 	}
 
@@ -212,7 +350,7 @@ func (iw *InfoViewer) show2(arg showParams) {
 		page = newSolarSystemInfo(iw, arg.entityID)
 	case infoLocation:
 		title = "Location"
-		page = newLocationInfo(iw, arg.entityID)
+		page = newLocationInfo(iw, arg.entityID, arg.characterID)
 	default:
 		ui.ShowInformation(
 			"Warning",
@@ -379,69 +517,6 @@ func (iw *InfoViewer) renderIconSize() fyne.Size {
 		s = renderIconUnitSize
 	}
 	return fyne.NewSquareSize(s)
-}
-
-type infoVariant uint
-
-const (
-	infoNotSupported infoVariant = iota
-	infoAlliance
-	infoBloodline
-	infoCharacter
-	infoConstellation
-	infoCorporation
-	infoInventoryType
-	infoLocation
-	infoRace
-	infoRegion
-	infoSolarSystem
-)
-
-func (iv infoVariant) String() string {
-	m := map[infoVariant]string{
-		infoAlliance:      "alliance",
-		infoBloodline:     "bloodline",
-		infoCharacter:     "character",
-		infoConstellation: "constellation",
-		infoCorporation:   "corporation",
-		infoInventoryType: "type",
-		infoLocation:      "location",
-		infoRegion:        "region",
-		infoRace:          "race",
-		infoSolarSystem:   "solar system",
-	}
-
-	s, ok := m[iv]
-	if !ok {
-		return ""
-	}
-	return s
-}
-
-var eveEntityCategory2InfoVariant = map[app.EveEntityCategory]infoVariant{
-	app.EveEntityAlliance:      infoAlliance,
-	app.EveEntityCharacter:     infoCharacter,
-	app.EveEntityConstellation: infoConstellation,
-	app.EveEntityCorporation:   infoCorporation,
-	app.EveEntityRegion:        infoRegion,
-	app.EveEntitySolarSystem:   infoSolarSystem,
-	app.EveEntityStation:       infoLocation,
-	app.EveEntityInventoryType: infoInventoryType,
-}
-
-func eveEntity2InfoVariant(ee *app.EveEntity) infoVariant {
-	v, ok := eveEntityCategory2InfoVariant[ee.Category]
-	if !ok {
-		return infoNotSupported
-	}
-	return v
-
-}
-
-// SupportedCategories returns which EveEntity categories are supported.
-func SupportedCategories() set.Set[app.EveEntityCategory] {
-	return set.Collect(maps.Keys(eveEntityCategory2InfoVariant))
-
 }
 
 // baseInfo represents shared functionality between all info widgets.

--- a/internal/app/ui/infoviewer/infoviewer.go
+++ b/internal/app/ui/infoviewer/infoviewer.go
@@ -764,7 +764,7 @@ func newEntityItemFromEvePlanet(o *app.EvePlanet) entityItem {
 }
 
 func newEntityItemFromEveSolarSystem(o *app.EveSolarSystem) entityItem {
-	ee := o.EveEntity()
+	ee := o.ToEveEntity()
 	return entityItem{
 		id:           ee.ID,
 		category:     ee.CategoryDisplay(),

--- a/internal/app/ui/infoviewer/locationinfo.go
+++ b/internal/app/ui/infoviewer/locationinfo.go
@@ -119,7 +119,7 @@ func (a *locationInfo) update(ctx context.Context) error {
 			})
 			a.typeInfo.SetText(et.Name)
 			a.typeInfo.OnTapped = func() {
-				a.iw.Show(et.EveEntity())
+				a.iw.Show(et.ToEveEntity())
 			}
 			a.typeImage.OnTapped = func() {
 				a.iw.showZoomWindow(o.Name, et.ID, a.iw.u.EVEImage().InventoryTypeRenderAsync, a.iw.w)
@@ -146,8 +146,8 @@ func (a *locationInfo) update(ctx context.Context) error {
 	if es, ok := o.SolarSystem.Value(); ok {
 		fyne.Do(func() {
 			a.location.set(
-				newEntityItemFromEveEntityWithText(es.Constellation.Region.EveEntity(), ""),
-				newEntityItemFromEveEntityWithText(es.Constellation.EveEntity(), ""),
+				newEntityItemFromEveEntityWithText(es.Constellation.Region.ToEveEntity(), ""),
+				newEntityItemFromEveEntityWithText(es.Constellation.ToEveEntity(), ""),
 				newEntityItemFromEveSolarSystem(es),
 			)
 		})

--- a/internal/app/ui/infoviewer/locationinfo.go
+++ b/internal/app/ui/infoviewer/locationinfo.go
@@ -13,9 +13,13 @@ import (
 	"fyne.io/fyne/v2/widget"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ErikKalkoken/go-set"
+	"github.com/fnt-eve/goesi-openapi"
+
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
+	"github.com/ErikKalkoken/evebuddy/internal/xgoesi"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 	"github.com/ErikKalkoken/evebuddy/internal/xstrings"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
@@ -27,7 +31,8 @@ type locationInfo struct {
 	baseInfo
 
 	description *widget.Label
-	id          int64
+	itemID      int64
+	characterID int64
 	location    *entityList
 	owner       *widget.Hyperlink
 	ownerLogo   *canvas.Image
@@ -37,7 +42,7 @@ type locationInfo struct {
 	typeInfo    *widget.Hyperlink
 }
 
-func newLocationInfo(iw *InfoViewer, id int64) *locationInfo {
+func newLocationInfo(iw *InfoViewer, itemID, characterID int64) *locationInfo {
 	typeInfo := widget.NewHyperlink("", nil)
 	typeInfo.Wrapping = fyne.TextWrapWord
 	owner := widget.NewHyperlink("", nil)
@@ -47,7 +52,8 @@ func newLocationInfo(iw *InfoViewer, id int64) *locationInfo {
 	typeImage.SetMinSize(iw.renderIconSize())
 	a := &locationInfo{
 		description: newLabelWithWrapAndSelectable(""),
-		id:          id,
+		itemID:      itemID,
+		characterID: characterID,
 		owner:       owner,
 		ownerLogo:   xwidget.NewImageFromResource(icons.BlankSvg, fyne.NewSquareSize(ui.IconUnitSize)),
 		typeImage:   typeImage,
@@ -89,9 +95,19 @@ func (a *locationInfo) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (a *locationInfo) update(ctx context.Context) error {
-	o, err := a.iw.u.EVEUniverse().GetOrCreateLocationESI(ctx, a.id)
+	if a.characterID != 0 {
+		ts, err := a.iw.u.Character().TokenSource(ctx, a.characterID, set.Of(goesi.ScopeUniverseReadStructuresV1))
+		if err != nil {
+			return err
+		}
+		ctx = xgoesi.NewContextWithAuth(ctx, a.characterID, ts)
+	}
+	o, err := a.iw.u.EVEUniverse().GetOrCreateLocationESI(ctx, a.itemID)
 	if err != nil {
 		return err
+	}
+	if o.Name == "" {
+		return fmt.Errorf("not allowed to access structure")
 	}
 	fyne.Do(func() {
 		a.name.SetText(o.Name)
@@ -155,7 +171,7 @@ func (a *locationInfo) update(ctx context.Context) error {
 		if o.Variant() != app.EveLocationStation {
 			return nil
 		}
-		ss, err := a.iw.u.EVEUniverse().GetStationServicesESI(ctx, a.id)
+		ss, err := a.iw.u.EVEUniverse().GetStationServicesESI(ctx, a.itemID)
 		if err != nil {
 			return err
 		}

--- a/internal/app/ui/infoviewer/solarsysteminfo.go
+++ b/internal/app/ui/infoviewer/solarsysteminfo.go
@@ -130,11 +130,11 @@ func (a *solarSystemInfo) update(ctx context.Context) error {
 			a.name.SetText(o.Name)
 			a.region.SetText(o.Constellation.Region.Name)
 			a.region.OnTapped = func() {
-				a.iw.Show(o.Constellation.Region.EveEntity())
+				a.iw.Show(o.Constellation.Region.ToEveEntity())
 			}
 			a.constellation.SetText(o.Constellation.Name)
 			a.constellation.OnTapped = func() {
-				a.iw.Show(o.Constellation.EveEntity())
+				a.iw.Show(o.Constellation.ToEveEntity())
 			}
 			a.security.Text = o.SecurityStatusDisplay()
 			a.security.Importance = o.SecurityType().ToImportance()

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -60,6 +60,7 @@ type EVEImageService interface {
 // InfoViewer defines which methods from the info viewer is used in the UI.
 type InfoViewer interface {
 	Show(o *app.EveEntity)
+	Show2(typeID, itemID, characterID int64)
 	ShowBloodline(id int64)
 	ShowLocation(id int64)
 	ShowRace(id int64)

--- a/internal/app/ui/wallets/wallettransaction.go
+++ b/internal/app/ui/wallets/wallettransaction.go
@@ -657,7 +657,7 @@ func ShowCharacterWalletTransactionWindowAsync(u baseUI, characterID int64, char
 				widget.NewFormItem("Activity", widget.NewLabel(activity)),
 				widget.NewFormItem("Quantity", widget.NewLabel(humanize.Comma(int64(o.Quantity)))),
 				widget.NewFormItem("Type", ui.MakeLinkLabelWithWrap(o.Type.Name, func() {
-					u.InfoViewer().Show(o.Type.EveEntity())
+					u.InfoViewer().Show(o.Type.ToEveEntity())
 				})),
 				widget.NewFormItem("Unit price", widget.NewLabel(ui.FormatISKAmount(o.UnitPrice))),
 				widget.NewFormItem("Total", total),
@@ -724,7 +724,7 @@ func ShowCorporationWalletTransactionWindowAsync(u baseUI, corporationID int64, 
 				widget.NewFormItem("Date", widget.NewLabel(o.Date.Format(app.DateTimeFormatWithSeconds))),
 				widget.NewFormItem("Quantity", widget.NewLabel(humanize.Comma(int64(o.Quantity)))),
 				widget.NewFormItem("Type", ui.MakeLinkLabelWithWrap(o.Type.Name, func() {
-					u.InfoViewer().Show(o.Type.EveEntity())
+					u.InfoViewer().Show(o.Type.ToEveEntity())
 				})),
 				widget.NewFormItem("Unit price", widget.NewLabel(ui.FormatISKAmount(o.UnitPrice))),
 				widget.NewFormItem("Total", widget.NewLabel(ui.FormatISKAmount(totalAmount))),


### PR DESCRIPTION
- Communications are now shown with rich text formatting (e.g. bold) and links
- Links for Eve objects (e.g. a solar system) are shown as hyperlinks and open an info window with details
- Moved developer action for sending a test notification into a new overflow menu. The menu is only visible in developer mode.
- Added developer action for copying the notification data to clipboard in JSON format. This can be a very helpful input for adding new notification types

Implements part of #61
