### PR TITLE
feat: show contract description

### DIFF
--- a/internal/app/contract.go
+++ b/internal/app/contract.go
@@ -355,7 +355,10 @@ func contractNameDisplay(ct ContractType, start, end optional.Optional[*EntitySh
 		return "[Multiple Items]"
 	}
 	if len(items) == 1 {
+		if items[0] == "" {
+			return "[Single Item]"
+		}
 		return items[0]
 	}
-	return "?"
+	return "[Empty]"
 }

--- a/internal/app/storage/charactercontract.go
+++ b/internal/app/storage/charactercontract.go
@@ -418,9 +418,9 @@ func characterContractFromDBModel(
 	startSolarSystemName startSolarSystemName,
 	startSolarSystemSecurity startSolarSystemSecurity,
 ) *app.CharacterContract {
-	i2, ok := items.(string)
-	if !ok {
-		i2 = ""
+	var items2 []string
+	if x, ok := items.(string); ok && x != "" {
+		items2 = strings.Split(x, ",")
 	}
 	o := &app.CharacterContract{
 		Acceptor:          eveEntityFromNullableDBModel(nullEveEntity(acceptor)),
@@ -439,7 +439,7 @@ func characterContractFromDBModel(
 		ID:                cc.ID,
 		Issuer:            eveEntityFromDBModel(queries.EveEntity(issuer)),
 		IssuerCorporation: eveEntityFromDBModel(queries.EveEntity(issuerCorporation)),
-		Items:             strings.Split(i2, ","),
+		Items:             items2,
 		Price:             optional.FromZeroValue(cc.Price),
 		Reward:            optional.FromZeroValue(cc.Reward),
 		Status:            characterContractStatusFromDBValue[cc.Status],

--- a/internal/app/storage/charactercontract_test.go
+++ b/internal/app/storage/charactercontract_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,18 +18,20 @@ import (
 )
 
 func TestCharacterContract(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
-	t.Run("can create new minimal", func(t *testing.T) {
+
+	t.Run("can create new minimal courier contract", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		issuer := factory.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
+		c := f.CreateCharacter()
+		issuer := f.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
 		issuerCorporation := c.EveCharacter.Corporation
 		dateExpired := time.Now().Add(12 * time.Hour).UTC()
 		dateIssued := time.Now().UTC()
-		arg := storage.CreateCharacterContractParams{
+
+		// when
+		id, err := st.CreateCharacterContract(t.Context(), storage.CreateCharacterContractParams{
 			Availability:        app.ContractAvailabilityPrivate,
 			CharacterID:         c.ID,
 			ContractID:          42,
@@ -40,12 +41,11 @@ func TestCharacterContract(t *testing.T) {
 			IssuerID:            issuer.ID,
 			Status:              app.ContractStatusOutstanding,
 			Type:                app.ContractTypeCourier,
-		}
-		// when
-		id, err := st.CreateCharacterContract(ctx, arg)
+		})
+
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCharacterContract(ctx, c.ID, 42)
+		o, err := st.GetCharacterContract(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		xassert.Equal(t, id, o.ID)
 		xassert.Equal(t, issuer, o.Issuer)
@@ -55,17 +55,20 @@ func TestCharacterContract(t *testing.T) {
 		xassert.Equal(t, app.ContractTypeCourier, o.Type)
 		assert.WithinDuration(t, time.Now().UTC(), o.UpdatedAt, 5*time.Second)
 	})
-	t.Run("can create new full", func(t *testing.T) {
+
+	t.Run("can create new full courier contract", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		issuer := factory.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
+		c := f.CreateCharacter()
+		issuer := f.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
 		issuerCorporation := c.EveCharacter.Corporation
 		dateExpired := time.Now().Add(12 * time.Hour).UTC()
 		dateIssued := time.Now().UTC()
-		startLocation := factory.CreateEveLocationStructure()
-		endLocation := factory.CreateEveLocationStructure()
-		arg := storage.CreateCharacterContractParams{
+		startLocation := f.CreateEveLocationStructure()
+		endLocation := f.CreateEveLocationStructure()
+
+		// when
+		id, err := st.CreateCharacterContract(t.Context(), storage.CreateCharacterContractParams{
 			Availability:        app.ContractAvailabilityPrivate,
 			CharacterID:         c.ID,
 			ContractID:          42,
@@ -77,12 +80,11 @@ func TestCharacterContract(t *testing.T) {
 			Type:                app.ContractTypeCourier,
 			EndLocationID:       optional.New(endLocation.ID),
 			StartLocationID:     optional.New(startLocation.ID),
-		}
-		// when
-		id, err := st.CreateCharacterContract(ctx, arg)
+		})
+
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCharacterContract(ctx, c.ID, 42)
+		o, err := st.GetCharacterContract(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		xassert.Equal(t, id, o.ID)
 		xassert.Equal(t, issuer, o.Issuer)
@@ -98,10 +100,78 @@ func TestCharacterContract(t *testing.T) {
 		xassert.Equal(t, startLocation.SolarSystem.MustValue().Name, o.StartSolarSystem.MustValue().Name)
 		assert.WithinDuration(t, time.Now().UTC(), o.UpdatedAt, 5*time.Second)
 	})
+
+	t.Run("can create new minimal item exchange with item", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := f.CreateCharacter()
+		issuer := f.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
+		issuerCorporation := c.EveCharacter.Corporation
+		dateExpired := time.Now().Add(12 * time.Hour).UTC()
+		dateIssued := time.Now().UTC()
+		item := f.CreateEveType()
+
+		// when
+		id, err := st.CreateCharacterContract(t.Context(), storage.CreateCharacterContractParams{
+			Availability:        app.ContractAvailabilityPrivate,
+			CharacterID:         c.ID,
+			ContractID:          42,
+			DateExpired:         dateExpired,
+			DateIssued:          dateIssued,
+			IssuerCorporationID: issuerCorporation.ID,
+			IssuerID:            issuer.ID,
+			Status:              app.ContractStatusOutstanding,
+			Type:                app.ContractTypeItemExchange,
+		})
+		require.NoError(t, err)
+		err2 := st.CreateCharacterContractItem(t.Context(), storage.CreateCharacterContractItemParams{
+			ContractID: id,
+			IsIncluded: true,
+			Quantity:   1,
+			RecordID:   42,
+			TypeID:     item.ID,
+		})
+
+		// then
+		require.NoError(t, err2)
+		got, err := st.GetCharacterContract(t.Context(), c.ID, 42)
+		require.NoError(t, err)
+		xassert.Equal(t, []string{item.Name + " x 1"}, got.Items)
+	})
+
+	t.Run("can create new minimal item exchange without items", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := f.CreateCharacter()
+		issuer := f.CreateEveEntityCharacter(app.EveEntity{ID: c.ID})
+		issuerCorporation := c.EveCharacter.Corporation
+		dateExpired := time.Now().Add(12 * time.Hour).UTC()
+		dateIssued := time.Now().UTC()
+
+		// when
+		_, err := st.CreateCharacterContract(t.Context(), storage.CreateCharacterContractParams{
+			Availability:        app.ContractAvailabilityPrivate,
+			CharacterID:         c.ID,
+			ContractID:          42,
+			DateExpired:         dateExpired,
+			DateIssued:          dateIssued,
+			IssuerCorporationID: issuerCorporation.ID,
+			IssuerID:            issuer.ID,
+			Status:              app.ContractStatusOutstanding,
+			Type:                app.ContractTypeItemExchange,
+		})
+
+		// then
+		require.NoError(t, err)
+		got, err := st.GetCharacterContract(t.Context(), c.ID, 42)
+		require.NoError(t, err)
+		assert.Len(t, got.Items, 0)
+	})
+
 	t.Run("can update contract", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		o1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			UpdatedAt: time.Now().UTC().Add(-5 * time.Second),
 		})
 		dateAccepted := time.Now().UTC()
@@ -114,55 +184,58 @@ func TestCharacterContract(t *testing.T) {
 			Status:        app.ContractStatusFinished,
 		}
 		// when
-		err := st.UpdateCharacterContract(ctx, arg2)
+		err := st.UpdateCharacterContract(t.Context(), arg2)
 		// then
 		require.NoError(t, err)
-		o2, err := st.GetCharacterContract(ctx, o1.CharacterID, o1.ContractID)
+		o2, err := st.GetCharacterContract(t.Context(), o1.CharacterID, o1.ContractID)
 		require.NoError(t, err)
 		xassert.Equal(t, app.ContractStatusFinished, o2.Status)
 		xassert.Equal(t, optional.New(dateAccepted), o2.DateAccepted)
 		xassert.Equal(t, optional.New(dateCompleted), o2.DateCompleted)
 		assert.Less(t, o1.UpdatedAt, o2.UpdatedAt)
 	})
+
 	t.Run("can update notified", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		o1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			UpdatedAt: time.Now().UTC().Add(-5 * time.Second),
 		})
 		// when
-		err := st.UpdateCharacterContractNotified(ctx, o1.ID, app.ContractStatusInProgress)
+		err := st.UpdateCharacterContractNotified(t.Context(), o1.ID, app.ContractStatusInProgress)
 		// then
 		require.NoError(t, err)
-		o2, err := st.GetCharacterContract(ctx, o1.CharacterID, o1.ContractID)
+		o2, err := st.GetCharacterContract(t.Context(), o1.CharacterID, o1.ContractID)
 		require.NoError(t, err)
 		xassert.Equal(t, app.ContractStatusInProgress, o2.StatusNotified)
 		assert.Less(t, o1.UpdatedAt, o2.UpdatedAt)
 	})
+
 	t.Run("can list IDs of existing entries", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		e1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
-		e2 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
-		e3 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		c := f.CreateCharacter()
+		e1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		e2 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		e3 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
 		// when
-		got, err := st.ListCharacterContractIDs(ctx, c.ID)
+		got, err := st.ListCharacterContractIDs(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		want := set.Of(e1.ContractID, e2.ContractID, e3.ContractID)
 		xassert.Equal(t, want, got)
 	})
+
 	t.Run("can list contracts for multiple characters", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		character1 := factory.CreateCharacter()
-		c1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character1.ID})
-		c2 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character1.ID})
-		character2 := factory.CreateCharacter()
-		c3 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character2.ID})
+		character1 := f.CreateCharacter()
+		c1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character1.ID})
+		c2 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character1.ID})
+		character2 := f.CreateCharacter()
+		c3 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: character2.ID})
 		// when
