### PR TITLE
feat: add contact costs

### DIFF
--- a/internal/app/characterservice/characterservice.go
+++ b/internal/app/characterservice/characterservice.go
@@ -40,6 +40,7 @@ type EVENotificationService interface {
 }
 
 type Settings interface {
+	ApprovedContactCost() int
 	MarketOrderRetentionDays() int
 	MaxMails() int
 	MaxWalletTransactions() int

--- a/internal/app/characterservice/mail.go
+++ b/internal/app/characterservice/mail.go
@@ -137,9 +137,10 @@ func (s *CharacterService) SendMail(ctx context.Context, characterID int64, subj
 	ctx = xgoesi.NewContextWithAuth(ctx, characterID, ts)
 	ctx = xgoesi.NewContextWithOperationID(ctx, "PostCharactersCharacterIdMail")
 	request := esi.PostCharactersCharacterIdMailRequest{
-		Body:       body,
-		Subject:    subject,
-		Recipients: rr,
+		ApprovedCost: new(int64(s.settings.ApprovedContactCost())),
+		Body:         body,
+		Subject:      subject,
+		Recipients:   rr,
 	}
 	mailID, _, err := s.esiClient.MailAPI.PostCharactersCharacterIdMail(ctx, characterID).PostCharactersCharacterIdMailRequest(request).Execute()
 	if err != nil {

--- a/internal/app/characterservice/mail_test.go
+++ b/internal/app/characterservice/mail_test.go
@@ -1,7 +1,6 @@
 package characterservice_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+	"github.com/ErikKalkoken/evebuddy/internal/xgoesi"
 )
 
 func TestUpdateMailBodies(t *testing.T) {
@@ -23,7 +23,7 @@ func TestUpdateMailBodies(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	ctx := context.Background()
+
 	makeMailData := func(m *app.CharacterMail) map[string]any {
 		recipients := make([]map[string]any, 0)
 		for _, r := range m.Recipients {
@@ -62,10 +62,10 @@ func TestUpdateMailBodies(t *testing.T) {
 		)
 		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: mail.CharacterID})
 		// when
-		body, err := s.UpdateMailBodyESI(ctx, mail.CharacterID, mail.MailID)
+		body, err := s.UpdateMailBodyESI(t.Context(), mail.CharacterID, mail.MailID)
 		require.NoError(t, err)
 		xassert.Equal(t, "body", body)
-		mail2, err := s.GetMail(ctx, mail.CharacterID, mail.MailID)
+		mail2, err := s.GetMail(t.Context(), mail.CharacterID, mail.MailID)
 		require.NoError(t, err)
 		xassert.EqualOptional(t, "body", mail2.Body)
 	})
@@ -91,13 +91,13 @@ func TestUpdateMailBodies(t *testing.T) {
 			httpmock.NewJsonResponderOrPanic(200, makeMailData(mail2a)),
 		)
 		// when
-		aborted, err := s.DownloadMissingMailBodies(ctx, c.ID)
+		aborted, err := s.DownloadMissingMailBodies(t.Context(), c.ID)
 		require.NoError(t, err)
 		require.False(t, aborted)
-		mail1b, err := s.GetMail(ctx, c.ID, mail1a.MailID)
+		mail1b, err := s.GetMail(t.Context(), c.ID, mail1a.MailID)
 		require.NoError(t, err)
 		xassert.EqualOptional(t, "body1", mail1b.Body)
-		mail2b, err := s.GetMail(ctx, c.ID, mail2a.MailID)
+		mail2b, err := s.GetMail(t.Context(), c.ID, mail2a.MailID)
 		require.NoError(t, err)
 		xassert.EqualOptional(t, "body2", mail2b.Body)
 	})
