### PR TITLE
feat: add skill search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,23 @@ EVE Buddy is a multi-platform companion app for [Eve Online](https://www.eveonli
 EVE Buddy is available for Windows, Linux, macOS and Android.
 
 > [!NOTE]
-> We are proud to have been mentioned twice in Eve Online's official Community Beat newsletter:
+>**Featured in EVE Online's Official Community Beat!**<br>
+> We're proud to have been featured in EVE Online's official Community Beat newsletter:
 >
-> - [EVE Community Beat newsletter 16 August 2025](https://www.eveonline.com/news/view/community-beat-for-16-august-2025).
-> - [EVE Community Beat newsletter 22 November 2024](https://www.eveonline.com/news/view/community-beat-for-22-november).
+> - [16 August 2025 Edition](https://www.eveonline.com/news/view/community-beat-for-16-august-2025).
+> - [22 November 2024 Edition](https://www.eveonline.com/news/view/community-beat-for-22-november).
 
 > [!NOTE]
-> We would very much appreciate your feedback. If you encounter any problems or have a question please feel free to open an issue or come chat with us on our [Discord server](https://discord.gg/tVSCQEVJnJ) in the support channel **#evebuddy**.<br>
-> We are constantly adding new features and improving EVE Buddy further. If you are missing a feature that would make the app more useful for you, please feel free to open a feature request.
+> **Feedback & Support**
+>
+> We’d love to hear from you! If you run into bugs or have questions, feel free to open an issue or drop by the **#evebuddy** channel on our [Discord](https://discord.gg/tVSCQEVJnJ).
+>
+> Missing a feature? Open a feature request—we're actively building and improving EVE Buddy every day!
 
 > [!TIP]
-> Help wanted! We would very much appreciate any contribution. If you like to provide a fix or add a feature please feel free to open a PR. Or if you have any questions please contact us on Discord.
+> **Contribute & Get Involved**
+>
+> We welcome all contributions! Whether you want to fix a bug, add a feature, or improve documentation, feel free to open a Pull Request. Have questions or want to discuss an idea first? Join our community on [Discord](https://discord.gg/tVSCQEVJnJ).
 
 ## Screenshots
 
@@ -81,7 +87,7 @@ The following is a detailed list of EVE Buddy's features. Most features are avai
   - Contracts: Browse contracts of all characters
   - Industry: Browse industry jobs for all characters and related corporations
   - Location: Browse the location of all characters and their current ships
-  - Training: Keep track of the training status for all characters
+  - Skills: Keep track of the training status for all characters and search for skills across of characters.
   - Wealth: Charts showing wealth distribution across all characters
 
 - **Character monitor**: Check current information about each of your characters:

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -172,6 +172,16 @@ func (s *CharacterService) ListAllCharactersIndustrySlots(ctx context.Context, t
 	return rows, nil
 }
 
+// ListAllSkills returns the skills from all characters.
+func (s *CharacterService) ListAllSkills(ctx context.Context) ([]*app.CharacterSkill, error) {
+	oo, err := s.st.ListAllCharacterSkills(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return oo, nil
+}
+
+// ListSkills returns the skills from a character.
 func (s *CharacterService) ListSkills(ctx context.Context, characterID int64) ([]*app.CharacterSkill2, error) {
 	oo, err := s.st.ListCharacterSkills(ctx, characterID)
 	if err != nil {

--- a/internal/app/characterskill.go
+++ b/internal/app/characterskill.go
@@ -24,6 +24,8 @@ type CharacterSkill2 struct {
 	TrainedSkillLevel  int64
 }
 
+// TODO: Move to ui package
+
 func SkillDisplayName[N int | int64 | uint | uint32 | uint64](name string, level N) string {
 	return fmt.Sprintf("%s %s", name, ihumanize.RomanLetter(level))
 }

--- a/internal/app/characterskill.go
+++ b/internal/app/characterskill.go
@@ -1,9 +1,6 @@
 package app
 
 import (
-	"fmt"
-
-	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 )
 
@@ -22,12 +19,6 @@ type CharacterSkill2 struct {
 	Skill              *EveSkill
 	SkillPointsInSkill int64
 	TrainedSkillLevel  int64
-}
-
-// TODO: Move to ui package
-
-func SkillDisplayName[N int | int64 | uint | uint32 | uint64](name string, level N) string {
-	return fmt.Sprintf("%s %s", name, ihumanize.RomanLetter(level))
 }
 
 // CharacterActiveSkillLevel represents the active level of a character's skill.

--- a/internal/app/storage/characterskill.go
+++ b/internal/app/storage/characterskill.go
@@ -63,6 +63,19 @@ func (st *Storage) ListCharacterSkills(ctx context.Context, characterID int64) (
 	}
 	return oo, nil
 }
+
+func (st *Storage) ListAllCharacterSkills(ctx context.Context) ([]*app.CharacterSkill, error) {
+	rows, err := st.qRO.ListAllCharacterSkills(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ListAllCharacterSkills: %w", err)
+	}
+	var oo []*app.CharacterSkill
+	for _, r := range rows {
+		oo = append(oo, characterSkillFromDBModel(r.CharacterSkill, r.EveType, r.EveGroup, r.EveCategory))
+	}
+	return oo, nil
+}
+
 func (st *Storage) ListAllCharactersActiveSkillLevels(ctx context.Context, typeID int64) ([]app.CharacterActiveSkillLevel, error) {
 	wrapErr := func(err error) error {
 		return fmt.Errorf("ListAllCharactersActiveSkillLevels: %d: %w", typeID, err)
@@ -128,7 +141,12 @@ func (st *Storage) UpdateOrCreateCharacterSkill(ctx context.Context, arg UpdateO
 	return nil
 }
 
-func characterSkillFromDBModel(o queries.CharacterSkill, t queries.EveType, g queries.EveGroup, c queries.EveCategory) *app.CharacterSkill {
+func characterSkillFromDBModel(
+	o queries.CharacterSkill,
+	t queries.EveType,
+	g queries.EveGroup,
+	c queries.EveCategory,
+) *app.CharacterSkill {
 	return &app.CharacterSkill{
 		ActiveSkillLevel:   o.ActiveSkillLevel,
 		CharacterID:        o.CharacterID,

--- a/internal/app/storage/characterskill_test.go
+++ b/internal/app/storage/characterskill_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,14 +16,14 @@ import (
 )
 
 func TestCharacterSkill(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("can create new", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
-		eveType := factory.CreateEveType()
+		c := f.CreateCharacter()
+		eveType := f.CreateEveType()
 		arg := storage.UpdateOrCreateCharacterSkillParams{
 			ActiveSkillLevel:   3,
 			TypeID:             eveType.ID,
@@ -33,10 +32,10 @@ func TestCharacterSkill(t *testing.T) {
 			TrainedSkillLevel:  5,
 		}
 		// when
-		err := st.UpdateOrCreateCharacterSkill(ctx, arg)
+		err := st.UpdateOrCreateCharacterSkill(t.Context(), arg)
 		// then
 		require.NoError(t, err)
-		x, err := st.GetCharacterSkill(ctx, c.ID, arg.TypeID)
+		x, err := st.GetCharacterSkill(t.Context(), c.ID, arg.TypeID)
 		require.NoError(t, err)
 		xassert.Equal(t, 3, x.ActiveSkillLevel)
 		xassert.Equal(t, eveType, x.Type)
@@ -46,8 +45,8 @@ func TestCharacterSkill(t *testing.T) {
 	t.Run("can update existing", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
-		o1 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		c := f.CreateCharacter()
+		o1 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID:        c.ID,
 			ActiveSkillLevel:   3,
 			TrainedSkillLevel:  5,
@@ -61,10 +60,10 @@ func TestCharacterSkill(t *testing.T) {
 			SkillPointsInSkill: 99,
 		}
 		// when
-		err := st.UpdateOrCreateCharacterSkill(ctx, arg)
+		err := st.UpdateOrCreateCharacterSkill(t.Context(), arg)
 		// then
 		require.NoError(t, err)
-		o2, err := st.GetCharacterSkill(ctx, c.ID, o1.Type.ID)
+		o2, err := st.GetCharacterSkill(t.Context(), c.ID, o1.Type.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, 4, o2.ActiveSkillLevel)
 		xassert.Equal(t, 4, o2.TrainedSkillLevel)
@@ -73,52 +72,53 @@ func TestCharacterSkill(t *testing.T) {
 	t.Run("can delete excluded skills", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
-		x1 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{CharacterID: c.ID})
-		x2 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{CharacterID: c.ID})
+		c := f.CreateCharacter()
+		x1 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{CharacterID: c.ID})
+		x2 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{CharacterID: c.ID})
 		// when
-		err := st.DeleteCharacterSkills(ctx, c.ID, set.Of(x2.Type.ID))
+		err := st.DeleteCharacterSkills(t.Context(), c.ID, set.Of(x2.Type.ID))
 		// then
 		require.NoError(t, err)
-		ids, err := st.ListCharacterSkillIDs(ctx, c.ID)
+		ids, err := st.ListCharacterSkillIDs(t.Context(), c.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, set.Of(x1.Type.ID), ids)
 	})
 }
 
 func TestCharacterSkillLists(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
-	t.Run("can list skill IDs", func(t *testing.T) {
+
+	t.Run("can list skill IDs of a character", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
-		o1 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		c := f.CreateCharacter()
+		o1 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID: c.ID,
 		})
-		o2 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		o2 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID: c.ID,
 		})
+
 		// when
-		ids, err := st.ListCharacterSkillIDs(ctx, c.ID)
+		ids, err := st.ListCharacterSkillIDs(t.Context(), c.ID)
+
 		// then
 		require.NoError(t, err)
 		xassert.Equal(t, set.Of(o1.Type.ID, o2.Type.ID), ids)
 	})
-	t.Run("can list skills", func(t *testing.T) {
+
+	t.Run("can list skills of a character", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacterFull()
-		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
-		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
-		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{GroupID: group.ID, IsPublished: true})
-		o1 := factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		c := f.CreateCharacter()
+		o1 := f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID: c.ID,
-			TypeID:      skill1.ID,
 		})
+
 		// when
 		oo, err := st.ListCharacterSkills(t.Context(), c.ID)
+
 		// then
 		require.NoError(t, err)
 		want := set.Of(o1.Type.ID)
@@ -127,40 +127,58 @@ func TestCharacterSkillLists(t *testing.T) {
 		}))
 		xassert.Equal(t, want, got)
 	})
+
+	t.Run("can list all skills", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o1 := f.CreateCharacterSkill()
+		o2 := f.CreateCharacterSkill()
+
+		// when
+		oo, err := st.ListAllCharacterSkills(t.Context())
+
+		// then
+		require.NoError(t, err)
+		want := set.Of(o1.Type.ID, o2.Type.ID)
+		got := set.Collect(xiter.MapSlice(oo, func(x *app.CharacterSkill) int64 {
+			return x.Type.ID
+		}))
+		xassert.Equal(t, want, got)
+	})
 }
 
 func TestListCharactersActiveSkillLevels(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
+	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()
-	ctx := context.Background()
+
 	t.Run("returns skill level", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
-		c1 := factory.CreateCharacterFull()
-		c2 := factory.CreateCharacterFull()
-		c3 := factory.CreateCharacterFull()
-		skill1 := factory.CreateEveType()
-		skill2 := factory.CreateEveType()
-		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		c1 := f.CreateCharacter()
+		c2 := f.CreateCharacter()
+		c3 := f.CreateCharacter()
+		skill1 := f.CreateEveType()
+		skill2 := f.CreateEveType()
+		f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID:       c1.ID,
 			TypeID:            skill1.ID,
 			ActiveSkillLevel:  3,
 			TrainedSkillLevel: 5,
 		})
-		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID:       c2.ID,
 			TypeID:            skill1.ID,
 			ActiveSkillLevel:  4,
 			TrainedSkillLevel: 5,
 		})
-		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+		f.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
 			CharacterID:       c1.ID,
 			TypeID:            skill2.ID,
 			ActiveSkillLevel:  5,
 			TrainedSkillLevel: 5,
 		})
 		// when
-		got, err := st.ListAllCharactersActiveSkillLevels(ctx, skill1.ID)
+		got, err := st.ListAllCharactersActiveSkillLevels(t.Context(), skill1.ID)
 		// then
 		require.NoError(t, err)
 		want := []app.CharacterActiveSkillLevel{{

--- a/internal/app/storage/queries/character_skills.sql
+++ b/internal/app/storage/queries/character_skills.sql
@@ -19,6 +19,18 @@ WHERE
     character_id = ?
     AND eve_type_id IN (sqlc.slice ('eve_type_ids'));
 
+-- name: ListAllCharacterSkills :many
+SELECT
+    sqlc.embed(cs),
+    sqlc.embed(et),
+    sqlc.embed(eg),
+    sqlc.embed(ec)
+FROM
+    character_skills cs
+    JOIN eve_types et ON et.id = cs.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id;
+
 -- name: ListCharactersActiveSkillLevels :many
 SELECT
     c.id as character_id,

--- a/internal/app/storage/queries/character_skills.sql.go
+++ b/internal/app/storage/queries/character_skills.sql.go
@@ -102,6 +102,77 @@ func (q *Queries) GetCharacterSkill(ctx context.Context, arg GetCharacterSkillPa
 	return i, err
 }
 
+const listAllCharacterSkills = `-- name: ListAllCharacterSkills :many
+SELECT
+    cs.id, cs.active_skill_level, cs.character_id, cs.eve_type_id, cs.skill_points_in_skill, cs.trained_skill_level,
+    et.id, et.eve_group_id, et.capacity, et.description, et.graphic_id, et.icon_id, et.is_published, et.market_group_id, et.mass, et.name, et.packaged_volume, et.portion_size, et.radius, et.volume,
+    eg.id, eg.eve_category_id, eg.name, eg.is_published,
+    ec.id, ec.name, ec.is_published
+FROM
+    character_skills cs
+    JOIN eve_types et ON et.id = cs.eve_type_id
+    JOIN eve_groups eg ON eg.id = et.eve_group_id
+    JOIN eve_categories ec ON ec.id = eg.eve_category_id
+`
+
+type ListAllCharacterSkillsRow struct {
+	CharacterSkill CharacterSkill
+	EveType        EveType
+	EveGroup       EveGroup
+	EveCategory    EveCategory
+}
+
+func (q *Queries) ListAllCharacterSkills(ctx context.Context) ([]ListAllCharacterSkillsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAllCharacterSkills)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllCharacterSkillsRow
+	for rows.Next() {
+		var i ListAllCharacterSkillsRow
+		if err := rows.Scan(
+			&i.CharacterSkill.ID,
+			&i.CharacterSkill.ActiveSkillLevel,
+			&i.CharacterSkill.CharacterID,
+			&i.CharacterSkill.EveTypeID,
+			&i.CharacterSkill.SkillPointsInSkill,
+			&i.CharacterSkill.TrainedSkillLevel,
+			&i.EveType.ID,
+			&i.EveType.EveGroupID,
+			&i.EveType.Capacity,
+			&i.EveType.Description,
+			&i.EveType.GraphicID,
+			&i.EveType.IconID,
+			&i.EveType.IsPublished,
+			&i.EveType.MarketGroupID,
+			&i.EveType.Mass,
+			&i.EveType.Name,
+			&i.EveType.PackagedVolume,
+			&i.EveType.PortionSize,
+			&i.EveType.Radius,
+			&i.EveType.Volume,
+			&i.EveGroup.ID,
+			&i.EveGroup.EveCategoryID,
+			&i.EveGroup.Name,
+			&i.EveGroup.IsPublished,
+			&i.EveCategory.ID,
+			&i.EveCategory.Name,
+			&i.EveCategory.IsPublished,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCharacterShipSkills = `-- name: ListCharacterShipSkills :many
 SELECT
     rank,

--- a/internal/app/ui/assets/assets.go
+++ b/internal/app/ui/assets/assets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 )
 
-type coreUI interface {
+type baseUI interface {
 	Character() *characterservice.CharacterService
 	Corporation() *corporationservice.CorporationService
 	ErrorDisplay(err error) string

--- a/internal/app/ui/assets/browser.go
+++ b/internal/app/ui/assets/browser.go
@@ -56,18 +56,18 @@ type Browser struct {
 	characterNames map[int64]string
 	corporation    atomic.Pointer[app.Corporation]
 	forCorporation bool
-	u              coreUI
+	u              baseUI
 }
 
-func NewCharacterBrowser(u coreUI) *Browser {
+func NewCharacterBrowser(u baseUI) *Browser {
 	return newBrowser(u, false)
 }
 
-func NewCorporationBrowser(u coreUI) *Browser {
+func NewCorporationBrowser(u baseUI) *Browser {
 	return newBrowser(u, true)
 }
 
-func newBrowser(u coreUI, forCorporation bool) *Browser {
+func newBrowser(u baseUI, forCorporation bool) *Browser {
 	a := &Browser{
 		forCorporation: forCorporation,
 		characterNames: make(map[int64]string),

--- a/internal/app/ui/assets/detailwindow.go
+++ b/internal/app/ui/assets/detailwindow.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ShowDetails shows the details for an assets in a new window.
-func ShowDetails(u coreUI, r assetRow) {
+func ShowDetails(u baseUI, r assetRow) {
 	w, created := u.GetOrCreateWindow(
 		fmt.Sprintf("asset-%d-%d", r.owner.ID, r.itemID),
 		"Asset: Information",

--- a/internal/app/ui/assets/search.go
+++ b/internal/app/ui/assets/search.go
@@ -220,7 +220,7 @@ type Search struct {
 	selectTotal    *kxwidget.FilterChipSelect
 	sortButton     *xwidget.SortButton
 	top            *widget.Label
-	u              coreUI
+	u              baseUI
 }
 
 const (
@@ -234,15 +234,15 @@ const (
 	searchColTags
 )
 
-func NewSearchForAll(u coreUI) *Search {
+func NewSearchForAll(u baseUI) *Search {
 	return newAssetSearch(u, false)
 }
 
-func NewSearchForCorporation(u coreUI) *Search {
+func NewSearchForCorporation(u baseUI) *Search {
 	return newAssetSearch(u, true)
 }
 
-func newAssetSearch(u coreUI, forCorporation bool) *Search {
+func newAssetSearch(u baseUI, forCorporation bool) *Search {
 	corporationIcon := theme.NewThemedResource(icons.StarCircleOutlineSvg)
 	cols := []xwidget.DataColumn[assetRow]{{
 		ID:    searchColItem,

--- a/internal/app/ui/characters/charactersheet.go
+++ b/internal/app/ui/characters/charactersheet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
@@ -25,18 +26,18 @@ import (
 type CharacterSheet struct {
 	widget.BaseWidget
 
-	bloodline   *widget.Hyperlink
+	bloodline   *ui.InfoLink
 	born        *widget.Label
 	character   atomic.Pointer[app.Character]
-	faction     *widget.Hyperlink
-	home        *widget.Hyperlink
+	faction     *ui.InfoLink
+	home        *ui.InfoLink
 	lastLoginAt *widget.Label
-	location    *widget.Hyperlink
-	name        *widget.Hyperlink
+	location    *ui.InfoLink
+	name        *ui.InfoLink
 	portrait    *xwidget.TappableImage
-	race        *widget.Hyperlink
+	race        *ui.InfoLink
 	security    *widget.Label
-	ship        *widget.Hyperlink
+	ship        *ui.InfoLink
 	skillpoints *widget.Label
 	tags        *widget.Label
 	u           baseUI
@@ -44,34 +45,31 @@ type CharacterSheet struct {
 }
 
 func NewCharacterSheet(u baseUI) *CharacterSheet {
-	makeHyperLink := func() *widget.Hyperlink {
-		x := widget.NewHyperlink("?", nil)
-		x.OnTapped = nil
-		x.Truncation = fyne.TextTruncateEllipsis
-		return x
-	}
 	makeLabel := func() *widget.Label {
 		x := widget.NewLabel("?")
 		x.Selectable = true
 		x.Truncation = fyne.TextTruncateEllipsis
 		return x
 	}
+	makeInfoLink := func() *ui.InfoLink {
+		return ui.NewInfoLink(u.InfoViewer())
+	}
 	portrait := xwidget.NewTappableImage(icons.Characterplaceholder64Jpeg, nil)
 	portrait.SetFillMode(canvas.ImageFillContain)
 	portrait.SetMinSize(fyne.NewSquareSize(128))
 	portrait.SetToolTip("Show details")
 	a := &CharacterSheet{
-		bloodline:   makeHyperLink(),
+		bloodline:   makeInfoLink(),
 		born:        makeLabel(),
-		faction:     makeHyperLink(),
-		home:        makeHyperLink(),
+		faction:     makeInfoLink(),
+		home:        makeInfoLink(),
 		lastLoginAt: makeLabel(),
-		location:    makeHyperLink(),
-		name:        makeHyperLink(),
+		location:    makeInfoLink(),
+		name:        makeInfoLink(),
 		portrait:    portrait,
-		race:        makeHyperLink(),
+		race:        makeInfoLink(),
 		security:    makeLabel(),
-		ship:        makeHyperLink(),
+		ship:        makeInfoLink(),
 		skillpoints: makeLabel(),
 		tags:        makeLabel(),
 		u:           u,
@@ -157,39 +155,44 @@ func (a *CharacterSheet) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (a *CharacterSheet) update(ctx context.Context) {
-	setName := func(s string) {
+	clearAll := func() {
 		fyne.Do(func() {
-			a.name.Text = s
-			a.name.OnTapped = nil
-			a.name.Refresh()
+			a.bloodline.Clear()
+			a.born.SetText("")
+			a.faction.Clear()
+			a.home.Clear()
+			a.lastLoginAt.SetText("")
+			a.location.Clear()
+			a.name.Clear()
+			a.portrait.SetResource(icons.BlankSvg)
+			a.race.Clear()
+			a.security.SetText("")
+			a.ship.Clear()
+			a.skillpoints.SetText("")
+			a.tags.SetText("")
+			a.wealth.SetText("")
 		})
 	}
 	c := a.character.Load()
 	if c == nil || c.EveCharacter == nil {
-		setName("No character...")
+		clearAll()
 		return
 	}
 	c2, err := a.u.Character().GetCharacter(ctx, c.ID)
 	if err != nil {
 		slog.Error("Failed to fetch character for sheet", "err", err)
-		setName("ERROR: " + a.u.ErrorDisplay(err))
+		clearAll()
 		return
 	}
 	a.character.Store(c2)
 	c = c2
 
 	fyne.Do(func() {
-		a.name.SetText(c.EveCharacter.Name)
-		a.name.OnTapped = func() {
+		a.name.Set(c.EveCharacter.ToEveEntity())
+		a.portrait.OnTapped = func() {
 			a.u.InfoViewer().Show(c.EveCharacter.ToEveEntity())
 		}
-		a.portrait.OnTapped = a.name.OnTapped
-
-		a.race.SetText(c.EveCharacter.Race.Name)
-		a.race.OnTapped = func() {
-			a.u.InfoViewer().ShowRace(c.EveCharacter.Race.ID)
-		}
-
+		a.race.SetRace(c.EveCharacter.Race)
 		a.born.SetText(c.EveCharacter.Birthday.Format(app.DateTimeFormat))
 		a.security.SetText(c.EveCharacter.SecurityStatus.StringFunc("?", func(v float64) string {
 			return fmt.Sprintf("%.1f", v)
@@ -205,50 +208,34 @@ func (a *CharacterSheet) update(ctx context.Context) {
 		})
 		el, ok := c.Location.Value()
 		if !ok {
-			a.location.SetText("?")
-			a.location.OnTapped = nil
+			a.location.Clear()
 			return
 		}
-		a.location.SetText(el.DisplayName())
-		a.location.OnTapped = func() {
-			a.u.InfoViewer().ShowLocation(el.ID)
-		}
+		a.location.SetLocation(el)
 	})
 	fyne.Do(func() {
 		v, ok := c.EveCharacter.Bloodline.Value()
 		if !ok {
-			a.bloodline.SetText("?")
-			a.bloodline.OnTapped = nil
+			a.bloodline.Clear()
 			return
 		}
-		a.bloodline.SetText(v.Name)
-		a.bloodline.OnTapped = func() {
-			a.u.InfoViewer().ShowBloodline(v.ID)
-		}
+		a.bloodline.SetBloodline(v)
 	})
 	fyne.Do(func() {
 		ship, ok := c.Ship.Value()
 		if !ok {
-			a.ship.SetText("?")
-			a.ship.OnTapped = nil
+			a.ship.Clear()
 			return
 		}
-		a.ship.SetText(ship.Name)
-		a.ship.OnTapped = func() {
-			a.u.InfoViewer().Show(ship.ToEveEntity())
-		}
+		a.ship.Set(ship.ToEveEntity())
 	})
 	fyne.Do(func() {
 		home, ok := c.Home.Value()
 		if !ok {
-			a.home.SetText("?")
-			a.home.OnTapped = nil
+			a.home.Clear()
 			return
 		}
-		a.home.SetText(home.DisplayName())
-		a.home.OnTapped = func() {
-			a.u.InfoViewer().ShowLocation(home.ID)
-		}
+		a.home.SetLocation(home)
 	})
 	fyne.Do(func() {
 		a.skillpoints.SetText(ihumanize.OptionalWithComma(c.TrainedSP, "?"))
@@ -260,14 +247,10 @@ func (a *CharacterSheet) update(ctx context.Context) {
 	fyne.Do(func() {
 		faction, ok := c.EveCharacter.Faction.Value()
 		if !ok {
-			a.faction.SetText("-")
-			a.faction.OnTapped = nil
+			a.faction.Clear()
 			return
 		}
-		a.faction.SetText(faction.Name)
-		a.faction.OnTapped = func() {
-			a.u.InfoViewer().Show(faction)
-		}
+		a.faction.Set(faction)
 	})
 
 	var s string

--- a/internal/app/ui/core/core.go
+++ b/internal/app/ui/core/core.go
@@ -114,8 +114,8 @@ type baseUI struct {
 	characterAttributes     *skills.Attributes
 	characterAugmentations  *clones.CharacterAugmentations
 	characterBiography      *characters.Biography
-	characterContacts       *characters.Contacts
 	characterCommunications *characters.Communications
+	characterContacts       *characters.Contacts
 	characterCorporation    *corporations.CorporationSheet
 	characterJumpClones     *clones.CharacterClones
 	characterMails          *characters.Mails
@@ -138,9 +138,11 @@ type baseUI struct {
 	corporationWallets      map[app.Division]*wallets.CorporationWallet
 	gameSearch              *gamesearch.GameSearch
 	industryJobs            *industry.Jobs
+	iw                      *infoviewer.InfoViewer
 	loyaltyPoints           *wallets.LoyaltyPoints
 	marketOrdersBuy         *industry.MarketOrders
 	marketOrdersSell        *industry.MarketOrders
+	skillSearch             *skills.Search
 	slotsManufacturing      *industry.Slots
 	slotsReactions          *industry.Slots
 	slotsResearch           *industry.Slots
@@ -148,7 +150,6 @@ type baseUI struct {
 	statusText              *statusText
 	training                *skills.Training
 	wealth                  *wallets.Wealth
-	iw                      *infoviewer.InfoViewer
 
 	// Services
 	cs       *characterservice.CharacterService
@@ -446,6 +447,7 @@ func newBaseUI(arg UIParams) *baseUI {
 	u.slotsReactions = industry.NewSlots(u, app.ReactionJob)
 	u.slotsResearch = industry.NewSlots(u, app.ScienceJob)
 	u.snackbar = xwidget.NewSnackbar(u.window.Canvas())
+	u.skillSearch = skills.NewSearch(u)
 	u.training = skills.NewTraining(u)
 	u.wealth = wallets.NewWealth(u)
 

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -165,17 +165,21 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		theme.MoreHorizontalIcon(),
 		fyne.NewMenu("", u.training.MoreItems()...),
 	)
-	training := xwidget.NewNavPage(
-		"Training",
+
+	skills := xwidget.NewNavPage(
+		"Skills",
 		theme.NewThemedResource(icons.SchoolSvg),
-		newContentPage("Training", u.training, trainingMore),
+		newContentPage("Skills", container.NewAppTabs(
+			container.NewTabItem("Training", u.training),
+			container.NewTabItem("Search", u.skillSearch),
+		), trainingMore),
 	)
 	u.training.OnUpdate = func(expired int) {
 		var badge string
 		if expired > 0 {
 			badge = ihumanize.Comma(expired)
 		}
-		homeNav.SetItemBadge(training, badge)
+		homeNav.SetItemBadge(skills, badge)
 	}
 
 	homeNav = xwidget.NewNavDrawer(
@@ -198,7 +202,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 			newContentPage("Loyalty Points", u.loyaltyPoints),
 		),
 		marketOrders,
-		training,
+		skills,
 		wealth,
 	)
 	homeNav.OnSelectItem = func(it *xwidget.NavItem) {

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -873,19 +873,22 @@ func makeHomeNav(u *MobileUI) (*xwidget.Navigator, *StatusBarItem) {
 		navItemCharacters.Refresh()
 	}
 
-	navItemTraining := xwidget.NewNavListItem(
-		"Training",
+	navItemSkills := xwidget.NewNavListItem(
+		"Skills",
 		theme.NewThemedResource(icons.SchoolSvg),
 		func() {
-			homeNav.Push(xwidget.NewAppBar("Training", u.training, kxwidget.NewIconButtonWithMenu(
+			homeNav.Push(xwidget.NewAppBar("Skills", container.NewAppTabs(
+				container.NewTabItem("Training", u.training),
+				container.NewTabItem("Search", u.skillSearch),
+			), kxwidget.NewIconButtonWithMenu(
 				theme.MoreHorizontalIcon(),
 				fyne.NewMenu("", u.training.MoreItems()...),
 			)))
 		},
 	)
 	u.training.OnUpdate = func(expired int) {
-		navItemTraining.Supporting = fmt.Sprintf("%d expired", expired)
-		navItemTraining.Refresh()
+		navItemSkills.Supporting = fmt.Sprintf("%d expired", expired)
+		navItemSkills.Refresh()
 	}
 
 	homeList = xwidget.NewNavList(
@@ -923,7 +926,7 @@ func makeHomeNav(u *MobileUI) (*xwidget.Navigator, *StatusBarItem) {
 				))
 			},
 		),
-		navItemTraining,
+		navItemSkills,
 		navItemWealth,
 	)
 	status := NewStatusBarItem(theme.NewThemedResource(icons.UpdateSvg), "?", func() {

--- a/internal/app/ui/corporations/corporationsheet.go
+++ b/internal/app/ui/corporations/corporationsheet.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
 	"github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
 	"github.com/ErikKalkoken/evebuddy/internal/xiter"
@@ -25,16 +26,16 @@ import (
 type CorporationSheet struct {
 	widget.BaseWidget
 
-	alliance    *widget.Hyperlink
-	ceo         *widget.Hyperlink
+	alliance    *ui.InfoLink
+	ceo         *ui.InfoLink
 	character   atomic.Pointer[app.Character]
 	corporation atomic.Pointer[app.Corporation]
-	faction     *widget.Hyperlink
-	home        *widget.Hyperlink
+	faction     *ui.InfoLink
+	home        *ui.InfoLink
 	isCorpMode  bool
 	logo        *xwidget.TappableImage
 	members     *widget.Label
-	name        *widget.Hyperlink
+	name        *ui.InfoLink
 	roles       *widget.Label
 	taxRate     *widget.Label
 	ticker      *widget.Label
@@ -45,26 +46,24 @@ func NewCorporationSheet(u baseUI, isCorpMode bool) *CorporationSheet {
 	logo := xwidget.NewTappableImage(icons.BlankSvg, nil)
 	logo.SetFillMode(canvas.ImageFillContain)
 	logo.SetMinSize(fyne.NewSquareSize(128))
-	makeHyperLink := func() *widget.Hyperlink {
-		x := widget.NewHyperlink("?", nil)
-		x.Truncation = fyne.TextTruncateEllipsis
-		return x
-	}
 	makeLabel := func() *widget.Label {
 		x := xwidget.NewLabelWithSelection("?")
 		x.Selectable = true
 		x.Truncation = fyne.TextTruncateEllipsis
 		return x
 	}
+	makeInfoLabel := func() *ui.InfoLink {
+		return ui.NewInfoLink(u.InfoViewer())
+	}
 	a := &CorporationSheet{
-		alliance:   makeHyperLink(),
-		ceo:        makeHyperLink(),
-		faction:    makeHyperLink(),
-		home:       makeHyperLink(),
+		alliance:   makeInfoLabel(),
+		ceo:        makeInfoLabel(),
+		faction:    makeInfoLabel(),
+		home:       makeInfoLabel(),
 		isCorpMode: isCorpMode,
 		logo:       logo,
 		members:    makeLabel(),
-		name:       makeHyperLink(),
+		name:       makeInfoLabel(),
 		roles:      makeLabel(),
 		taxRate:    makeLabel(),
 		ticker:     makeLabel(),
@@ -177,14 +176,13 @@ func (a *CorporationSheet) update(ctx context.Context) {
 	}
 	if corporation == nil {
 		fyne.Do(func() {
-			a.alliance.SetText("")
-			a.ceo.SetText("")
-			a.faction.SetText("")
-			a.home.SetText("")
+			a.alliance.Clear()
+			a.ceo.Clear()
+			a.faction.Clear()
+			a.home.Clear()
 			a.logo.SetResource(icons.BlankSvg)
 			a.members.SetText("")
-			a.name.OnTapped = nil
-			a.name.SetText("No corporation...")
+			a.name.Clear()
 			a.roles.SetText("")
 			a.taxRate.SetText("")
 			a.ticker.SetText("")
@@ -192,11 +190,10 @@ func (a *CorporationSheet) update(ctx context.Context) {
 		return
 	}
 	fyne.Do(func() {
-		a.name.SetText(corporation.Name)
-		a.name.OnTapped = func() {
+		a.name.Set(corporation.ToEveEntity())
+		a.logo.OnTapped = func() {
 			a.u.InfoViewer().Show(corporation.ToEveEntity())
 		}
-		a.logo.OnTapped = a.name.OnTapped
 		a.members.SetText(humanize.Comma(corporation.MemberCount))
 		a.taxRate.SetText(fmt.Sprintf("%.0f%%", corporation.TaxRate*100))
 		a.ticker.SetText(corporation.Ticker)
@@ -206,46 +203,30 @@ func (a *CorporationSheet) update(ctx context.Context) {
 	})
 	fyne.Do(func() {
 		if alliance, ok := corporation.Alliance.Value(); ok {
-			a.alliance.SetText(alliance.Name)
-			a.alliance.OnTapped = func() {
-				a.u.InfoViewer().Show(alliance)
-			}
+			a.alliance.Set(alliance)
 		} else {
-			a.alliance.SetText("-")
-			a.alliance.OnTapped = nil
+			a.alliance.Clear()
 		}
 	})
 	fyne.Do(func() {
 		if faction, ok := corporation.Faction.Value(); ok {
-			a.faction.SetText(faction.Name)
-			a.faction.OnTapped = func() {
-				a.u.InfoViewer().Show(faction)
-			}
+			a.faction.Set(faction)
 		} else {
-			a.faction.SetText("-")
-			a.faction.OnTapped = nil
+			a.faction.Clear()
 		}
 	})
 	fyne.Do(func() {
 		if ceo, ok := corporation.Ceo.Value(); ok {
-			a.ceo.SetText(ceo.Name)
-			a.ceo.OnTapped = func() {
-				a.u.InfoViewer().Show(ceo)
-			}
+			a.ceo.Set(ceo)
 		} else {
-			a.ceo.SetText("-")
-			a.ceo.OnTapped = nil
+			a.ceo.Clear()
 		}
 	})
 	fyne.Do(func() {
 		if home, ok := corporation.HomeStation.Value(); ok {
-			a.home.SetText(home.Name)
-			a.home.OnTapped = func() {
-				a.u.InfoViewer().Show(home)
-			}
+			a.home.Set(home)
 		} else {
-			a.home.SetText("-")
-			a.home.OnTapped = nil
+			a.home.Clear()
 		}
 	})
 }

--- a/internal/app/ui/corporations/members.go
+++ b/internal/app/ui/corporations/members.go
@@ -145,10 +145,12 @@ func (a *Members) filterRowsAsync() {
 
 func (a *Members) update(ctx context.Context) {
 	reset := func() {
-		a.rows = xslices.Reset(a.rows)
-		a.rowsFiltered = xslices.Reset(a.rowsFiltered)
-		a.searchBox.SetText("")
-		a.list.Refresh()
+		fyne.Do(func() {
+			a.rows = xslices.Reset(a.rows)
+			a.rowsFiltered = xslices.Reset(a.rowsFiltered)
+			a.searchBox.SetText("")
+			a.list.Refresh()
+		})
 	}
 	setTop := func(s string, i widget.Importance) {
 		fyne.Do(func() {

--- a/internal/app/ui/industry/job.go
+++ b/internal/app/ui/industry/job.go
@@ -50,6 +50,18 @@ const (
 	industryStatusReady              = "Ready for delivery"
 )
 
+// Column number
+const (
+	industryJobsColBlueprint = iota + 1
+	industryJobsColStatus
+	industryJobsColRuns
+	industryJobsColActivity
+	industryJobsColEndDate
+	industryJobsColLocation
+	industryJobsColOwner
+	industryJobsColInstaller
+)
+
 // industryJobRow represents a job row in the list widgets.
 // It combines character and corporation jobs and has precalculated fields for filters.
 type industryJobRow struct {
@@ -124,17 +136,6 @@ type Jobs struct {
 	sortButton      *xwidget.SortButton
 	u               baseUI
 }
-
-const (
-	industryJobsColBlueprint = iota + 1
-	industryJobsColStatus
-	industryJobsColRuns
-	industryJobsColActivity
-	industryJobsColEndDate
-	industryJobsColLocation
-	industryJobsColOwner
-	industryJobsColInstaller
-)
 
 func NewJobsForOverview(u baseUI) *Jobs {
 	return newIndustryJobs(u, false)

--- a/internal/app/ui/infolabel.go
+++ b/internal/app/ui/infolabel.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+)
+
+// InfoLink is a widget that shows a link for an entity that opens the infoviewer.
+// It can also be cleared to show that the entity does not exist.
+type InfoLink struct {
+	widget.BaseWidget
+
+	link  *widget.Hyperlink
+	label *widget.Label
+	iw    InfoViewer
+}
+
+func NewInfoLink(iw InfoViewer) *InfoLink {
+	w := &InfoLink{
+		link:  widget.NewHyperlink("", nil),
+		label: widget.NewLabel("-"),
+		iw:    iw,
+	}
+	w.ExtendBaseWidget(w)
+	w.link.Truncation = fyne.TextTruncateEllipsis
+	w.link.OnTapped = nil
+	w.link.Hide()
+	return w
+}
+
+func (w *InfoLink) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(container.NewStack(w.link, w.label))
+}
+
+func (w *InfoLink) Set(o *app.EveEntity) {
+	w.link.SetText(o.Name)
+	w.link.OnTapped = func() {
+		w.iw.Show(o)
+	}
+	w.link.Show()
+	w.label.Hide()
+}
+
+func (w *InfoLink) SetBloodline(o *app.EntityShort) {
+	w.link.SetText(o.Name)
+	w.link.OnTapped = func() {
+		w.iw.ShowBloodline(o.ID)
+	}
+	w.link.Show()
+	w.label.Hide()
+}
+
+func (w *InfoLink) SetLocation(o *app.EveLocation) {
+	w.link.SetText(o.Name)
+	w.link.OnTapped = func() {
+		w.iw.ShowLocation(o.ID)
+	}
+	w.link.Show()
+	w.label.Hide()
+}
+
+func (w *InfoLink) SetRace(o *app.EveRace) {
+	w.link.SetText(o.Name)
+	w.link.OnTapped = func() {
+		w.iw.ShowRace(o.ID)
+	}
+	w.link.Show()
+	w.label.Hide()
+}
+
+func (w *InfoLink) Clear() {
+	w.label.Show()
+	w.link.Hide()
+}
+
+// This widget is not used, because we can not both have truncation and place the icon directly next to the label.
+// // InfoLabel is a widget that shows a name label and an info icon for an entity.
+// // Clicking the info button opens the info viewer for that entity.
+// type InfoLabel struct {
+// 	widget.BaseWidget
+
+// 	name *widget.Label
+// 	icon *kxwidget.IconButton
+// 	iw   InfoViewer
+// }
+
+// func NewInfoLabel(iw InfoViewer) *InfoLabel {
+// 	w := &InfoLabel{
+// 		name: widget.NewLabel(""),
+// 		icon: kxwidget.NewIconButton(theme.NewThemedResource(icons.InformationSlabCircleSvg), nil),
+// 		iw:   iw,
+// 	}
+// 	w.ExtendBaseWidget(w)
+// 	w.name.Truncation = fyne.TextTruncateEllipsis
+// 	w.name.Hide()
+// 	w.icon.Hide()
+// 	return w
+// }
+
+// func (w *InfoLabel) CreateRenderer() fyne.WidgetRenderer {
+// 	c := container.NewBorder(nil, nil, nil, container.NewHBox(w.icon, layout.NewSpacer()), w.name)
+// 	return widget.NewSimpleRenderer(c)
+// }
+
+// func (w *InfoLabel) Set(o *app.EveEntity) {
+// 	w.name.SetText(o.Name)
+// 	w.icon.OnTapped = func() {
+// 		w.iw.Show(o)
+// 	}
+// 	w.name.Show()
+// 	w.icon.Show()
+// }
+
+// func (w *InfoLabel) Clear() {
+// 	w.name.Hide()
+// 	w.icon.Hide()
+// }

--- a/internal/app/ui/infoviewer/infoviewer.go
+++ b/internal/app/ui/infoviewer/infoviewer.go
@@ -84,7 +84,7 @@ func SupportedCategories() set.Set[app.EveEntityCategory] {
 
 }
 
-type coreUI interface {
+type baseUI interface {
 	Character() *characterservice.CharacterService
 	EVEImage() ui.EVEImageService
 	EVEUniverse() *eveuniverseservice.EVEUniverseService
@@ -106,7 +106,7 @@ type InfoViewer struct {
 	nav           *xwidget.Navigator
 	onClosedFuncs []func() // f runs when the window is closed. Useful for cleanup.
 	sb            *xwidget.Snackbar
-	u             coreUI
+	u             baseUI
 	w             fyne.Window
 }
 
@@ -120,7 +120,7 @@ const (
 )
 
 // New returns a new InfoViewer.
-func New(u coreUI) *InfoViewer {
+func New(u baseUI) *InfoViewer {
 	iw := &InfoViewer{
 		u: u,
 		w: u.MainWindow(),

--- a/internal/app/ui/infoviewer/infoviewer_internal_test.go
+++ b/internal/app/ui/infoviewer/infoviewer_internal_test.go
@@ -42,7 +42,7 @@ func (u *UIServiceFake) Janice() *janiceservice.JaniceService { return nil }
 func (u *UIServiceFake) MainWindow() fyne.Window              { return u.mainWindow }
 func (u *UIServiceFake) Settings() *settings.Settings         { return nil }
 
-var _ coreUI = (*UIServiceFake)(nil)
+var _ baseUI = (*UIServiceFake)(nil)
 
 // TestInfoViewer_show2_UsesMainWindowAsFallbackWhenInfoWindowClosed is a regression test
 // for the bug where show2 used iw.w directly as the dialog parent. After an info window is

--- a/internal/app/ui/infoviewer/inventorytypeinfo.go
+++ b/internal/app/ui/infoviewer/inventorytypeinfo.go
@@ -619,7 +619,7 @@ func (a *inventoryTypeInfo) makeRequirementsTab(requiredSkills []requiredSkill) 
 			text := row[2].(*widget.Label)
 			level := row[3].(*xwidget.SkillLevel)
 			icon := row[4].(*widget.Icon)
-			skill.SetText(app.SkillDisplayName(o.name, o.requiredLevel))
+			skill.SetText(ui.SkillDisplayName(o.name, o.requiredLevel))
 			if o.activeLevel == 0 && o.trainedLevel == 0 {
 				text.Text = "Skill not injected"
 				text.Importance = widget.DangerImportance

--- a/internal/app/ui/settings/settings.go
+++ b/internal/app/ui/settings/settings.go
@@ -166,12 +166,6 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 		},
 	})
 
-	items = slices.Concat(items, []SettingItem{
-		NewSettingItemHeading("UI"),
-		preferMarketTab,
-		hideLimitedCorporations,
-	})
-
 	colorTheme := NewSettingItemOptions(SettingItemOptionsParams{
 		label:        "Appearance",
 		hint:         "Choose the color scheme. 'Auto' uses the current OS theme.",
@@ -187,6 +181,12 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 		},
 		isMobile: a.u.IsMobile(),
 		window:   a.w,
+	})
+	items = slices.Concat(items, []SettingItem{
+		NewSettingItemHeading("UI"),
+		preferMarketTab,
+		hideLimitedCorporations,
+		colorTheme,
 	})
 
 	fyneScale := NewSettingItemSlider(SettingItemSliderParams{
@@ -218,7 +218,6 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 
 	if !a.u.IsMobile() {
 		items = slices.Concat(items, []SettingItem{
-			colorTheme,
 			fyneScale,
 			disableDPIDetection,
 		})

--- a/internal/app/ui/settings/settings.go
+++ b/internal/app/ui/settings/settings.go
@@ -1072,6 +1072,12 @@ func (w *settingListItem) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(c2)
 }
 
+func (w *settingListItem) Refresh() {
+	w.BaseWidget.Refresh()
+	w.background.FillColor = theme.Color(theme.ColorNameInputBackground)
+	w.background.Refresh()
+}
+
 func (w *settingListItem) set(r SettingItem) {
 	if r.Hint != "" {
 		w.hint.SetText(r.Hint)

--- a/internal/app/ui/skills/queue.go
+++ b/internal/app/ui/skills/queue.go
@@ -287,7 +287,7 @@ func showSkillInTrainingWindow(u baseUI, r *app.CharacterSkillqueueItem, charact
 			"Owner",
 			ui.MakeCharacterActionLabel(r.CharacterID, characterName, u.InfoViewer().Show),
 		),
-		widget.NewFormItem("Skill", ui.MakeLinkLabel(app.SkillDisplayName(r.SkillName, r.FinishedLevel), func() {
+		widget.NewFormItem("Skill", ui.MakeLinkLabel(ui.SkillDisplayName(r.SkillName, r.FinishedLevel), func() {
 			u.InfoViewer().ShowType(r.SkillID, r.CharacterID)
 		})),
 		widget.NewFormItem("Group", widget.NewLabel(r.GroupName)),
@@ -318,7 +318,7 @@ func showSkillInTrainingWindow(u baseUI, r *app.CharacterSkillqueueItem, charact
 
 	f := widget.NewForm(items...)
 	f.Orientation = widget.Adaptive
-	subTitle := fmt.Sprintf("%s by %s", app.SkillDisplayName(r.SkillName, r.FinishedLevel), characterName)
+	subTitle := fmt.Sprintf("%s by %s", ui.SkillDisplayName(r.SkillName, r.FinishedLevel), characterName)
 	ui.MakeDetailWindow(ui.MakeDetailWindowParams{
 		Content: f,
 		ImageAction: func() {

--- a/internal/app/ui/skills/search.go
+++ b/internal/app/ui/skills/search.go
@@ -336,7 +336,7 @@ func (a *Search) fetchRows(ctx context.Context) ([]searchRow, error) {
 			groupID:       s.Type.Group.ID,
 			groupName:     s.Type.Group.Name,
 			searchTarget:  strings.ToLower(fmt.Sprintf("%s %d", s.Type.Name, s.ActiveSkillLevel)),
-			skillName:     app.SkillDisplayName(s.Type.Name, s.ActiveSkillLevel),
+			skillName:     ui.SkillDisplayName(s.Type.Name, s.ActiveSkillLevel),
 			trainedLevel:  s.TrainedSkillLevel,
 			typeID:        s.Type.ID,
 			typeName:      s.Type.Name,

--- a/internal/app/ui/skills/search.go
+++ b/internal/app/ui/skills/search.go
@@ -1,0 +1,347 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+
+	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
+	"github.com/ErikKalkoken/evebuddy/internal/xslices"
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+type searchRow struct {
+	activeLevel   int64
+	characterID   int64
+	characterName string
+	groupID       int64
+	groupName     string
+	searchTarget  string
+	skillName     string
+	trainedLevel  int64
+	typeID        int64
+	typeName      string
+}
+
+type Search struct {
+	widget.BaseWidget
+
+	body            fyne.CanvasObject
+	columnSorter    *xwidget.ColumnSorter[searchRow]
+	footer          *widget.Label
+	rows            []searchRow
+	rowsFiltered    []searchRow
+	search          *widget.Entry
+	selectGroup     *kxwidget.FilterChipSelect
+	selectType      *kxwidget.FilterChipSelect
+	selectCharacter *kxwidget.FilterChipSelect
+	sortButton      *xwidget.SortButton
+	top             *widget.Label
+	u               baseUI
+}
+
+const (
+	searchColName = iota + 1
+	searchColGroup
+	searchColCharacter
+)
+
+func NewSearch(u baseUI) *Search {
+	cols := []xwidget.DataColumn[searchRow]{{
+		ID:    searchColName,
+		Label: "Skill",
+		Width: 300,
+		Sort: func(a, b searchRow) int {
+			return strings.Compare(a.searchTarget, b.searchTarget)
+		},
+		Update: func(r searchRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(r.skillName)
+		},
+	}, {
+		ID:    searchColGroup,
+		Label: "Group",
+		Width: 200,
+		Sort: func(a, b searchRow) int {
+			return strings.Compare(a.groupName, b.groupName)
+		},
+		Update: func(r searchRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(r.groupName)
+		},
+	}, ui.MakeEveEntityColumn(ui.MakeEveEntityColumnParams[searchRow]{
+		ColumnID: searchColCharacter,
+		EIS:      u.EVEImage(),
+		GetEntity: func(r searchRow) *app.EveEntity {
+			return &app.EveEntity{
+				ID:       r.characterID,
+				Name:     r.characterName,
+				Category: app.EveEntityCharacter,
+			}
+		},
+		IsAvatar: true,
+		Label:    "Character",
+	})}
+
+	columns := xwidget.NewDataColumns(cols)
+	a := &Search{
+		columnSorter: xwidget.NewColumnSorter(columns, searchColName, xwidget.SortAsc),
+		footer:       ui.NewLabelWithTruncation(""),
+		search:       widget.NewEntry(),
+		top:          ui.NewLabelWithWrapping(""),
+		u:            u,
+	}
+	a.ExtendBaseWidget(a)
+
+	if a.u.IsMobile() {
+		a.body = a.makeDataList()
+	} else {
+		a.body = xwidget.MakeDataTable(
+			columns,
+			&a.rowsFiltered,
+			func() fyne.CanvasObject {
+				x := xwidget.NewRichText()
+				x.Truncation = fyne.TextTruncateClip
+				return x
+			},
+			a.columnSorter, a.filterRowsAsync, func(_ int, r searchRow) {
+				u.InfoViewer().ShowType(r.typeID, r.characterID)
+			})
+	}
+
+	// filters
+	a.search.ActionItem = kxwidget.NewIconButton(theme.CancelIcon(), func() {
+		a.search.SetText("")
+		a.filterRowsAsync(-1)
+	})
+	a.search.OnChanged = func(_ string) {
+		a.filterRowsAsync(-1)
+	}
+	a.search.PlaceHolder = "Search items"
+	a.selectGroup = kxwidget.NewFilterChipSelectWithSearch("Group", []string{}, func(string) {
+		a.filterRowsAsync(-1)
+	}, a.u.MainWindow())
+	a.selectCharacter = kxwidget.NewFilterChipSelect("Character", []string{}, func(string) {
+		a.filterRowsAsync(-1)
+	})
+	a.selectType = kxwidget.NewFilterChipSelectWithSearch("Type", []string{}, func(string) {
+		a.filterRowsAsync(-1)
+	}, a.u.MainWindow())
+	a.sortButton = a.columnSorter.NewSortButton(func() {
+		a.filterRowsAsync(-1)
+	}, a.u.MainWindow())
+
+	// Signals
+	a.u.Signals().AppInit.AddListener(func(ctx context.Context, _ struct{}) {
+		a.update(ctx)
+	})
+	a.u.Signals().CharacterSectionChanged.AddListener(func(ctx context.Context, arg app.CharacterSectionUpdated) {
+		if arg.Section == app.SectionCharacterSkills {
+			a.update(ctx)
+		}
+	})
+	a.u.Signals().CharacterAdded.AddListener(func(ctx context.Context, _ *app.Character) {
+		a.update(ctx)
+	})
+	a.u.Signals().CharacterRemoved.AddListener(func(ctx context.Context, _ *app.EntityShort) {
+		a.update(ctx)
+	})
+
+	return a
+}
+
+func (a *Search) CreateRenderer() fyne.WidgetRenderer {
+	filters := container.NewHBox(
+		a.selectGroup,
+		a.selectType,
+		a.selectCharacter,
+	)
+	topBox := container.NewVBox(a.top)
+	if a.u.IsMobile() {
+		filters.Add(a.sortButton)
+		topBox.Add(a.search)
+		topBox.Add(container.NewHScroll(filters))
+	} else {
+		topBox.Add(container.NewBorder(nil, nil, filters, nil, a.search))
+	}
+	c := container.NewBorder(topBox, a.footer, nil, nil, a.body)
+	return widget.NewSimpleRenderer(c)
+}
+
+func (a *Search) makeDataList() *xwidget.StripedList {
+	p := theme.Padding()
+	l := xwidget.NewStripedList(
+		func() int {
+			return len(a.rowsFiltered)
+		},
+		func() fyne.CanvasObject {
+			title := widget.NewLabelWithStyle("Template", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+			character := widget.NewLabel("Template")
+			group := widget.NewLabel("Template")
+			return container.New(layout.NewCustomPaddedVBoxLayout(-p),
+				title,
+				group,
+				character,
+			)
+		},
+		func(id widget.ListItemID, co fyne.CanvasObject) {
+			if id < 0 || id >= len(a.rowsFiltered) {
+				return
+			}
+			r := a.rowsFiltered[id]
+			box := co.(*fyne.Container).Objects
+			box[0].(*widget.Label).SetText(r.skillName)
+			box[1].(*widget.Label).SetText(r.groupName)
+			box[2].(*widget.Label).SetText(r.characterName)
+		},
+	)
+	l.OnSelected = func(id widget.ListItemID) {
+		defer l.UnselectAll()
+		if id < 0 || id >= len(a.rowsFiltered) {
+			return
+		}
+		r := a.rowsFiltered[id]
+		a.u.InfoViewer().ShowType(r.typeID, r.characterID)
+	}
+	return l
+}
+
+func (a *Search) Focus() {
+	a.u.MainWindow().Canvas().Focus(a.search)
+}
+
+func (a *Search) filterRowsAsync(sortCol int) {
+	totalRows := len(a.rows)
+	rows := slices.Clone(a.rows)
+	group := a.selectGroup.Selected
+	character := a.selectCharacter.Selected
+	type_ := a.selectType.Selected
+	search := strings.ToLower(a.search.Text)
+	sortCol, dir, doSort := a.columnSorter.CalcSort(sortCol)
+
+	go func() {
+		if character != "" {
+			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
+				return r.characterName != character
+			})
+		}
+		if group != "" {
+			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
+				return r.groupName != group
+			})
+		}
+		if type_ != "" {
+			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
+				return r.typeName != type_
+			})
+		}
+
+		// search filter
+		if len(search) > 1 {
+			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
+				return !strings.Contains(r.searchTarget, search)
+			})
+		}
+		a.columnSorter.SortRows(rows, sortCol, dir, doSort)
+
+		// set data & refresh
+		characterOptions := xslices.Map(rows, func(r searchRow) string {
+			return r.characterName
+		})
+		groupOptions := xslices.Map(rows, func(r searchRow) string {
+			return r.groupName
+		})
+		typeOptions := xslices.Map(rows, func(r searchRow) string {
+			return r.typeName
+		})
+
+		footer := fmt.Sprintf("Showing %s / %s items", ihumanize.Comma(len(rows)), ihumanize.Comma(totalRows))
+
+		fyne.Do(func() {
+			a.footer.Text = footer
+			a.footer.Importance = widget.MediumImportance
+			a.footer.Refresh()
+			a.selectCharacter.SetOptions(characterOptions)
+			a.selectGroup.SetOptions(groupOptions)
+			a.selectType.SetOptions(typeOptions)
+			a.rowsFiltered = rows
+			a.body.Refresh()
+			switch x := a.body.(type) {
+			case *widget.Table:
+				x.ScrollToTop()
+			}
+		})
+	}()
+}
+
+func (a *Search) update(ctx context.Context) {
+	reset := func() {
+		fyne.Do(func() {
+			a.rows = xslices.Reset(a.rows)
+			a.filterRowsAsync(-1)
+		})
+	}
+	setTop := func(s string, i widget.Importance) {
+		fyne.Do(func() {
+			a.top.Text = s
+			a.top.Importance = i
+			a.top.Refresh()
+			a.top.Show()
+		})
+	}
+	var rows []searchRow
+	var err error
+	rows, err = a.fetchRows(ctx)
+	if err != nil {
+		slog.Error("Failed to refresh skills", "err", err)
+		reset()
+		setTop("ERROR: "+a.u.ErrorDisplay(err), widget.DangerImportance)
+		return
+	}
+	fyne.Do(func() {
+		a.top.Hide()
+		a.rows = rows
+		a.filterRowsAsync(-1)
+	})
+}
+
+func (a *Search) fetchRows(ctx context.Context) ([]searchRow, error) {
+	characters, err := a.u.Character().CharacterNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	skills, err := a.u.Character().ListAllSkills(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var rows []searchRow
+	for _, s := range skills {
+		if s.ActiveSkillLevel == 0 {
+			continue
+		}
+		r := searchRow{
+			activeLevel:   s.ActiveSkillLevel,
+			characterID:   s.CharacterID,
+			characterName: characters[s.CharacterID],
+			groupID:       s.Type.Group.ID,
+			groupName:     s.Type.Group.Name,
+			searchTarget:  strings.ToLower(fmt.Sprintf("%s %d", s.Type.Name, s.ActiveSkillLevel)),
+			skillName:     app.SkillDisplayName(s.Type.Name, s.ActiveSkillLevel),
+			trainedLevel:  s.TrainedSkillLevel,
+			typeID:        s.Type.ID,
+			typeName:      s.Type.Name,
+		}
+		rows = append(rows, r)
+	}
+	return rows, nil
+}

--- a/internal/app/ui/skills/search.go
+++ b/internal/app/ui/skills/search.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -22,17 +23,50 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
+// Option in search skill widget
+const (
+	searchSkillActive     = "Active skills"
+	searchSkillRestricted = "Restricted skills"
+	searchSkillAll        = "All skills"
+)
+
+// Column number in search table
+const (
+	searchColSkill = iota + 1
+	searchColActiveLevel
+	searchColTrainedLevel
+	searchColSkillPoints
+	searchColGroup
+	searchColCharacter
+)
+
 type searchRow struct {
-	activeLevel   int64
-	characterID   int64
-	characterName string
-	groupID       int64
-	groupName     string
-	searchTarget  string
-	skillName     string
-	trainedLevel  int64
-	typeID        int64
-	typeName      string
+	activeLevel        int64
+	activeLevelRoman   string
+	characterID        int64
+	characterName      string
+	groupID            int64
+	groupName          string
+	searchTarget       string
+	skillPoints        int64
+	skillPointsDisplay string
+	trainedLevel       int64
+	trainedLevelRoman  string
+	typeID             int64
+	typeName           string
+}
+
+func (r searchRow) skillNameCondensed() string {
+	skill := r.typeName
+	if r.activeLevel == 0 && r.trainedLevel > 0 {
+		skill += fmt.Sprintf(" [%s]", r.trainedLevelRoman)
+	} else {
+		skill += fmt.Sprintf(" %s", r.activeLevelRoman)
+		if r.activeLevel != r.trainedLevel {
+			skill += fmt.Sprintf(" [%s]", r.trainedLevelRoman)
+		}
+	}
+	return skill
 }
 
 type Search struct {
@@ -44,35 +78,69 @@ type Search struct {
 	rows            []searchRow
 	rowsFiltered    []searchRow
 	search          *widget.Entry
-	selectGroup     *kxwidget.FilterChipSelect
-	selectType      *kxwidget.FilterChipSelect
 	selectCharacter *kxwidget.FilterChipSelect
+	selectGroup     *kxwidget.FilterChipSelect
+	selectSkill     *kxwidget.FilterChipSelect
+	selectType      *kxwidget.FilterChipSelect
 	sortButton      *xwidget.SortButton
 	top             *widget.Label
 	u               baseUI
 }
 
-const (
-	searchColName = iota + 1
-	searchColGroup
-	searchColCharacter
-)
-
 func NewSearch(u baseUI) *Search {
 	cols := []xwidget.DataColumn[searchRow]{{
-		ID:    searchColName,
+		ID:    searchColSkill,
 		Label: "Skill",
-		Width: 300,
+		Width: 275,
 		Sort: func(a, b searchRow) int {
 			return strings.Compare(a.searchTarget, b.searchTarget)
 		},
 		Update: func(r searchRow, co fyne.CanvasObject) {
-			co.(*xwidget.RichText).SetWithText(r.skillName)
+			co.(*xwidget.RichText).SetWithText(r.typeName)
+		},
+	}, {
+		ID:    searchColActiveLevel,
+		Label: "Active",
+		Width: 70,
+		Sort: func(a, b searchRow) int {
+			return cmp.Compare(a.activeLevel, b.activeLevel)
+		},
+		Update: func(r searchRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(
+				fmt.Sprint(r.activeLevelRoman),
+				widget.RichTextStyle{Alignment: fyne.TextAlignCenter},
+			)
+		},
+	}, {
+		ID:    searchColTrainedLevel,
+		Label: "Trained",
+		Width: 70,
+		Sort: func(a, b searchRow) int {
+			return cmp.Compare(a.trainedLevel, b.trainedLevel)
+		},
+		Update: func(r searchRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(
+				fmt.Sprint(r.trainedLevelRoman),
+				widget.RichTextStyle{Alignment: fyne.TextAlignCenter},
+			)
+		},
+	}, {
+		ID:    searchColSkillPoints,
+		Label: "Skill Points",
+		Width: 90,
+		Sort: func(a, b searchRow) int {
+			return cmp.Compare(a.skillPoints, b.skillPoints)
+		},
+		Update: func(r searchRow, co fyne.CanvasObject) {
+			co.(*xwidget.RichText).SetWithText(
+				r.skillPointsDisplay,
+				widget.RichTextStyle{Alignment: fyne.TextAlignTrailing},
+			)
 		},
 	}, {
 		ID:    searchColGroup,
 		Label: "Group",
-		Width: 200,
+		Width: 180,
 		Sort: func(a, b searchRow) int {
 			return strings.Compare(a.groupName, b.groupName)
 		},
@@ -91,11 +159,12 @@ func NewSearch(u baseUI) *Search {
 		},
 		IsAvatar: true,
 		Label:    "Character",
+		Width:    250,
 	})}
 
 	columns := xwidget.NewDataColumns(cols)
 	a := &Search{
-		columnSorter: xwidget.NewColumnSorter(columns, searchColName, xwidget.SortAsc),
+		columnSorter: xwidget.NewColumnSorter(columns, searchColSkill, xwidget.SortAsc),
 		footer:       ui.NewLabelWithTruncation(""),
 		search:       widget.NewEntry(),
 		top:          ui.NewLabelWithWrapping(""),
@@ -127,7 +196,17 @@ func NewSearch(u baseUI) *Search {
 	a.search.OnChanged = func(_ string) {
 		a.filterRowsAsync(-1)
 	}
-	a.search.PlaceHolder = "Search items"
+	a.search.PlaceHolder = "Search skills"
+	a.selectSkill = kxwidget.NewFilterChipSelect("", []string{
+		searchSkillActive,
+		searchSkillRestricted,
+		searchSkillAll,
+	}, func(_ string) {
+		a.filterRowsAsync(-1)
+	})
+	a.selectSkill.Selected = searchSkillActive
+	a.selectSkill.SortDisabled = true
+
 	a.selectGroup = kxwidget.NewFilterChipSelectWithSearch("Group", []string{}, func(string) {
 		a.filterRowsAsync(-1)
 	}, a.u.MainWindow())
@@ -164,6 +243,7 @@ func (a *Search) CreateRenderer() fyne.WidgetRenderer {
 	filters := container.NewHBox(
 		a.selectGroup,
 		a.selectType,
+		a.selectSkill,
 		a.selectCharacter,
 	)
 	topBox := container.NewVBox(a.top)
@@ -185,24 +265,14 @@ func (a *Search) makeDataList() *xwidget.StripedList {
 			return len(a.rowsFiltered)
 		},
 		func() fyne.CanvasObject {
-			title := widget.NewLabelWithStyle("Template", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
-			character := widget.NewLabel("Template")
-			group := widget.NewLabel("Template")
-			return container.New(layout.NewCustomPaddedVBoxLayout(-p),
-				title,
-				group,
-				character,
-			)
+			return newSearchRowWidget(p)
 		},
 		func(id widget.ListItemID, co fyne.CanvasObject) {
 			if id < 0 || id >= len(a.rowsFiltered) {
 				return
 			}
-			r := a.rowsFiltered[id]
-			box := co.(*fyne.Container).Objects
-			box[0].(*widget.Label).SetText(r.skillName)
-			box[1].(*widget.Label).SetText(r.groupName)
-			box[2].(*widget.Label).SetText(r.characterName)
+
+			co.(*searchRowWidget).Set(a.rowsFiltered[id])
 		},
 	)
 	l.OnSelected = func(id widget.ListItemID) {
@@ -230,6 +300,18 @@ func (a *Search) filterRowsAsync(sortCol int) {
 	sortCol, dir, doSort := a.columnSorter.CalcSort(sortCol)
 
 	go func() {
+		// filter
+		rows := slices.DeleteFunc(rows, func(r searchRow) bool {
+			switch a.selectSkill.Selected {
+			case searchSkillActive:
+				return r.activeLevel == 0
+			case searchSkillRestricted:
+				return r.activeLevel >= r.trainedLevel
+			case searchSkillAll:
+				return false
+			}
+			return true
+		})
 		if character != "" {
 			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
 				return r.characterName != character
@@ -246,7 +328,7 @@ func (a *Search) filterRowsAsync(sortCol int) {
 			})
 		}
 
-		// search filter
+		// search
 		if len(search) > 1 {
 			rows = slices.DeleteFunc(rows, func(r searchRow) bool {
 				return !strings.Contains(r.searchTarget, search)
@@ -326,22 +408,63 @@ func (a *Search) fetchRows(ctx context.Context) ([]searchRow, error) {
 	}
 	var rows []searchRow
 	for _, s := range skills {
-		if s.ActiveSkillLevel == 0 {
-			continue
-		}
 		r := searchRow{
-			activeLevel:   s.ActiveSkillLevel,
-			characterID:   s.CharacterID,
-			characterName: characters[s.CharacterID],
-			groupID:       s.Type.Group.ID,
-			groupName:     s.Type.Group.Name,
-			searchTarget:  strings.ToLower(fmt.Sprintf("%s %d", s.Type.Name, s.ActiveSkillLevel)),
-			skillName:     ui.SkillDisplayName(s.Type.Name, s.ActiveSkillLevel),
-			trainedLevel:  s.TrainedSkillLevel,
-			typeID:        s.Type.ID,
-			typeName:      s.Type.Name,
+			activeLevel:        s.ActiveSkillLevel,
+			activeLevelRoman:   ihumanize.RomanLetter(s.ActiveSkillLevel),
+			characterID:        s.CharacterID,
+			characterName:      characters[s.CharacterID],
+			groupID:            s.Type.Group.ID,
+			groupName:          s.Type.Group.Name,
+			searchTarget:       strings.ToLower(fmt.Sprintf("%s %d", s.Type.Name, s.ActiveSkillLevel)),
+			skillPoints:        s.SkillPointsInSkill,
+			skillPointsDisplay: ihumanize.Comma(s.SkillPointsInSkill),
+			trainedLevel:       s.TrainedSkillLevel,
+			trainedLevelRoman:  ihumanize.RomanLetter(s.TrainedSkillLevel),
+			typeID:             s.Type.ID,
+			typeName:           s.Type.Name,
 		}
 		rows = append(rows, r)
 	}
 	return rows, nil
+}
+
+type searchRowWidget struct {
+	widget.BaseWidget
+
+	skill       *widget.Label
+	group       *widget.Label
+	skillPoints *widget.Label
+	character   *widget.Label
+	padding     float32
+}
+
+func newSearchRowWidget(padding float32) *searchRowWidget {
+	w := &searchRowWidget{
+		skill:       widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		group:       widget.NewLabel(""),
+		skillPoints: widget.NewLabel(""),
+		character:   widget.NewLabel(""),
+		padding:     padding,
+	}
+
+	w.ExtendBaseWidget(w)
+	return w
+}
+
+func (w *searchRowWidget) Set(r searchRow) {
+	w.skill.SetText(r.skillNameCondensed())
+	w.group.SetText(r.groupName)
+	w.skillPoints.SetText(fmt.Sprintf("%s SP", r.skillPointsDisplay))
+	w.character.SetText(r.characterName)
+}
+
+func (w *searchRowWidget) CreateRenderer() fyne.WidgetRenderer {
+	c := container.New(
+		layout.NewCustomPaddedVBoxLayout(-w.padding),
+		w.skill,
+		container.NewHBox(w.group, layout.NewSpacer(), w.skillPoints),
+		w.character,
+	)
+
+	return widget.NewSimpleRenderer(c)
 }

--- a/internal/app/ui/skills/search_internal_test.go
+++ b/internal/app/ui/skills/search_internal_test.go
@@ -1,0 +1,67 @@
+package skills
+
+import (
+	"testing"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+)
+
+func TestSkillNameCondensed(t *testing.T) {
+	tests := []struct {
+		name string
+		row  searchRow
+		want string
+	}{
+		{
+			name: "active level zero and trained level greater than zero",
+			row: searchRow{
+				typeName:          "Gunnery",
+				activeLevel:       0,
+				activeLevelRoman:  "0",
+				trainedLevel:      3,
+				trainedLevelRoman: "III",
+			},
+			want: "Gunnery [III]",
+		},
+		{
+			name: "active level equal to trained level",
+			row: searchRow{
+				typeName:          "Gunnery",
+				activeLevel:       5,
+				activeLevelRoman:  "V",
+				trainedLevel:      5,
+				trainedLevelRoman: "V",
+			},
+			want: "Gunnery V",
+		},
+		{
+			name: "active level different from trained level",
+			row: searchRow{
+				typeName:          "Gunnery",
+				activeLevel:       3,
+				activeLevelRoman:  "III",
+				trainedLevel:      5,
+				trainedLevelRoman: "V",
+			},
+			want: "Gunnery III [V]",
+		},
+		{
+			name: "both levels zero",
+			row: searchRow{
+				typeName:          "Gunnery",
+				activeLevel:       0,
+				activeLevelRoman:  "-",
+				trainedLevel:      0,
+				trainedLevelRoman: "-",
+			},
+			want: "Gunnery -",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.row.skillNameCondensed()
+			xassert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/app/ui/skills/search_test.go
+++ b/internal/app/ui/skills/search_test.go
@@ -1,0 +1,40 @@
+package skills
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+)
+
+func TestSearch(t *testing.T) {
+	db, st, f := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	u := testdouble.NewUIFake(testdouble.UIParams{
+		App:     test.NewTempApp(t),
+		Storage: st,
+	})
+	a := NewSearch(u)
+
+	t.Run("should fetch skills", func(t *testing.T) {
+		// given
+		cs := f.CreateCharacterSkill()
+
+		// when
+		a.update(t.Context())
+
+		// then
+		assert.Len(t, a.rows, 1)
+		r := a.rows[0]
+		xassert.Equal(t, r.typeName, cs.Type.Name)
+		xassert.Equal(t, r.activeLevel, cs.ActiveSkillLevel)
+		xassert.Equal(t, r.trainedLevel, cs.TrainedSkillLevel)
+		xassert.Equal(t, r.skillPoints, cs.SkillPointsInSkill)
+		xassert.Equal(t, r.characterID, cs.CharacterID)
+	})
+}

--- a/internal/app/ui/skills/training.go
+++ b/internal/app/ui/skills/training.go
@@ -678,7 +678,7 @@ func (a *Training) fetchRow(ctx context.Context, c *app.Character) (trainingRow,
 	if r.skill != nil {
 		r.isActive = true
 		r.skillID = r.skill.SkillID
-		r.skillName = app.SkillDisplayName(r.skill.SkillName, r.skill.FinishedLevel)
+		r.skillName = ui.SkillDisplayName(r.skill.SkillName, r.skill.FinishedLevel)
 		r.skillFinishDate = r.skill.FinishDate
 		r.skillProgress.Set(r.skill.CompletionP())
 	} else {

--- a/internal/app/ui/ui.go
+++ b/internal/app/ui/ui.go
@@ -2,12 +2,14 @@
 package ui
 
 import (
+	"fmt"
 	"log/slog"
 	"net/url"
 
 	"fyne.io/fyne/v2"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 )
 
 // Width of common columns in data tables
@@ -89,4 +91,8 @@ func WebsiteRootURL() *url.URL {
 		uri, _ = url.Parse(fallbackWebsiteURL)
 	}
 	return uri
+}
+
+func SkillDisplayName[N int | int64 | uint | uint32 | uint64](name string, level N) string {
+	return fmt.Sprintf("%s %s", name, ihumanize.RomanLetter(level))
 }

--- a/internal/humanize/hmanize_test.go
+++ b/internal/humanize/hmanize_test.go
@@ -125,7 +125,7 @@ func TestRomanLetters(t *testing.T) {
 		{4, "IV"},
 		{5, "V"},
 		{5, "V"},
-		{0, ""},
+		{0, "-"},
 		{6, ""},
 	}
 	for _, tc := range cases {

--- a/internal/humanize/humanize.go
+++ b/internal/humanize/humanize.go
@@ -161,10 +161,13 @@ func OptionalWithDecimals[T float32 | float64](o optional.Optional[T], decimals 
 	return NumberF(float64(v), decimals)
 }
 
-// RomanLetter returns a number as roman letters.
+// RomanLetter returns a number as roman letters
+//
+// Zero is returned as dash.
 // Returns an empty string if v can not be resolved.
 func RomanLetter[T constraints.Integer](v T) string {
 	m := map[int]string{
+		0: "-",
 		1: "I",
 		2: "II",
 		3: "III",


### PR DESCRIPTION
- Added new feature skill search:
  - New page "Search" shows the current skills all characters with active levels, trained levels and skill points
  - Skills can be sorted, searched and filtered
- Renamed "Training" menu entry on overview tab to "Skills", which now contains two tabs: Training & Search
- Removed inactive links on character and corporation sheet for not existing fields (e.g. corporation without alliance)
- Re-activated UI theme setting for mobile 
- Fixed a bug where the setting options where not dynamically themeable
- Updated and improved README
- Refactoring

Resolves #473 

## Screenshot Desktop

<img width="1920" height="1046" alt="image" src="https://github.com/user-attachments/assets/15d1ffeb-f8d0-4a6a-a6bb-5c9022b7e528" />


## Screenshot Mobile (simulator)

<img width="520" height="1055" alt="image" src="https://github.com/user-attachments/assets/54053c54-cb33-4bbe-9aa3-c89825824b17" />