-		oo, err := st.ListAllCharacterContracts(ctx)
+		oo, err := st.ListAllCharacterContracts(t.Context())
 		// then
 		require.NoError(t, err)
 		want := set.Of(c1.ID, c2.ID, c3.ID)
@@ -171,30 +244,32 @@ func TestCharacterContract(t *testing.T) {
 		})...)
 		xassert.Equal(t, want, got)
 	})
+
 	t.Run("can list existing contracts for a character", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		c := f.CreateCharacter()
+		o := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
 		// when
-		oo, err := st.ListCharacterContracts(ctx, c.ID)
+		oo, err := st.ListCharacterContracts(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		assert.Len(t, oo, 1)
 		xassert.Equal(t, o.ID, oo[0].ID)
 	})
+
 	t.Run("can delete contracts for a character", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		e1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
-		e2 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
-		e3 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		c := f.CreateCharacter()
+		e1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		e2 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
+		e3 := f.CreateCharacterContract(storage.CreateCharacterContractParams{CharacterID: c.ID})
 		// when
-		err := st.DeleteCharacterContracts(ctx, c.ID, set.Of(e1.ContractID))
+		err := st.DeleteCharacterContracts(t.Context(), c.ID, set.Of(e1.ContractID))
 		// then
 		require.NoError(t, err)
-		got, err := st.ListCharacterContractIDs(ctx, c.ID)
+		got, err := st.ListCharacterContractIDs(t.Context(), c.ID)
 		require.NoError(t, err)
 		want := set.Of(e2.ContractID, e3.ContractID)
 		xassert.Equal(t, want, got)
@@ -202,14 +277,14 @@ func TestCharacterContract(t *testing.T) {
 }
 
 func TestCharacterContractBid(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterContract()
-		bidder := factory.CreateEveEntityCharacter()
+		c := f.CreateCharacterContract()
+		bidder := f.CreateEveEntityCharacter()
 		const (
 			amount = 123.45
 			bidID  = 12345
@@ -223,23 +298,24 @@ func TestCharacterContractBid(t *testing.T) {
 			DateBid:    dateBid,
 		}
 		// when
-		err := st.CreateCharacterContractBid(ctx, arg)
+		err := st.CreateCharacterContractBid(t.Context(), arg)
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCharacterContractBid(ctx, c.ID, bidID)
+		o, err := st.GetCharacterContractBid(t.Context(), c.ID, bidID)
 		require.NoError(t, err)
 		assert.InDelta(t, amount, o.Amount, 0.1)
 		xassert.Equal(t, bidder, o.Bidder)
 		xassert.Equal(t, dateBid, o.DateBid)
 	})
+
 	t.Run("can list existing bids", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterContract()
-		b1 := factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
-		b2 := factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
+		c := f.CreateCharacterContract()
+		b1 := f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
+		b2 := f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
 		// when
-		oo, err := st.ListCharacterContractBids(ctx, c.ID)
+		oo, err := st.ListCharacterContractBids(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(oo, func(x *app.CharacterContractBid) int64 {
@@ -248,14 +324,15 @@ func TestCharacterContractBid(t *testing.T) {
 		want := set.Of(b1.BidID, b2.BidID)
 		xassert.Equal(t, want, got)
 	})
+
 	t.Run("can list bid IDs", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterContract()
-		b1 := factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
-		b2 := factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
+		c := f.CreateCharacterContract()
+		b1 := f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
+		b2 := f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: c.ID})
 		// when
-		got, err := st.ListCharacterContractBidIDs(ctx, c.ID)
+		got, err := st.ListCharacterContractBidIDs(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		want := set.Of(b1.BidID, b2.BidID)
@@ -264,14 +341,14 @@ func TestCharacterContractBid(t *testing.T) {
 }
 
 func TestCharacterContractItem(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterContract()
-		et := factory.CreateEveType()
+		c := f.CreateCharacterContract()
+		et := f.CreateEveType()
 		arg := storage.CreateCharacterContractItemParams{
 			ContractID:  c.ID,
 			IsIncluded:  true,
@@ -282,10 +359,10 @@ func TestCharacterContractItem(t *testing.T) {
 			TypeID:      et.ID,
 		}
 		// when
-		err := st.CreateCharacterContractItem(ctx, arg)
+		err := st.CreateCharacterContractItem(t.Context(), arg)
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCharacterContractItem(ctx, c.ID, 42)
+		o, err := st.GetCharacterContractItem(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		assert.True(t, o.IsIncluded)
 		assert.True(t, o.IsSingleton)
@@ -293,14 +370,15 @@ func TestCharacterContractItem(t *testing.T) {
 		xassert.EqualOptional(t, -5, o.RawQuantity)
 		xassert.Equal(t, et, o.Type)
 	})
+
 	t.Run("can list existing items", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterContract()
-		i1 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{ContractID: c.ID})
-		i2 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{ContractID: c.ID})
+		c := f.CreateCharacterContract()
+		i1 := f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{ContractID: c.ID})
+		i2 := f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{ContractID: c.ID})
 		// when
-		oo, err := st.ListCharacterContractItems(ctx, c.ID)
+		oo, err := st.ListCharacterContractItems(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(oo, func(x *app.CharacterContractItem) int64 {
@@ -312,7 +390,7 @@ func TestCharacterContractItem(t *testing.T) {
 }
 
 func TestCalculateCharacterContractItemsValue(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
 
 	const characterID = 42
@@ -357,23 +435,23 @@ func TestCalculateCharacterContractItemsValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			testutil.MustTruncateTables(db)
-			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+			ec := f.CreateEveCharacter(storage.CreateEveCharacterParams{
 				ID: characterID,
 			})
-			c := factory.CreateCharacter(storage.CreateCharacterParams{
+			c := f.CreateCharacter(storage.CreateCharacterParams{
 				ID: ec.ID,
 			})
-			o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			o := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 				CharacterID: c.ID,
 				Status:      tc.status,
 				Type:        tc.contractType,
 			})
-			u := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+			u := f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
 				ContractID: o.ID,
 				IsIncluded: true,
 				Quantity:   1,
 			})
-			factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+			f.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
 				TypeID:       u.Type.ID,
 				AveragePrice: optional.New(tc.price),
 			})
@@ -390,32 +468,32 @@ func TestCalculateCharacterContractItemsValue(t *testing.T) {
 	t.Run("can calculate items value for multiple contracts", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		c := f.CreateCharacter()
+		o1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			Status:      app.ContractStatusOutstanding,
 			Type:        app.ContractTypeAuction,
 		})
-		u1 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+		u1 := f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
 			ContractID: o1.ID,
 			IsIncluded: true,
 			Quantity:   1,
 		})
-		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+		f.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
 			TypeID:       u1.Type.ID,
 			AveragePrice: optional.New(100.1),
 		})