@@ -107,7 +107,7 @@ func TestNotifyMails(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()
 	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	ctx := context.Background()
+
 	now := time.Now().UTC()
 	earliest := now.Add(-12 * time.Hour)
 	cases := []struct {
@@ -130,7 +130,7 @@ func TestNotifyMails(t *testing.T) {
 			})
 			var sendCount int
 			// when
-			err := cs.NotifyMails(ctx, n.CharacterID, earliest, func(title string, content string) {
+			err := cs.NotifyMails(t.Context(), n.CharacterID, earliest, func(title string, content string) {
 				sendCount++
 			})
 			// then
@@ -143,10 +143,10 @@ func TestNotifyMails(t *testing.T) {
 func TestSendMail(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+
 	t.Run("Can send mail", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
@@ -161,11 +161,40 @@ func TestSendMail(t *testing.T) {
 			httpmock.NewJsonResponderOrPanic(201, 123))
 
 		// when
-		mailID, err := s.SendMail(ctx, c.ID, "subject", []*app.EveEntity{r}, "body")
+		mailID, err := s.SendMail(t.Context(), c.ID, "subject", []*app.EveEntity{r}, "body")
+
 		// then
 		require.NoError(t, err)
-		m, err := s.GetMail(ctx, c.ID, mailID)
+		m, err := s.GetMail(t.Context(), c.ID, mailID)
 		require.NoError(t, err)
 		xassert.EqualOptional(t, "body", m.Body)
+	})
+
+	t.Run("should handle 520 error", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		r := factory.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"POST",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/mail", c.ID),
+			httpmock.NewJsonResponderOrPanic(xgoesi.StatusTooManyErrors, map[string]any{
+				"error": "ContactCostNotApproved",
+				"details": map[string]any{
+					"totalCost":       1,
+					"totalCostISK":    []int{20, 1},
+					"approvedCost":    0,
+					"approvedCostISK": []int{20, 0},
+				},
+			}))
+
+		// when
+		_, err := s.SendMail(t.Context(), c.ID, "subject", []*app.EveEntity{r}, "body")
+
+		// then
+		require.Error(t, err)
 	})
 }

--- a/internal/app/settings/settings.go
+++ b/internal/app/settings/settings.go
@@ -32,6 +32,8 @@ const (
 	settingLastCorporationID                  = "settingLastCorporationID"
 	settingLogLevel                           = "logLevel"
 	settingLogLevelDefault                    = "info"
+	settingApprovedContactCost                = "settingApprovedContactCost"
+	settingApprovedContactCostMax             = 1_000_000
 	settingMaxMails                           = "settingMaxMails"
 	settingMaxMailsDefault                    = 250
 	settingMaxMailsMax                        = 10_000
@@ -146,6 +148,20 @@ func (s Settings) ResetLogLevel() {
 
 func (s Settings) SetLogLevel(l string) {
 	s.p.SetString(settingLogLevel, l)
+}
+
+func (s Settings) ApprovedContactCost() int {
+	return s.p.IntWithFallback(settingApprovedContactCost, 0)
+}
+
+func (s Settings) ApprovedContactCostPresets() (minimum int, maximum int, def int) {
+	minimum = 0
+	maximum = settingApprovedContactCostMax
+	def = 0
+	return
+}
+func (s Settings) SetApprovedContactCost(v int) {
+	s.p.SetInt(settingApprovedContactCost, v)
 }
 
 func (s Settings) MaxMails() int {

--- a/internal/app/testutil/testdouble.go
+++ b/internal/app/testutil/testdouble.go
@@ -326,6 +326,10 @@ type SettingsStub struct {
 	MarketOrderRetentionDaysDefault int
 }
 
+func (s *SettingsStub) ApprovedContactCost() int {
+	return 0
+}
+
 func (s *SettingsStub) MaxMails() int {
 	return s.MaxMailsDefault
 }

--- a/internal/app/ui/characters/mails.go
+++ b/internal/app/ui/characters/mails.go
@@ -671,8 +671,6 @@ func (a *Mails) MakeComposeMessageAction() (fyne.Resource, func()) {
 	}
 }
 
-// TODO: Convert to ButtonWithProgressIndicator
-
 func (a *Mails) MakeDeleteAction(onSuccess func()) (fyne.Resource, func()) {
 	return theme.DeleteIcon(), func() {
 		ui.ShowProgressConfirm(

--- a/internal/app/ui/settings/settings.go
+++ b/internal/app/ui/settings/settings.go
@@ -278,8 +278,27 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 		window:   a.w,
 	})
 
+	vMin, vMax, vDef = a.u.Settings().ApprovedContactCostPresets()
+	approvedContactCost := NewSettingItemSlider(SettingItemSliderParams{
+		label:        "Approved contact cost",
+		hint:         "Maximum approved cost per contact in ISK",
+		minValue:     float64(vMin),
+		maxValue:     float64(vMax),
+		defaultValue: float64(vDef),
+		step:         10,
+		getter: func() float64 {
+			return float64(a.u.Settings().ApprovedContactCost())
+		},
+		setter: func(v float64) {
+			a.u.Settings().SetApprovedContactCost(int(v))
+		},
+		isMobile: a.u.IsMobile(),
+		window:   a.w,
+	})
+
 	items = slices.Concat(items, []SettingItem{
-		NewSettingItemHeading("Section updates"),
+		NewSettingItemHeading("EVE Online API"),
+		approvedContactCost,
 		maxMail,
 		maxWallet,
 		marketOrdersRetention,
@@ -287,7 +306,7 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 
 	developerMode := NewSettingItemSwitch(SettingItemSwitchParams{
 		label:  "Developer mode",
-		hint:   "Show debug information, e.g. EVE IDs of objects",
+		hint:   "Show debug information, e.g. EVE IDs and technical error messages",
 		getter: a.u.Settings().DeveloperMode,
 		onChanged: func(b bool) {
 			a.u.Settings().SetDeveloperMode(b)


### PR DESCRIPTION
- Added a new setting for approved contact costs. Default is 0, max is 1.000.000 (same as game)
- The approved contact cos setting will be used when sending mail from all characters
- Renamed the settings header "Section updates" to "EVE Online API"

Fixes #470 
