### PR TITLE
feat: move export fetures to overflow menu

### DIFF
--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -165,7 +165,6 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		theme.MoreHorizontalIcon(),
 		fyne.NewMenu("", u.training.MoreItems()...),
 	)
-	trainingMore.SetToolTip("More actions")
 	training := xwidget.NewNavPage(
 		"Training",
 		theme.NewThemedResource(icons.SchoolSvg),

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -20,6 +20,8 @@ import (
 
 	fynetooltip "github.com/dweymouth/fyne-tooltip"
 
+	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
+
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui/charactermanager"
@@ -164,7 +166,10 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 	training := xwidget.NewNavPage(
 		"Training",
 		theme.NewThemedResource(icons.SchoolSvg),
-		newContentPage("Training", u.training),
+		newContentPage("Training", u.training, kxwidget.NewIconButtonWithMenu(
+			theme.MoreHorizontalIcon(),
+			fyne.NewMenu("", u.training.MoreItems()...),
+		)),
 	)
 	u.training.OnUpdate = func(expired int) {
 		var badge string
@@ -826,27 +831,39 @@ func (u *DesktopUI) showUserDataDialog() {
 	d.Show()
 }
 
+// contentPage is a widget that is used produce a consistent appearance for each page.
+// It always has a title.
+// It can optionally have trailing items, i.e. icon buttons.
 type contentPage struct {
 	widget.BaseWidget
 
-	content fyne.CanvasObject
-	title   *widget.Label
+	content  fyne.CanvasObject
+	title    *widget.Label
+	trailing []fyne.CanvasObject
 }
 
-func newContentPage(title string, content fyne.CanvasObject) *contentPage {
+func newContentPage(title string, content fyne.CanvasObject, trailing ...fyne.CanvasObject) *contentPage {
 	l := widget.NewLabel(title)
 	l.SizeName = theme.SizeNameSubHeadingText
 	w := &contentPage{
-		content: content,
-		title:   l,
+		content:  content,
+		title:    l,
+		trailing: trailing,
 	}
 	w.ExtendBaseWidget(w)
 	return w
 }
 
 func (w *contentPage) CreateRenderer() fyne.WidgetRenderer {
+	top := container.NewHBox(w.title)
+	if len(w.trailing) > 0 {
+		top.Add(layout.NewSpacer())
+		for _, x := range w.trailing {
+			top.Add(x)
+		}
+	}
 	c := container.NewBorder(
-		w.title,
+		top,
 		nil,
 		nil,
 		nil,

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -20,8 +20,6 @@ import (
 
 	fynetooltip "github.com/dweymouth/fyne-tooltip"
 
-	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
-
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui/charactermanager"
@@ -163,13 +161,15 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		)),
 	)
 
+	trainingMore := xwidget.NewIconButtonWithMenu(
+		theme.MoreHorizontalIcon(),
+		fyne.NewMenu("", u.training.MoreItems()...),
+	)
+	trainingMore.SetToolTip("More actions")
 	training := xwidget.NewNavPage(
 		"Training",
 		theme.NewThemedResource(icons.SchoolSvg),
-		newContentPage("Training", u.training, kxwidget.NewIconButtonWithMenu(
-			theme.MoreHorizontalIcon(),
-			fyne.NewMenu("", u.training.MoreItems()...),
-		)),
+		newContentPage("Training", u.training, trainingMore),
 	)
 	u.training.OnUpdate = func(expired int) {
 		var badge string

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -877,7 +877,10 @@ func makeHomeNav(u *MobileUI) (*xwidget.Navigator, *StatusBarItem) {
 		"Training",
 		theme.NewThemedResource(icons.SchoolSvg),
 		func() {
-			homeNav.Push(xwidget.NewAppBar("Training", u.training))
+			homeNav.Push(xwidget.NewAppBar("Training", u.training, kxwidget.NewIconButtonWithMenu(
+				theme.MoreHorizontalIcon(),
+				fyne.NewMenu("", u.training.MoreItems()...),
+			)))
 		},
 	)
 	u.training.OnUpdate = func(expired int) {

--- a/internal/app/ui/core/toolbar.go
+++ b/internal/app/ui/core/toolbar.go
@@ -21,8 +21,8 @@ type toolbar struct {
 	widget.BaseWidget
 
 	searchBar  *widget.Entry
-	searchIcon *xwidget.TappableIcon
-	hamburger  *xwidget.TappableIcon
+	searchIcon *xwidget.IconButton
+	hamburger  *xwidget.IconButton
 	u          *DesktopUI
 }
 
@@ -40,7 +40,7 @@ func newToolbar(u *DesktopUI) *toolbar {
 	clearSearch.SetToolTip("Clear search bar")
 	searchBar.ActionItem = container.NewPadded(clearSearch)
 
-	searchIcon := xwidget.NewTappableIcon(theme.SearchIcon(), func() {
+	searchIcon := xwidget.NewIconButton(theme.SearchIcon(), func() {
 		u.showAdvancedSearch(searchBar.Text)
 	})
 	searchIcon.SetToolTip("Advanced search")
@@ -76,7 +76,7 @@ func newToolbar(u *DesktopUI) *toolbar {
 		it,
 		makeMenuItem("Quit", quit),
 	)
-	hamburger := xwidget.NewTappableIconWithMenu(theme.MenuIcon(), menu)
+	hamburger := xwidget.NewIconButtonWithMenu(theme.MenuIcon(), menu)
 	hamburger.SetToolTip("Main menu")
 	a := &toolbar{
 		hamburger:  hamburger,

--- a/internal/app/ui/skills/catalogue.go
+++ b/internal/app/ui/skills/catalogue.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
-	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
@@ -55,21 +54,21 @@ type Catalogue struct {
 	widget.BaseWidget
 
 	character      atomic.Pointer[app.Character]
+	columnSorter   *xwidget.ColumnSorter[skillRow]
 	footer         *widget.Label
 	levelBlocked   *theme.ErrorThemedResource
 	levelTrained   *theme.PrimaryThemedResource
 	levelUnTrained *theme.DisabledResource
+	moreButton     *xwidget.IconButton
 	rows           []skillRow
 	rowsFiltered   []skillRow
 	search         *widget.Entry
 	selectGroup    *kxwidget.FilterChipSelect
 	selectMain     *kxwidget.FilterChipSelect
 	skills         fyne.CanvasObject
+	sortButton     *xwidget.SortButton
 	top            *widget.Label
 	u              baseUI
-	sortButton     *xwidget.SortButton
-	columnSorter   *xwidget.ColumnSorter[skillRow]
-	exportButton   *xwidget.ContextMenuButton
 }
 
 func NewCatalogue(u baseUI) *Catalogue {
@@ -135,18 +134,17 @@ func NewCatalogue(u baseUI) *Catalogue {
 		a.filterRowsAsync()
 	}, a.u.MainWindow())
 
-	a.exportButton = xwidget.NewContextMenuButtonWithIcon(
-		"Export",
-		theme.NewThemedResource(icons.ExportVariantSvg),
+	a.moreButton = xwidget.NewIconButtonWithMenu(
+		theme.MoreHorizontalIcon(),
 		fyne.NewMenu("",
-			fyne.NewMenuItem("Copy to clipboard", func() {
+			fyne.NewMenuItem("Copy skills to clipboard", func() {
 				a.copySkillsToClipboard()
 			}),
-			fyne.NewMenuItem("Save as CSV", func() {
+			fyne.NewMenuItem("Save skills as CSV", func() {
 				a.exportSkillsToCSV()
 			}),
-		))
-	a.exportButton.SetToolTip("Export skills to clipboard or file")
+		),
+	)
 
 	// signals
 	a.u.Signals().CurrentCharacterExchanged.AddListener(func(ctx context.Context, c *app.Character) {
@@ -182,7 +180,7 @@ func (a *Catalogue) CreateRenderer() fyne.WidgetRenderer {
 		topBox.Add(container.NewHScroll(filter))
 	} else {
 		topAligned := container.NewVBox(layout.NewSpacer(), a.top, layout.NewSpacer())
-		topBox.Add(container.NewBorder(nil, nil, nil, container.NewPadded(a.exportButton), topAligned))
+		topBox.Add(container.NewBorder(nil, nil, nil, a.moreButton, topAligned))
 		topBox.Add(container.NewBorder(nil, nil, filter, nil, a.search))
 	}
 	c := container.NewBorder(
@@ -450,7 +448,7 @@ func makeGridOrList(isMobile bool, length func() int, makeCreateItem func(trunc 
 func (a *Catalogue) copySkillsToClipboard() {
 	characterID := a.character.Load().IDOrZero()
 	if characterID == 0 {
-		a.u.ShowSnackbar("No character")
+		a.u.ShowSnackbar("No skills to copy")
 		return
 	}
 	text, err := a.u.Character().MakeSkillsExportLines(context.Background(), characterID)
@@ -466,7 +464,7 @@ func (a *Catalogue) copySkillsToClipboard() {
 func (a *Catalogue) exportSkillsToCSV() {
 	character := a.character.Load()
 	if character == nil {
-		a.u.ShowSnackbar("No character")
+		a.u.ShowSnackbar("No skills to export")
 		return
 	}
 
@@ -476,15 +474,15 @@ func (a *Catalogue) exportSkillsToCSV() {
 		}
 		defer writer.Close()
 		if err != nil {
-			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return
 		}
 		if err := a.u.Character().WriteSkillsExportCSV(context.Background(), character.ID, writer); err != nil {
-			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return
 		}
 		slog.Info("Skills exported to file", "uri", writer.URI())
-		a.u.ShowSnackbar("Skills saved to CSV")
+		a.u.ShowSnackbar("Skills saved")
 	}, a.u.MainWindow())
 
 	characterName := character.NameOrZero()

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
-	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
@@ -303,15 +302,6 @@ func NewTraining(u baseUI) *Training {
 	a.selectTag = kxwidget.NewFilterChipSelect("Tag", []string{}, func(string) {
 		a.filterRowsAsync(-1)
 	})
-	a.exportButton = xwidget.NewContextMenuButtonWithIcon(
-		"Export",
-		theme.NewThemedResource(icons.ExportVariantSvg),
-		fyne.NewMenu("",
-			fyne.NewMenuItem("Copy to clipboard", a.copyTrainingToClipboard),
-			fyne.NewMenuItem("Save as CSV", a.saveTrainingAsCSV),
-		),
-	)
-	a.exportButton.SetToolTip("Export training data to clipboard or file")
 	a.sortButton = a.columnSorter.NewSortButton(func() {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow())
@@ -350,8 +340,6 @@ func (a *Training) CreateRenderer() fyne.WidgetRenderer {
 	filter := container.NewHBox(a.selectStatus, a.selectTag)
 	if a.u.IsMobile() {
 		filter.Add(a.sortButton)
-	} else {
-		filter.Add(a.exportButton)
 	}
 	var topBox *fyne.Container
 	if a.u.IsMobile() {
@@ -370,6 +358,15 @@ func (a *Training) CreateRenderer() fyne.WidgetRenderer {
 		a.main,
 	)
 	return widget.NewSimpleRenderer(c)
+}
+
+// MoreItems returns the list of menu items for the overflow menu.
+func (a *Training) MoreItems() []*fyne.MenuItem {
+	items := []*fyne.MenuItem{
+		fyne.NewMenuItem("Copy training data to clipboard", a.copyTrainingToClipboard),
+		fyne.NewMenuItem("Save training data as CSV", a.saveTrainingAsCSV),
+	}
+	return items
 }
 
 func (a *Training) makeDataList() *xwidget.StripedList {

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -364,7 +364,7 @@ func (a *Training) CreateRenderer() fyne.WidgetRenderer {
 func (a *Training) MoreItems() []*fyne.MenuItem {
 	items := []*fyne.MenuItem{
 		fyne.NewMenuItem("Copy training data to clipboard", a.copyTrainingToClipboard),
-		fyne.NewMenuItem("Save training data as CSV", a.saveTrainingAsCSV),
+		fyne.NewMenuItem("Save training data as file", a.saveTrainingAsCSV),
 	}
 	return items
 }
@@ -483,7 +483,7 @@ func (a *Training) makeTrainingCSVString() string {
 
 func (a *Training) copyTrainingToClipboard() {
 	fyne.CurrentApp().Clipboard().SetContent(a.makeTrainingCSVString())
-	a.u.ShowSnackbar("Copied to clipboard")
+	a.u.ShowSnackbar("Training data copied to clipboard")
 }
 
 func (a *Training) saveTrainingAsCSV() {
@@ -493,21 +493,21 @@ func (a *Training) saveTrainingAsCSV() {
 		}
 		defer writer.Close()
 		if err != nil {
-			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return
 		}
 		_, err = writer.Write([]byte(a.makeTrainingCSVString()))
 		if err != nil {
-			ui.ShowErrorAndLog("Failed to save CSV", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
 			return
 		}
 		slog.Info("Training data exported to file", "uri", writer.URI())
-		a.u.ShowSnackbar("Training data saved to CSV")
+		a.u.ShowSnackbar("Training data saved to file")
 	}, a.u.MainWindow())
 
 	d.SetFileName("training.csv")
 	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
-	d.SetTitleText("Save training data as CSV")
+	d.SetTitleText("Save training data")
 	d.Show()
 
 	_, s := a.u.MainWindow().Canvas().InteractiveArea()

--- a/internal/app/ui/wallets/overview.go
+++ b/internal/app/ui/wallets/overview.go
@@ -66,7 +66,7 @@ type Overview struct {
 	selectTag    *kxwidget.FilterChipSelect
 	sortButton   *xwidget.SortButton
 	u            baseUI
-	showHelp     *xwidget.TappableIcon
+	showHelp     *xwidget.IconButton
 }
 
 const (
@@ -215,7 +215,7 @@ func NewOverview(u baseUI) *Overview {
 	}
 	a.search.PlaceHolder = "Search characters"
 
-	a.showHelp = xwidget.NewTappableIcon(theme.QuestionIcon(), func() {
+	a.showHelp = xwidget.NewIconButton(theme.QuestionIcon(), func() {
 		showHelpPopUp(overviewHelpText, a.u.IsMobile(), a.showHelp)
 	})
 	a.showHelp.SetToolTip("Show explanation for columns")

--- a/internal/xwidget/buttonwithprogress.go
+++ b/internal/xwidget/buttonwithprogress.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -13,21 +14,20 @@ import (
 type ProgressButton struct {
 	widget.BaseWidget
 
-	isDisabled bool
-	button     *widget.Button
-	progress   *widget.Activity
-	spacer     *canvas.Rectangle
-	label      string
-	icon       fyne.Resource
+	button   *lockableButton
+	progress *widget.Activity
+	spacer   *canvas.Rectangle
+	label    string
+	icon     fyne.Resource
 }
 
 // NewProgressButton creates a new button with a progress indicator.
 //
-// Note that action will be run in a goroutine.
-// Make use to use fyne.Do when accessing the Fyne API
+// The action will be run in a goroutine.
+// Note that the button remains clickable
 func NewProgressButton(label string, icon fyne.Resource, action func()) *ProgressButton {
 	w := &ProgressButton{
-		button:   widget.NewButtonWithIcon(label, icon, nil),
+		button:   newLockableButton(label, icon, nil),
 		progress: widget.NewActivity(),
 		spacer:   canvas.NewRectangle(color.Transparent),
 		label:    label,
@@ -37,6 +37,7 @@ func NewProgressButton(label string, icon fyne.Resource, action func()) *Progres
 	w.progress.Hide()
 	w.progress.Stop()
 	w.button.OnTapped = func() {
+		w.button.disable()
 		// clear button
 		w.spacer.SetMinSize(w.button.Size())
 		w.button.Text = ""
@@ -57,6 +58,7 @@ func NewProgressButton(label string, icon fyne.Resource, action func()) *Progres
 				w.progress.Stop()
 				w.progress.Hide()
 				w.progress.Stop()
+				w.button.enable()
 			})
 		}()
 	}
@@ -86,17 +88,66 @@ func (w *ProgressButton) SetIcon(icon fyne.Resource) {
 
 // Disabled reports whether this widget is disabled.
 func (w *ProgressButton) Disabled() bool {
-	return w.isDisabled
+	return w.button.Disabled()
 }
 
 // Disable disables this widget.
 func (w *ProgressButton) Disable() {
-	w.isDisabled = true
 	w.button.Disable()
 }
 
 // Enable enables this widget.
 func (w *ProgressButton) Enable() {
-	w.isDisabled = false
 	w.button.Enable()
+}
+
+// lockableButton is an extension of the Fyne button which can be fully disabled
+// without changing it's appearance.
+//
+// This feature is used by the ProgressButton.
+type lockableButton struct {
+	widget.Button
+	disabled bool
+}
+
+func newLockableButton(label string, icon fyne.Resource, tapped func()) *lockableButton {
+	w := &lockableButton{
+		Button: widget.Button{
+			Text:     label,
+			Icon:     icon,
+			OnTapped: tapped,
+		},
+	}
+	w.ExtendBaseWidget(w)
+	return w
+}
+
+func (w *lockableButton) enable() {
+	w.disabled = false
+}
+
+func (w *lockableButton) disable() {
+	w.disabled = true
+}
+
+func (w *lockableButton) Tapped(pe *fyne.PointEvent) {
+	if w.disabled {
+		return
+	}
+	w.Button.Tapped(pe)
+}
+
+func (w *lockableButton) MouseIn(me *desktop.MouseEvent) {
+	if w.disabled {
+		return
+	}
+	w.Button.MouseIn(me)
+}
+
+func (w *lockableButton) MouseOut() {
+	if w.disabled {
+		return
+	}
+	w.Button.MouseOut()
+
 }

--- a/internal/xwidget/iconbutton.go
+++ b/internal/xwidget/iconbutton.go
@@ -1,0 +1,39 @@
+package xwidget
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+)
+
+// IconButton represents an icon button.
+//
+// This is a workaround until kxwidget.IconButton has been modified to be extensible with tooltips.
+type IconButton struct {
+	widget.BaseWidget
+	Icon *TappableIcon
+}
+
+func NewIconButton(res fyne.Resource, tapped func()) *IconButton {
+	w := &IconButton{
+		Icon: NewTappableIcon(res, tapped),
+	}
+	w.ExtendBaseWidget(w)
+	return w
+}
+
+func NewIconButtonWithMenu(res fyne.Resource, menu *fyne.Menu) *IconButton {
+	w := &IconButton{
+		Icon: NewTappableIconWithMenu(res, menu),
+	}
+	w.ExtendBaseWidget(w)
+	return w
+}
+
+func (w *IconButton) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(container.NewPadded(w.Icon))
+}
+
+func (w *IconButton) SetToolTip(toolTip string) {
+	w.Icon.SetToolTip(toolTip)
+}


### PR DESCRIPTION
- Moved the export feature in training and catalogue to an overflow menu for better UX
- Added `xwidget.IconButton`
- Fixed a bug in `xwidget.ProgressButton` where the button was still active while the action was running