-		o2 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		o2 := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			Status:      app.ContractStatusOutstanding,
 			Type:        app.ContractTypeAuction,
 		})
-		u2 := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+		u2 := f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
 			ContractID: o2.ID,
 			IsIncluded: true,
 			Quantity:   2,
 		})
-		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+		f.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
 			TypeID:       u2.Type.ID,
 			AveragePrice: optional.New(200.2),
 		})
@@ -431,28 +509,28 @@ func TestCalculateCharacterContractItemsValue(t *testing.T) {
 	t.Run("should ignore blueprints", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		blueprintCategory := factory.CreateEveCategory(storage.CreateEveCategoryParams{
+		c := f.CreateCharacter()
+		blueprintCategory := f.CreateEveCategory(storage.CreateEveCategoryParams{
 			ID:   app.EveCategoryBlueprint,
 			Name: "Blueprint",
 		})
-		blueprintGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{
+		blueprintGroup := f.CreateEveGroup(storage.CreateEveGroupParams{
 			CategoryID: blueprintCategory.ID,
 		})
-		blueprintType := factory.CreateEveType(storage.CreateEveTypeParams{
+		blueprintType := f.CreateEveType(storage.CreateEveTypeParams{
 			GroupID: blueprintGroup.ID,
 		})
-		o1 := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		o1 := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			Status:      app.ContractStatusOutstanding,
 			Type:        app.ContractTypeAuction,
 		})
-		factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
+		f.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{
 			ContractID: o1.ID,
 			IsIncluded: true,
 			Quantity:   1,
 		})
-		factory.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
+		f.CreateEveMarketPrice(storage.UpdateOrCreateEveMarketPriceParams{
 			TypeID:       blueprintType.ID,
 			AveragePrice: optional.New(66.6),
 		})
@@ -467,7 +545,7 @@ func TestCalculateCharacterContractItemsValue(t *testing.T) {
 }
 
 func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
-	db, st, factory := testutil.NewDBOnDisk(t)
+	db, st, f := testutil.NewDBOnDisk(t)
 	defer db.Close()
 
 	characterID := int64(42)
@@ -487,19 +565,19 @@ func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			testutil.MustTruncateTables(db)
-			ec := factory.CreateEveCharacter(storage.CreateEveCharacterParams{
+			ec := f.CreateEveCharacter(storage.CreateEveCharacterParams{
 				ID: characterID,
 			})
-			c := factory.CreateCharacter(storage.CreateCharacterParams{
+			c := f.CreateCharacter(storage.CreateCharacterParams{
 				ID: ec.ID,
 			})
-			factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+			f.CreateCharacterContract(storage.CreateCharacterContractParams{
 				CharacterID: c.ID,
 				AcceptorID:  tc.acceptorID,
 				Collateral:  tc.collateral,
 				Type:        tc.contractType,
 			})
-			factory.CreateCharacterContract() // should be ignored
+			f.CreateCharacterContract() // should be ignored
 
 			// when
 			got, err := st.CalculateCharacterContractsCourierEscrow(t.Context(), c.ID)
@@ -513,22 +591,22 @@ func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
 	t.Run("should sum over multiple courier contracts", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		c := f.CreateCharacter()
+		f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			AcceptorID:  c.ID,
 			Collateral:  optional.New(100.0),
 			Type:        app.ContractTypeCourier,
 			Status:      app.ContractStatusInProgress,
 		})
-		factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			AcceptorID:  c.ID,
 			Collateral:  optional.New(200.0),
 			Type:        app.ContractTypeCourier,
 			Status:      app.ContractStatusInProgress,
 		})
-		factory.CreateCharacterContract() // should be ignored
+		f.CreateCharacterContract() // should be ignored
 
 		// when
 		got, err := st.CalculateCharacterContractsCourierEscrow(t.Context(), c.ID)
@@ -540,24 +618,24 @@ func TestCalculateCharacterContractsCourierEscrow(t *testing.T) {
 }
 
 func TestCalculateCharacterContractsAuctionEscrow(t *testing.T) {
-	db, st, factory := testutil.NewDBOnDisk(t)
+	db, st, f := testutil.NewDBOnDisk(t)
 	defer db.Close()
 
 	t.Run("should include when own bid is highest", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		c := f.CreateCharacter()
+		o := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			Type:        app.ContractTypeAuction,
 			Status:      app.ContractStatusInProgress,
 		})
-		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+		f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
 			Amount:     12.3,
 			BidderID:   c.ID,
 			ContractID: o.ID,
 		})
-		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+		f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
 			Amount:     3,
 			ContractID: o.ID,
 		})
@@ -573,18 +651,18 @@ func TestCalculateCharacterContractsAuctionEscrow(t *testing.T) {
 	t.Run("should not include when own bid is not highest", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		o := factory.CreateCharacterContract(storage.CreateCharacterContractParams{
+		c := f.CreateCharacter()
+		o := f.CreateCharacterContract(storage.CreateCharacterContractParams{
 			CharacterID: c.ID,
 			Type:        app.ContractTypeAuction,
 			Status:      app.ContractStatusInProgress,
 		})
-		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+		f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
 			Amount:     12.3,
 			BidderID:   c.ID,
 			ContractID: o.ID,
 		})
-		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
+		f.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{
 			Amount:     15,
 			ContractID: o.ID,
 		})

--- a/internal/app/storage/corporationcontract.go
+++ b/internal/app/storage/corporationcontract.go
@@ -298,9 +298,9 @@ func corporationContractFromDBModel(
 	startSolarSystemName startSolarSystemName,
 	startSolarSystemSecurity startSolarSystemSecurity,
 ) *app.CorporationContract {
-	i2, ok := items.(string)
-	if !ok {
-		i2 = ""
+	var items2 []string
+	if x, ok := items.(string); ok && x != "" {
+		items2 = strings.Split(x, ",")
 	}
 	o2 := &app.CorporationContract{
 		Acceptor:          eveEntityFromNullableDBModel(nullEveEntity(acceptor)),
@@ -319,7 +319,7 @@ func corporationContractFromDBModel(
 		ID:                cc.ID,
 		Issuer:            eveEntityFromDBModel(queries.EveEntity(issuer)),
 		IssuerCorporation: eveEntityFromDBModel(queries.EveEntity(issuerCorporation)),
-		Items:             strings.Split(i2, ","),
+		Items:             items2,
 		Price:             optional.FromZeroValue(cc.Price),
 		Reward:            optional.FromZeroValue(cc.Reward),
 		Status:            corporationContractStatusFromDBValue[cc.Status],

--- a/internal/app/storage/corporationcontract_test.go
+++ b/internal/app/storage/corporationcontract_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,18 +18,20 @@ import (
 )
 
 func TestCorporationContract(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
-	t.Run("can create new minimal", func(t *testing.T) {
+
+	t.Run("can create new minimal courier", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporation()
-		issuer := factory.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
+		c := f.CreateCorporation()
+		issuer := f.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
 		issuerCorporation := c.EveCorporation
 		dateExpired := time.Now().Add(12 * time.Hour).UTC()
 		dateIssued := time.Now().UTC()
-		arg := storage.CreateCorporationContractParams{
+
+		// when
+		id, err := st.CreateCorporationContract(t.Context(), storage.CreateCorporationContractParams{
 			Availability:        app.ContractAvailabilityPrivate,
 			CorporationID:       c.ID,
 			ContractID:          42,
@@ -40,12 +41,11 @@ func TestCorporationContract(t *testing.T) {
 			IssuerID:            issuer.ID,
 			Status:              app.ContractStatusOutstanding,
 			Type:                app.ContractTypeCourier,
-		}
-		// when
-		id, err := st.CreateCorporationContract(ctx, arg)
+		})
+
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCorporationContract(ctx, c.ID, 42)
+		o, err := st.GetCorporationContract(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		xassert.Equal(t, id, o.ID)
 		xassert.Equal(t, issuer, o.Issuer)
@@ -55,17 +55,20 @@ func TestCorporationContract(t *testing.T) {
 		xassert.Equal(t, app.ContractTypeCourier, o.Type)
 		assert.WithinDuration(t, time.Now().UTC(), o.UpdatedAt, 5*time.Second)
 	})
-	t.Run("can create new full", func(t *testing.T) {
+
+	t.Run("can create new full courier", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporation()
-		issuer := factory.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
+		c := f.CreateCorporation()
+		issuer := f.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
 		issuerCorporation := c.EveCorporation
 		dateExpired := time.Now().Add(12 * time.Hour).UTC()
 		dateIssued := time.Now().UTC()
-		startLocation := factory.CreateEveLocationStructure()
-		endLocation := factory.CreateEveLocationStructure()
-		arg := storage.CreateCorporationContractParams{
+		startLocation := f.CreateEveLocationStructure()
+		endLocation := f.CreateEveLocationStructure()
+
+		// when
+		id, err := st.CreateCorporationContract(t.Context(), storage.CreateCorporationContractParams{
 			Availability:        app.ContractAvailabilityPrivate,
 			CorporationID:       c.ID,
 			ContractID:          42,
@@ -77,12 +80,11 @@ func TestCorporationContract(t *testing.T) {
 			Type:                app.ContractTypeCourier,
 			EndLocationID:       optional.New(endLocation.ID),
 			StartLocationID:     optional.New(startLocation.ID),
-		}
-		// when
-		id, err := st.CreateCorporationContract(ctx, arg)
+		})
+
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCorporationContract(ctx, c.ID, 42)
+		o, err := st.GetCorporationContract(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		xassert.Equal(t, id, o.ID)
 		xassert.Equal(t, issuer, o.Issuer)
@@ -98,10 +100,78 @@ func TestCorporationContract(t *testing.T) {
 		xassert.Equal(t, startLocation.SolarSystem.MustValue().Name, o.StartSolarSystem.MustValue().Name)
 		assert.WithinDuration(t, time.Now().UTC(), o.UpdatedAt, 5*time.Second)
 	})
+
+	t.Run("can create new minimal item exchange with item", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := f.CreateCorporation()
+		issuer := f.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
+		issuerCorporation := c.EveCorporation
+		dateExpired := time.Now().Add(12 * time.Hour).UTC()
+		dateIssued := time.Now().UTC()
+		item := f.CreateEveType()
+
+		// when
+		id, err := st.CreateCorporationContract(t.Context(), storage.CreateCorporationContractParams{
+			Availability:        app.ContractAvailabilityPrivate,
+			CorporationID:       c.ID,
+			ContractID:          42,
+			DateExpired:         dateExpired,
+			DateIssued:          dateIssued,
+			IssuerCorporationID: issuerCorporation.ID,
+			IssuerID:            issuer.ID,
+			Status:              app.ContractStatusOutstanding,
+			Type:                app.ContractTypeItemExchange,
+		})
+		require.NoError(t, err)
+		err2 := st.CreateCorporationContractItem(t.Context(), storage.CreateCorporationContractItemParams{
+			ContractID: id,
+			IsIncluded: true,
+			Quantity:   1,
+			RecordID:   42,
+			TypeID:     item.ID,
+		})
+
+		// then
+		require.NoError(t, err2)
+		got, err := st.GetCorporationContract(t.Context(), c.ID, 42)
+		require.NoError(t, err)
+		xassert.Equal(t, []string{item.Name + " x 1"}, got.Items)
+	})
+
+	t.Run("can create new minimal item exchange without items", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := f.CreateCorporation()
+		issuer := f.CreateEveEntityCorporation(app.EveEntity{ID: c.ID})
+		issuerCorporation := c.EveCorporation
+		dateExpired := time.Now().Add(12 * time.Hour).UTC()
+		dateIssued := time.Now().UTC()
+
+		// when
+		_, err := st.CreateCorporationContract(t.Context(), storage.CreateCorporationContractParams{
+			Availability:        app.ContractAvailabilityPrivate,
+			CorporationID:       c.ID,
+			ContractID:          42,
+			DateExpired:         dateExpired,
+			DateIssued:          dateIssued,
+			IssuerCorporationID: issuerCorporation.ID,
+			IssuerID:            issuer.ID,
+			Status:              app.ContractStatusOutstanding,
+			Type:                app.ContractTypeItemExchange,
+		})
+
+		// then
+		require.NoError(t, err)
+		got, err := st.GetCorporationContract(t.Context(), c.ID, 42)
+		require.NoError(t, err)
+		assert.Len(t, got.Items, 0)
+	})
+
 	t.Run("can update contract", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		o1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{
+		o1 := f.CreateCorporationContract(storage.CreateCorporationContractParams{
 			UpdatedAt: time.Now().UTC().Add(-5 * time.Second),
 		})
 		dateAccepted := time.Now().UTC()
@@ -113,55 +183,66 @@ func TestCorporationContract(t *testing.T) {
 			DateCompleted: optional.New(dateCompleted),
 			Status:        app.ContractStatusFinished,
 		}
+
 		// when
-		err := st.UpdateCorporationContract(ctx, arg2)
+		err := st.UpdateCorporationContract(t.Context(), arg2)
+
 		// then
 		require.NoError(t, err)
-		o2, err := st.GetCorporationContract(ctx, o1.CorporationID, o1.ContractID)
+		o2, err := st.GetCorporationContract(t.Context(), o1.CorporationID, o1.ContractID)
 		require.NoError(t, err)
 		xassert.Equal(t, app.ContractStatusFinished, o2.Status)
 		xassert.Equal(t, optional.New(dateAccepted), o2.DateAccepted)
 		xassert.Equal(t, optional.New(dateCompleted), o2.DateCompleted)
 		assert.Less(t, o1.UpdatedAt, o2.UpdatedAt)
 	})
+
 	t.Run("can update notified", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		o1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{
+		o1 := f.CreateCorporationContract(storage.CreateCorporationContractParams{
 			UpdatedAt: time.Now().UTC().Add(-5 * time.Second),
 		})
+
 		// when
-		err := st.UpdateCorporationContractNotified(ctx, o1.ID, app.ContractStatusInProgress)
+		err := st.UpdateCorporationContractNotified(t.Context(), o1.ID, app.ContractStatusInProgress)
+
 		// then
 		require.NoError(t, err)
-		o2, err := st.GetCorporationContract(ctx, o1.CorporationID, o1.ContractID)
+		o2, err := st.GetCorporationContract(t.Context(), o1.CorporationID, o1.ContractID)
 		require.NoError(t, err)
 		xassert.Equal(t, app.ContractStatusInProgress, o2.StatusNotified)
 		assert.Less(t, o1.UpdatedAt, o2.UpdatedAt)
 	})
+
 	t.Run("can list IDs of existing entries", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporation()
-		e1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		e2 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		e3 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		c := f.CreateCorporation()
+		e1 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		e2 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		e3 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+
 		// when
-		got, err := st.ListCorporationContractIDs(ctx, c.ID)
+		got, err := st.ListCorporationContractIDs(t.Context(), c.ID)
+
 		// then
 		require.NoError(t, err)
 		want := set.Of(e1.ContractID, e2.ContractID, e3.ContractID)
 		xassert.Equal(t, want, got)
 	})
+
 	t.Run("can list contracts for a corporation", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporation()
-		o1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		o2 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		factory.CreateCorporationContract()
+		c := f.CreateCorporation()
+		o1 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		o2 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		f.CreateCorporationContract()
+
 		// when
-		oo, err := st.ListCorporationContracts(ctx, c.ID)
+		oo, err := st.ListCorporationContracts(t.Context(), c.ID)
+
 		// then
 		require.NoError(t, err)
 		want := set.Of(o1.ID, o2.ID)
@@ -170,18 +251,21 @@ func TestCorporationContract(t *testing.T) {
 		})...)
 		xassert.Equal(t, want, got)
 	})
+
 	t.Run("can delete contracts", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporation()
-		e1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		e2 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
-		e3 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		c := f.CreateCorporation()
+		e1 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		e2 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		e3 := f.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+
 		// when
-		err := st.DeleteCorporationContracts(ctx, c.ID, set.Of(e1.ContractID))
+		err := st.DeleteCorporationContracts(t.Context(), c.ID, set.Of(e1.ContractID))
+
 		// then
 		require.NoError(t, err)
-		got, err := st.ListCorporationContractIDs(ctx, c.ID)
+		got, err := st.ListCorporationContractIDs(t.Context(), c.ID)
 		require.NoError(t, err)
 		want := set.Of(e2.ContractID, e3.ContractID)
 		xassert.Equal(t, want, got)
@@ -189,14 +273,14 @@ func TestCorporationContract(t *testing.T) {
 }
 
 func TestCorporationContractBid(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporationContract()
-		bidder := factory.CreateEveEntityCorporation()
+		c := f.CreateCorporationContract()
+		bidder := f.CreateEveEntityCorporation()
 		const (
 			amount = 123.45
 			bidID  = 12345
@@ -210,10 +294,10 @@ func TestCorporationContractBid(t *testing.T) {
 			DateBid:    dateBid,
 		}
 		// when
-		err := st.CreateCorporationContractBid(ctx, arg)
+		err := st.CreateCorporationContractBid(t.Context(), arg)
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCorporationContractBid(ctx, c.ID, bidID)
+		o, err := st.GetCorporationContractBid(t.Context(), c.ID, bidID)
 		require.NoError(t, err)
 		assert.InDelta(t, amount, o.Amount, 0.1)
 		xassert.Equal(t, bidder, o.Bidder)
@@ -222,11 +306,11 @@ func TestCorporationContractBid(t *testing.T) {
 	t.Run("can list existing bids", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporationContract()
-		b1 := factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
-		b2 := factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
+		c := f.CreateCorporationContract()
+		b1 := f.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
+		b2 := f.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
 		// when
-		oo, err := st.ListCorporationContractBids(ctx, c.ID)
+		oo, err := st.ListCorporationContractBids(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(oo, func(x *app.CorporationContractBid) int64 {
@@ -238,11 +322,11 @@ func TestCorporationContractBid(t *testing.T) {
 	t.Run("can list bid IDs", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporationContract()
-		b1 := factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
-		b2 := factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
+		c := f.CreateCorporationContract()
+		b1 := f.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
+		b2 := f.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: c.ID})
 		// when
-		got, err := st.ListCorporationContractBidIDs(ctx, c.ID)
+		got, err := st.ListCorporationContractBidIDs(t.Context(), c.ID)
 		// then
 		require.NoError(t, err)
 		want := set.Of(b1.BidID, b2.BidID)
@@ -251,15 +335,17 @@ func TestCorporationContractBid(t *testing.T) {
 }
 
 func TestCorporationContractItem(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporationContract()
-		et := factory.CreateEveType()
-		arg := storage.CreateCorporationContractItemParams{
+		c := f.CreateCorporationContract()
+		et := f.CreateEveType()
+
+		// when
+		err := st.CreateCorporationContractItem(t.Context(), storage.CreateCorporationContractItemParams{
 			ContractID:  c.ID,
 			IsIncluded:  true,
 			IsSingleton: true,
@@ -267,12 +353,11 @@ func TestCorporationContractItem(t *testing.T) {
 			RawQuantity: optional.New[int64](-5),
 			RecordID:    42,
 			TypeID:      et.ID,
-		}
-		// when
-		err := st.CreateCorporationContractItem(ctx, arg)
+		})
+
 		// then
 		require.NoError(t, err)
-		o, err := st.GetCorporationContractItem(ctx, c.ID, 42)
+		o, err := st.GetCorporationContractItem(t.Context(), c.ID, 42)
 		require.NoError(t, err)
 		assert.True(t, o.IsIncluded)
 		assert.True(t, o.IsSingleton)
@@ -280,14 +365,17 @@ func TestCorporationContractItem(t *testing.T) {
 		xassert.EqualOptional(t, -5, o.RawQuantity)
 		xassert.Equal(t, et, o.Type)
 	})
+
 	t.Run("can list existing items", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCorporationContract()
-		i1 := factory.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: c.ID})
-		i2 := factory.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: c.ID})
+		c := f.CreateCorporationContract()
+		i1 := f.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: c.ID})
+		i2 := f.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: c.ID})
+
 		// when
-		oo, err := st.ListCorporationContractItems(ctx, c.ID)
+		oo, err := st.ListCorporationContractItems(t.Context(), c.ID)
+
 		// then
 		require.NoError(t, err)
 		got := set.Collect(xiter.MapSlice(oo, func(x *app.CorporationContractItem) int64 {

--- a/internal/app/ui/contracts/contracts.go
+++ b/internal/app/ui/contracts/contracts.go
@@ -230,6 +230,7 @@ const (
 	contractsColStatus
 	contractsColIssuedAt
 	contractsColExpiresAt
+	contractsColDescription
 )
 
 func NewContractsForCorporation(u baseUI) *Contracts {
@@ -310,6 +311,16 @@ func newContracts(u baseUI, forCorporation bool) *Contracts {
 		},
 		Update: func(r contractRow, co fyne.CanvasObject) {
 			co.(*xwidget.RichText).Set(r.dateExpiredDisplay)
+		},
+	}, {
+		ID:    contractsColDescription,
+		Label: "Description",
+		Width: 300,
+		Sort: func(a, b contractRow) int {
+			return strings.Compare(a.title, b.title)
+		},
+		Update: func(r contractRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(r.title)
 		},
 	}})
 	a := &Contracts{

--- a/internal/app/ui/contracts/detailwindow.go
+++ b/internal/app/ui/contracts/detailwindow.go
@@ -213,12 +213,13 @@ func showContractDetails(u baseUI, r contractRow, fetchBids func(context.Context
 					{Text: "Destination", Widget: makeLocationLabel2(r.endLocation, u.InfoViewer().ShowLocation)},
 				})
 			case app.ContractTypeItemExchange:
-				if r.price.ValueOrZero() > 0 {
-					x := widget.NewLabel(r.price.StringFunc("?", ui.FormatISKAmount))
+				if v, ok := r.price.Value(); ok {
+					x := widget.NewLabel(ui.FormatISKAmount(v))
 					x.Importance = widget.DangerImportance
 					fi = append(fi, widget.NewFormItem("Buyer Will Pay", x))
-				} else {
-					x := widget.NewLabel(r.reward.StringFunc("?", ui.FormatISKAmount))
+				}
+				if v, ok := r.reward.Value(); ok {
+					x := widget.NewLabel(ui.FormatISKAmount(v))
 					x.Importance = widget.SuccessImportance
 					fi = append(fi, widget.NewFormItem("Buyer Will Get", x))
 				}

--- a/internal/app/ui/contracts/detailwindow.go
+++ b/internal/app/ui/contracts/detailwindow.go
@@ -174,7 +174,7 @@ func showContractDetails(u baseUI, r contractRow, fetchBids func(context.Context
 			}
 			fi := []*widget.FormItem{
 				widget.NewFormItem("Owner", ui.MakeCharacterActionLabel(r.ownerID, r.ownerName, u.InfoViewer().Show)),
-				widget.NewFormItem("Info by issuer", widget.NewLabel(r.title)),
+				widget.NewFormItem("Description", widget.NewLabel(r.title)),
 				widget.NewFormItem("Type", widget.NewLabel(r.contractType.Display())),
 				widget.NewFormItem("Issued By", ui.MakeEveEntityActionLabel(r.issuer, u.InfoViewer().Show)),
 				widget.NewFormItem("Availability", availability),


### PR DESCRIPTION
- Added the column "Description" to contract lists (both overview and corporation)
- Fixed a bug where an empty contract would still show as having one unnamed item

Resolves #456 