### PR TITLE
feat: overhaul update status window

### DIFF
--- a/internal/app/statuscache.go
+++ b/internal/app/statuscache.go
@@ -120,10 +120,6 @@ type CacheSectionStatus struct {
 	Timeout      time.Duration
 }
 
-func (ss CacheSectionStatus) IsEveUniverseSection() bool {
-	return ss.EntityID == EveUniverseSectionEntityID
-}
-
 func (ss CacheSectionStatus) HasError() bool {
 	return ss.ErrorMessage != ""
 }

--- a/internal/app/statuscache.go
+++ b/internal/app/statuscache.go
@@ -108,11 +108,11 @@ const (
 )
 
 type CacheSectionStatus struct {
-	EntityID     int64
-	EntityName   string
 	Comment      string
 	CompletedAt  time.Time
 	ContentHash  string
+	EntityID     int64
+	EntityName   string
 	ErrorMessage string
 	SectionID    string
 	SectionName  string

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -1,4 +1,4 @@
-// Package updatestatus provides a window that shows the current update status.
+// Package updatestatus shows the current update status in a window.
 package updatestatus
 
 import (
@@ -13,7 +13,6 @@ import (
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
-	kxlayout "github.com/ErikKalkoken/fyne-kx/layout"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	"github.com/dustin/go-humanize"
 
@@ -42,7 +41,7 @@ type baseUI interface {
 	StatusCache() *statuscache.StatusCache
 }
 
-// Show shows the status window.
+// Show shows the update status window.
 func Show(s baseUI) {
 	w, ok, onClosed := s.GetOrCreateWindowWithOnClosed("statusWindow", "Update Status")
 	if !ok {
@@ -94,29 +93,29 @@ type entity struct {
 type updateStatus struct {
 	widget.BaseWidget
 
-	details           *sectionDetails
+	currentEntityID   int
+	currentSectionID  int
+	currentSections   []app.CacheSectionStatus
 	entities          []entity
 	entityList        *widget.List
 	entityMoreButton  *kxwidget.IconButton
 	nav               *xwidget.Navigator
 	sb                *xwidget.Snackbar
+	sectionStatus     *sectionStatus
 	sectionList       *widget.List
 	sectionMoreButton *kxwidget.IconButton
-	currentSections   []app.CacheSectionStatus
-	currentEntityID   int
-	currentSectionID  int
 	signalKey         string
 	u                 baseUI
 }
 
-func newUpdateStatus(s baseUI, w fyne.Window) *updateStatus {
+func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 	a := &updateStatus{
-		details:          newSectionDetails(),
+		sectionStatus:    newSectionStatus(u.IsMobile()),
 		sb:               xwidget.NewSnackbar(w.Canvas()),
 		currentEntityID:  -1,
 		currentSectionID: -1,
-		signalKey:        s.Signals().UniqueKey(),
-		u:                s,
+		signalKey:        u.Signals().UniqueKey(),
+		u:                u,
 	}
 	a.ExtendBaseWidget(a)
 	a.entityList = a.makeEntityList()
@@ -343,7 +342,7 @@ func (a *updateStatus) makeSectionList() *widget.List {
 		x2 := a.currentSections[id]
 		subTitle := widget.NewLabel(fmt.Sprintf("%s > %s", x1.category.name(), x2.EntityName))
 		subTitle.TextStyle.Bold = true
-		c := container.NewBorder(subTitle, nil, nil, nil, a.details)
+		c := container.NewBorder(subTitle, nil, nil, nil, a.sectionStatus)
 		ab := xwidget.NewAppBar(x2.SectionName, c, a.sectionMoreButton)
 		ab.HideBackground = !a.u.IsMobile()
 		a.nav.Push(ab)
@@ -371,7 +370,7 @@ func (a *updateStatus) refreshSections() {
 func (a *updateStatus) refreshDetails() {
 	id := a.currentSectionID
 	if id == -1 || id >= len(a.currentSections) {
-		a.details.Hide()
+		a.sectionStatus.Hide()
 		a.sectionMoreButton.Disable()
 		return
 	}
@@ -380,8 +379,8 @@ func (a *updateStatus) refreshDetails() {
 		a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss.EntityID, ss.SectionID))
 		a.sectionMoreButton.Enable()
 	}
-	a.details.set(ss)
-	a.details.Show()
+	a.sectionStatus.set(ss)
+	a.sectionStatus.Show()
 }
 
 func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []*fyne.MenuItem {
@@ -556,7 +555,7 @@ func (w *sectionItem) set(r app.CacheSectionStatus) {
 	}
 }
 
-type sectionDetails struct {
+type sectionStatus struct {
 	widget.BaseWidget
 
 	completedAt *widget.Label
@@ -565,35 +564,39 @@ type sectionDetails struct {
 	startedAt   *widget.Label
 	status      *widget.Label
 	timeout     *widget.Label
+	isMobile    bool
 }
 
-func newSectionDetails() *sectionDetails {
-	w := &sectionDetails{
+func newSectionStatus(isMobile bool) *sectionStatus {
+	w := &sectionStatus{
 		completedAt: ui.NewLabelWithWrapping(""),
 		issue:       ui.NewLabelWithWrapping(""),
 		nextUpdate:  ui.NewLabelWithWrapping(""),
 		startedAt:   ui.NewLabelWithWrapping(""),
 		status:      ui.NewLabelWithWrapping(""),
 		timeout:     ui.NewLabelWithWrapping(""),
+		isMobile:    isMobile,
 	}
 	w.ExtendBaseWidget(w)
 	return w
 }
 
-func (w *sectionDetails) CreateRenderer() fyne.WidgetRenderer {
-	layout := kxlayout.NewColumns(100)
-	c := container.NewVScroll(container.NewVBox(
-		container.New(layout, widget.NewLabel("Status"), w.status),
-		container.New(layout, widget.NewLabel("Started"), w.startedAt),
-		container.New(layout, widget.NewLabel("Completed"), w.completedAt),
-		container.New(layout, widget.NewLabel("Timeout"), w.timeout),
-		container.New(layout, widget.NewLabel("Next update"), w.nextUpdate),
-		container.New(layout, widget.NewLabel("Issue"), w.issue),
-	))
-	return widget.NewSimpleRenderer(c)
+func (w *sectionStatus) CreateRenderer() fyne.WidgetRenderer {
+	c := widget.NewForm(
+		widget.NewFormItem("Status", w.status),
+		widget.NewFormItem("Started", w.startedAt),
+		widget.NewFormItem("Completed", w.completedAt),
+		widget.NewFormItem("Timeout", w.timeout),
+		widget.NewFormItem("Next update", w.nextUpdate),
+		widget.NewFormItem("Issue", w.issue),
+	)
+	if w.isMobile {
+		c.Orientation = widget.Adaptive
+	}
+	return widget.NewSimpleRenderer(container.NewVScroll(c))
 }
 
-func (w *sectionDetails) set(ss app.CacheSectionStatus) {
+func (w *sectionStatus) set(ss app.CacheSectionStatus) {
 	w.status.Text, w.status.Importance = ss.Display()
 	w.status.Refresh()
 

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -50,7 +50,7 @@ func Show(s baseUI) {
 	}
 	a := newUpdateStatus(s, w)
 	w.SetContent(a)
-	w.Resize(fyne.Size{Width: 400, Height: 600})
+	w.Resize(fyne.Size{Width: 400, Height: 700})
 	w.SetOnClosed(func() {
 		a.stop()
 		if onClosed != nil {
@@ -95,7 +95,7 @@ type updateStatus struct {
 
 	currentEntityID   int
 	currentSectionID  int
-	currentSections   []app.CacheSectionStatus
+	entitySections    []app.CacheSectionStatus
 	entities          []entity
 	entityList        *widget.List
 	entityMoreButton  *kxwidget.IconButton
@@ -131,8 +131,10 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 				if err != nil {
 					slog.Error("update status", "error", err)
 					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
+					return
 				}
 			}()
+			a.sb.Show("Started updating characters")
 		}),
 		fyne.NewMenuItem("Update all corporations", func() {
 			go func() {
@@ -140,12 +142,36 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 				if err != nil {
 					slog.Error("update status", "error", err)
 					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
+					return
 				}
 			}()
+			a.sb.Show("Started updating corporations")
 
 		}),
-		fyne.NewMenuItem("Update all general topics", func() {
+		fyne.NewMenuItem("Update all general entities", func() {
 			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
+			a.sb.Show("Started updating all general entities")
+		}),
+		fyne.NewMenuItem("Update notifications for all characters", func() {
+			var characterIDs []int64
+			for _, x := range a.entities {
+				if x.category != sectionCharacter {
+					continue
+				}
+				characterIDs = append(characterIDs, x.id)
+			}
+			go func() {
+				ctx := context.Background()
+				for _, id := range characterIDs {
+					go a.u.Character().UpdateCharacterSectionAndRefreshIfNeeded(
+						ctx,
+						id,
+						app.SectionCharacterNotifications,
+						true,
+					)
+				}
+			}()
+			a.sb.Show("Started updating notifications")
 		}),
 	)
 	moreButton := kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), menu)
@@ -255,6 +281,7 @@ func (a *updateStatus) makeEntityMenuItems() []*fyne.MenuItem {
 		default:
 			panic(fmt.Sprintf("makeUpdateAllAction: Undefined category: %v", c.category))
 		}
+		a.sb.Show("Started updating sections")
 	}
 	item := fyne.NewMenuItem("Update all sections", action)
 	return []*fyne.MenuItem{item}
@@ -321,28 +348,27 @@ func (a *updateStatus) makeSectionList() *widget.List {
 	isOfflineMode := a.u.IsOffline()
 	l := widget.NewList(
 		func() int {
-			return len(a.currentSections)
+			return len(a.entitySections)
 		},
 		func() fyne.CanvasObject {
 			return newSectionItem(isOfflineMode)
 		},
 		func(id widget.GridWrapItemID, co fyne.CanvasObject) {
-			if id >= len(a.currentSections) {
+			if id >= len(a.entitySections) {
 				return
 			}
-			co.(*sectionItem).set(a.currentSections[id])
+			co.(*sectionItem).set(a.entitySections[id])
 		},
 	)
 	l.OnSelected = func(id widget.ListItemID) {
-		if id >= len(a.currentSections) {
+		if id >= len(a.entitySections) {
 			l.UnselectAll()
 			return
 		}
 		a.currentSectionID = id
 		a.refreshDetails()
-		x1 := a.entities[a.currentEntityID]
-		x2 := a.currentSections[id]
-		subTitle := widget.NewLabel(fmt.Sprintf("%s > %s", x1.category.name(), x2.EntityName))
+		x2 := a.entitySections[id]
+		subTitle := widget.NewLabel(x2.EntityName)
 		subTitle.TextStyle.Bold = true
 		c := container.NewBorder(subTitle, nil, nil, nil, a.sectionStatus)
 		ab := xwidget.NewAppBar(x2.SectionName, c, a.sectionMoreButton)
@@ -360,47 +386,48 @@ func (a *updateStatus) refreshSections() {
 	se := a.entities[a.currentEntityID]
 	switch se.category {
 	case sectionCharacter:
-		a.currentSections = a.u.StatusCache().ListCharacterSections(se.id)
+		a.entitySections = a.u.StatusCache().ListCharacterSections(se.id)
 	case sectionCorporation:
-		a.currentSections = a.u.StatusCache().ListCorporationSections(se.id)
+		a.entitySections = a.u.StatusCache().ListCorporationSections(se.id)
 	case sectionGeneral:
-		a.currentSections = a.u.StatusCache().ListEveUniverseSections()
+		a.entitySections = a.u.StatusCache().ListEveUniverseSections()
 	}
 	a.sectionList.Refresh()
 }
 
 func (a *updateStatus) refreshDetails() {
 	id := a.currentSectionID
-	if id == -1 || id >= len(a.currentSections) {
+	if id == -1 || id >= len(a.entitySections) {
 		return
 	}
-	ss := a.currentSections[id]
-	a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss.EntityID, ss.SectionID))
+	ss := a.entitySections[id]
+	c := a.entities[a.currentEntityID].category
+	a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss, c))
 	a.sectionStatus.set(ss)
 	a.sectionStatus.Show()
 }
 
-func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []*fyne.MenuItem {
+func (a *updateStatus) makeSectionMenuItems(ss app.CacheSectionStatus, c sectionCategory) []*fyne.MenuItem {
 	items := make([]*fyne.MenuItem, 0)
 	action := func() {
 		ctx := context.Background()
-		c := a.entities[a.currentEntityID]
-		switch c.category {
+		switch c {
 		case sectionGeneral:
 			go a.u.EVEUniverse().UpdateSectionAndRefreshIfNeeded(
-				ctx, app.EveUniverseSection(sectionID), true,
+				ctx, app.EveUniverseSection(ss.SectionID), true,
 			)
 		case sectionCharacter:
 			go a.u.Character().UpdateCharacterSectionAndRefreshIfNeeded(
-				ctx, entityID, app.CharacterSection(sectionID), true,
+				ctx, ss.EntityID, app.CharacterSection(ss.SectionID), true,
 			)
 		case sectionCorporation:
 			go a.u.Corporation().UpdateSectionAndRefreshIfNeeded(
-				ctx, entityID, app.CorporationSection(sectionID), true,
+				ctx, ss.EntityID, app.CorporationSection(ss.SectionID), true,
 			)
 		default:
 			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}
+		a.sb.Show("Started updating section")
 	}
 	item1 := fyne.NewMenuItem("Update section", action)
 	if a.u.IsOffline() {
@@ -408,13 +435,12 @@ func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []
 	}
 	items = append(items, item1)
 	item2 := fyne.NewMenuItem("Copy issue to clipboard", func() {
-		x := a.currentSections[a.currentSectionID]
 		s := fmt.Sprintf(
 			"%s [%d] / %s: %s",
-			x.EntityName,
-			x.EntityID,
-			x.SectionName,
-			x.ErrorMessage,
+			ss.EntityName,
+			ss.EntityID,
+			ss.SectionName,
+			ss.ErrorMessage,
 		)
 		fyne.CurrentApp().Clipboard().SetContent(s)
 		a.sb.Show("Issue copied to clipboard")

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -51,7 +51,7 @@ func Show(s baseUI) {
 	}
 	a := newUpdateStatus(s, w)
 	w.SetContent(a)
-	w.Resize(fyne.Size{Width: 1100, Height: 500})
+	w.Resize(fyne.Size{Width: 400, Height: 600})
 	w.SetOnClosed(func() {
 		a.stop()
 		if onClosed != nil {
@@ -71,8 +71,20 @@ const (
 	sectionHeader
 )
 
+func (sc sectionCategory) name() string {
+	switch sc {
+	case sectionCharacter:
+		return "Characters"
+	case sectionCorporation:
+		return "Corporations"
+	case sectionGeneral:
+		return "General"
+	}
+	return "?"
+}
+
 // An entity which has update sections, e.g. a character
-type sectionEntity struct {
+type entity struct {
 	id       int64
 	name     string
 	category sectionCategory
@@ -82,79 +94,68 @@ type sectionEntity struct {
 type updateStatus struct {
 	widget.BaseWidget
 
-	charactersTop     *widget.Label
 	details           *sectionDetails
-	detailsTop        *widget.Label
-	entities          fyne.CanvasObject
+	entities          []entity
 	entityList        *widget.List
+	entityMoreButton  *kxwidget.IconButton
 	nav               *xwidget.Navigator
-	onEntitySelected  func(int)
-	onSectionSelected func(int)
 	sb                *xwidget.Snackbar
-	sectionEntities   []sectionEntity
 	sectionList       *widget.List
-	sections          []app.CacheSectionStatus
-	sectionsTop       *widget.Label
-	selectedEntityID  int
-	selectedSectionID int
+	sectionMoreButton *kxwidget.IconButton
+	currentSections   []app.CacheSectionStatus
+	currentEntityID   int
+	currentSectionID  int
 	signalKey         string
-	top2              fyne.CanvasObject
-	top3              fyne.CanvasObject
-	updateAllSections *widget.Button
-	updateSection     *widget.Button
 	u                 baseUI
 }
 
 func newUpdateStatus(s baseUI, w fyne.Window) *updateStatus {
 	a := &updateStatus{
-		charactersTop:     ui.NewLabelWithWrapping(""),
-		details:           newSectionDetails(),
-		detailsTop:        ui.NewLabelWithWrapping(""),
-		sb:                xwidget.NewSnackbar(w.Canvas()),
-		sectionsTop:       ui.NewLabelWithWrapping(""),
-		selectedEntityID:  -1,
-		selectedSectionID: -1,
-		signalKey:         s.Signals().UniqueKey(),
-		u:                 s,
+		details:          newSectionDetails(),
+		sb:               xwidget.NewSnackbar(w.Canvas()),
+		currentEntityID:  -1,
+		currentSectionID: -1,
+		signalKey:        s.Signals().UniqueKey(),
+		u:                s,
 	}
 	a.ExtendBaseWidget(a)
 	a.entityList = a.makeEntityList()
-	a.entities = container.NewBorder(
-		container.NewVBox(a.charactersTop, widget.NewSeparator()),
-		nil,
-		nil,
-		nil,
-		a.entityList,
-	)
 
 	a.sectionList = a.makeSectionList()
-	a.updateAllSections = widget.NewButton("Force update all sections", nil)
-	a.updateAllSections.Disable()
-	a.updateSection = widget.NewButton("Force update section", nil)
-	a.updateSection.Disable()
+	a.entityMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
+	a.entityMoreButton.Disable()
+	a.sectionMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
+	a.sectionMoreButton.Disable()
 
-	a.top2 = container.NewVBox(a.sectionsTop, widget.NewSeparator())
-	a.top3 = container.NewVBox(a.detailsTop, widget.NewSeparator())
-	if a.u.IsMobile() {
-		sections := container.NewBorder(a.top2, nil, nil, nil, a.sectionList)
-		details := container.NewBorder(a.top3, nil, nil, nil, a.details)
-		menu := kxwidget.NewIconButtonWithMenu(
-			theme.MoreVerticalIcon(),
-			fyne.NewMenu("", fyne.NewMenuItem(a.updateAllSections.Text, a.makeUpdateAllAction())),
-		)
-		a.onEntitySelected = func(_ int) {
-			a.nav.Push(xwidget.NewAppBar("Sections", sections, menu))
-		}
-		a.onSectionSelected = func(id int) {
-			s := a.sections[id]
-			menu := kxwidget.NewIconButtonWithMenu(
-				theme.MoreVerticalIcon(),
-				fyne.NewMenu(
-					"", fyne.NewMenuItem(a.updateSection.Text, a.makeUpdateSectionAction(s.EntityID, s.SectionID))),
-			)
-			a.nav.Push(xwidget.NewAppBar("Section Detail", details, menu))
-		}
-	}
+	menu := fyne.NewMenu("",
+		fyne.NewMenuItem("Update all characters", func() {
+			go func() {
+				err := a.u.Character().UpdateCharactersIfNeeded(context.Background(), true)
+				if err != nil {
+					slog.Error("update status", "error", err)
+					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
+				}
+			}()
+		}),
+		fyne.NewMenuItem("Update all corporations", func() {
+			go func() {
+				err := a.u.Corporation().UpdateCorporationsIfNeeded(context.Background(), true)
+				if err != nil {
+					slog.Error("update status", "error", err)
+					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
+				}
+			}()
+
+		}),
+		fyne.NewMenuItem("Update all general topics", func() {
+			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
+		}),
+	)
+	ab := xwidget.NewAppBar("Update status", a.entityList, kxwidget.NewIconButtonWithMenu(
+		theme.MoreVerticalIcon(), menu,
+	))
+	ab.HideBackground = !a.u.IsMobile()
+	a.nav = xwidget.NewNavigator(ab)
 
 	// Signals
 	a.sb.Start()
@@ -186,56 +187,14 @@ func (a *updateStatus) stop() {
 }
 
 func (a *updateStatus) CreateRenderer() fyne.WidgetRenderer {
-	updateMenu := fyne.NewMenu("",
-		fyne.NewMenuItem("Update all characters", func() {
-			go func() {
-				err := a.u.Character().UpdateCharactersIfNeeded(context.Background(), true)
-				if err != nil {
-					slog.Error("update status", "error", err)
-					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
-				}
-			}()
-		}),
-		fyne.NewMenuItem("Update all corporations", func() {
-			go func() {
-				err := a.u.Corporation().UpdateCorporationsIfNeeded(context.Background(), true)
-				if err != nil {
-					slog.Error("update status", "error", err)
-					a.sb.Show("Error: " + a.u.ErrorDisplay(err))
-				}
-			}()
-
-		}),
-		fyne.NewMenuItem("Update all general topics", func() {
-			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
-		}),
-	)
-	updateEntities := xwidget.NewContextMenuButton("Force update all entities", updateMenu)
-	var c fyne.CanvasObject
-	if a.u.IsMobile() {
-		ab := xwidget.NewAppBar("Home", a.entities, kxwidget.NewIconButtonWithMenu(
-			theme.MoreVerticalIcon(),
-			updateMenu,
-		))
-		a.nav = xwidget.NewNavigator(ab)
-		c = a.nav
-	} else {
-		sections := container.NewBorder(a.top2, a.updateAllSections, nil, nil, a.sectionList)
-		details := container.NewBorder(a.top3, a.updateSection, nil, nil, a.details)
-		vs := container.NewHSplit(sections, details)
-		vs.SetOffset(0.5)
-		hs := container.NewHSplit(container.NewBorder(nil, updateEntities, nil, nil, a.entities), vs)
-		hs.SetOffset(0.33)
-		c = hs
-	}
-	return widget.NewSimpleRenderer(c)
+	return widget.NewSimpleRenderer(a.nav)
 }
 
 func (a *updateStatus) makeEntityList() *widget.List {
 	isOfflineMode := a.u.IsOffline()
 	list := widget.NewList(
 		func() int {
-			return len(a.sectionEntities)
+			return len(a.entities)
 		},
 		func() fyne.CanvasObject {
 			return newEntityItem(
@@ -245,40 +204,46 @@ func (a *updateStatus) makeEntityList() *widget.List {
 			)
 		},
 		func(id widget.ListItemID, co fyne.CanvasObject) {
-			if id >= len(a.sectionEntities) {
+			if id >= len(a.entities) {
 				return
 			}
-			co.(*entityItem).set(a.sectionEntities[id])
+			co.(*entityItem).set(a.entities[id])
 		})
 
 	list.OnSelected = func(id widget.ListItemID) {
-		if id >= len(a.sectionEntities) || a.sectionEntities[id].category == sectionHeader {
+		if id >= len(a.entities) || a.entities[id].category == sectionHeader {
 			list.UnselectAll()
 			return
 		}
 
-		a.selectedEntityID = id
-		a.selectedSectionID = -1
+		a.currentEntityID = id
+		a.currentSectionID = -1
 		a.sectionList.UnselectAll()
 
 		if !a.u.IsOffline() {
-			a.updateAllSections.OnTapped = a.makeUpdateAllAction()
-			a.updateAllSections.Enable()
+			a.entityMoreButton.SetMenuItems(a.makeEntityMenuItems())
+			a.entityMoreButton.Enable()
 		}
-		if a.onEntitySelected != nil {
-			a.onEntitySelected(id)
-			list.UnselectAll()
-		}
+
+		x := a.entities[id]
+		subTitle := widget.NewLabel(x.category.name())
+		subTitle.TextStyle.Bold = true
+		c := container.NewBorder(subTitle, nil, nil, nil, a.sectionList)
+		ab := xwidget.NewAppBar(x.name, c, a.entityMoreButton)
+		ab.HideBackground = !a.u.IsMobile()
+		a.nav.Push(ab)
+
+		list.UnselectAll()
 		a.refreshSections()
 		a.refreshDetails()
 	}
 	return list
 }
 
-func (a *updateStatus) makeUpdateAllAction() func() {
-	return func() {
+func (a *updateStatus) makeEntityMenuItems() []*fyne.MenuItem {
+	action := func() {
 		ctx := context.Background()
-		c := a.sectionEntities[a.selectedEntityID]
+		c := a.entities[a.currentEntityID]
 		switch c.category {
 		case sectionGeneral:
 			go a.u.EVEUniverse().UpdateSectionsIfNeeded(ctx, true)
@@ -290,30 +255,31 @@ func (a *updateStatus) makeUpdateAllAction() func() {
 			panic(fmt.Sprintf("makeUpdateAllAction: Undefined category: %v", c.category))
 		}
 	}
+	item := fyne.NewMenuItem("Update all sections", action)
+	return []*fyne.MenuItem{item}
 }
 
 func (a *updateStatus) update(ctx context.Context) {
-	entities, count := a.updateEntityList(ctx)
+	entities, _ := a.updateEntityList(ctx)
 
 	fyne.Do(func() {
-		a.sectionEntities = entities
+		a.entities = entities
 		a.entityList.Refresh()
 		a.refreshSections()
-		a.charactersTop.SetText(fmt.Sprintf("Entities: %d", count))
 		a.refreshDetails()
 	})
 }
 
-func (a *updateStatus) updateEntityList(_ context.Context) ([]sectionEntity, int) {
+func (a *updateStatus) updateEntityList(_ context.Context) ([]entity, int) {
 	var count int
-	var entities []sectionEntity
+	var entities []entity
 	cc := a.u.StatusCache().ListCharacters()
 	if len(cc) > 0 {
-		entities = append(entities, sectionEntity{category: sectionHeader, name: "Characters"})
+		entities = append(entities, entity{category: sectionHeader, name: "Characters"})
 		count += len(cc)
 		for _, c := range cc {
 			ss := a.u.StatusCache().CharacterSectionSummary(c.ID)
-			o := sectionEntity{
+			o := entity{
 				category: sectionCharacter,
 				id:       c.ID,
 				name:     c.Name,
@@ -324,11 +290,11 @@ func (a *updateStatus) updateEntityList(_ context.Context) ([]sectionEntity, int
 	}
 	rr := a.u.StatusCache().ListCorporations()
 	if len(rr) > 0 {
-		entities = append(entities, sectionEntity{category: sectionHeader, name: "Corporations"})
+		entities = append(entities, entity{category: sectionHeader, name: "Corporations"})
 		count += len(rr)
 		for _, r := range rr {
 			ss := a.u.StatusCache().CorporationSectionSummary(r.ID)
-			o := sectionEntity{
+			o := entity{
 				category: sectionCorporation,
 				id:       r.ID,
 				name:     r.Name,
@@ -337,9 +303,9 @@ func (a *updateStatus) updateEntityList(_ context.Context) ([]sectionEntity, int
 			entities = append(entities, o)
 		}
 	}
-	entities = append(entities, sectionEntity{category: sectionHeader, name: "General"})
+	entities = append(entities, entity{category: sectionHeader, name: "General"})
 	ss := a.u.StatusCache().EveUniverseSectionSummary()
-	o := sectionEntity{
+	o := entity{
 		category: sectionGeneral,
 		id:       app.EveUniverseSectionEntityID,
 		name:     app.EveUniverseSectionEntityName,
@@ -354,76 +320,74 @@ func (a *updateStatus) makeSectionList() *widget.List {
 	isOfflineMode := a.u.IsOffline()
 	l := widget.NewList(
 		func() int {
-			return len(a.sections)
+			return len(a.currentSections)
 		},
 		func() fyne.CanvasObject {
 			return newSectionItem(isOfflineMode)
 		},
 		func(id widget.GridWrapItemID, co fyne.CanvasObject) {
-			if id >= len(a.sections) {
+			if id >= len(a.currentSections) {
 				return
 			}
-			co.(*sectionItem).set(a.sections[id])
+			co.(*sectionItem).set(a.currentSections[id])
 		},
 	)
 	l.OnSelected = func(id widget.ListItemID) {
-		if id >= len(a.sections) {
+		if id >= len(a.currentSections) {
 			l.UnselectAll()
 			return
 		}
-		a.selectedSectionID = id
+		a.currentSectionID = id
 		a.refreshDetails()
-		if a.onSectionSelected != nil {
-			a.onSectionSelected(id)
-			l.UnselectAll()
-		}
+		x1 := a.entities[a.currentEntityID]
+		x2 := a.currentSections[id]
+		subTitle := widget.NewLabel(fmt.Sprintf("%s > %s", x1.category.name(), x2.EntityName))
+		subTitle.TextStyle.Bold = true
+		c := container.NewBorder(subTitle, nil, nil, nil, a.details)
+		ab := xwidget.NewAppBar(x2.SectionName, c, a.sectionMoreButton)
+		ab.HideBackground = !a.u.IsMobile()
+		a.nav.Push(ab)
+		l.UnselectAll()
 	}
 	return l
 }
 
 func (a *updateStatus) refreshSections() {
-	if a.selectedEntityID == -1 || a.selectedEntityID >= len(a.sectionEntities) {
+	if a.currentEntityID == -1 || a.currentEntityID >= len(a.entities) {
 		return
 	}
-	se := a.sectionEntities[a.selectedEntityID]
+	se := a.entities[a.currentEntityID]
 	switch se.category {
 	case sectionCharacter:
-		a.sections = a.u.StatusCache().ListCharacterSections(se.id)
+		a.currentSections = a.u.StatusCache().ListCharacterSections(se.id)
 	case sectionCorporation:
-		a.sections = a.u.StatusCache().ListCorporationSections(se.id)
+		a.currentSections = a.u.StatusCache().ListCorporationSections(se.id)
 	case sectionGeneral:
-		a.sections = a.u.StatusCache().ListEveUniverseSections()
+		a.currentSections = a.u.StatusCache().ListEveUniverseSections()
 	}
 	a.sectionList.Refresh()
-	a.sectionsTop.SetText(fmt.Sprintf("%s: Sections", se.name))
 }
 
 func (a *updateStatus) refreshDetails() {
-	id := a.selectedSectionID
-	if id == -1 || id >= len(a.sections) {
+	id := a.currentSectionID
+	if id == -1 || id >= len(a.currentSections) {
 		a.details.Hide()
-		a.updateSection.Disable()
-		a.detailsTop.SetText("")
+		a.sectionMoreButton.Disable()
 		return
 	}
-	ss := a.sections[id]
-	if ss.EntityName != "" {
-		a.detailsTop.SetText(fmt.Sprintf("%s: %s", ss.EntityName, ss.SectionName))
-	} else {
-		a.detailsTop.SetText("")
-	}
+	ss := a.currentSections[id]
 	if !a.u.IsOffline() {
-		a.updateSection.OnTapped = a.makeUpdateSectionAction(ss.EntityID, ss.SectionID)
-		a.updateSection.Enable()
+		a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss.EntityID, ss.SectionID))
+		a.sectionMoreButton.Enable()
 	}
 	a.details.set(ss)
 	a.details.Show()
 }
 
-func (a *updateStatus) makeUpdateSectionAction(entityID int64, sectionID string) func() {
-	return func() {
+func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []*fyne.MenuItem {
+	action := func() {
 		ctx := context.Background()
-		c := a.sectionEntities[a.selectedEntityID]
+		c := a.entities[a.currentEntityID]
 		switch c.category {
 		case sectionGeneral:
 			go a.u.EVEUniverse().UpdateSectionAndRefreshIfNeeded(
@@ -441,6 +405,8 @@ func (a *updateStatus) makeUpdateSectionAction(entityID int64, sectionID string)
 			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}
 	}
+	item := fyne.NewMenuItem("Update section", action)
+	return []*fyne.MenuItem{item}
 }
 
 type loadFuncAsync func(int64, int, func(fyne.Resource))
@@ -485,7 +451,7 @@ func (w *entityItem) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(c)
 }
 
-func (w *entityItem) set(r sectionEntity) {
+func (w *entityItem) set(r entity) {
 	w.name.Text = r.name
 
 	switch r.category {

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -51,14 +51,16 @@ func Show(s baseUI) {
 	a := newUpdateStatus(s, w)
 	w.SetContent(a)
 	w.Resize(fyne.Size{Width: 400, Height: 700})
+	ctx, cancel := context.WithCancel(context.Background())
 	w.SetOnClosed(func() {
+		cancel()
 		a.stop()
 		if onClosed != nil {
 			onClosed()
 		}
 	})
 	w.Show()
-	go a.update(context.Background())
+	go a.update(ctx)
 }
 
 type sectionCategory uint
@@ -95,15 +97,15 @@ type updateStatus struct {
 
 	currentEntityID   int
 	currentSectionID  int
-	entitySections    []app.CacheSectionStatus
 	entities          []entity
 	entityList        *widget.List
 	entityMoreButton  *kxwidget.IconButton
+	entitySections    []app.CacheSectionStatus
 	nav               *xwidget.Navigator
 	sb                *xwidget.Snackbar
-	sectionStatus     *sectionStatus
 	sectionList       *widget.List
 	sectionMoreButton *kxwidget.IconButton
+	sectionStatus     *sectionStatus
 	signalKey         string
 	u                 baseUI
 }
@@ -118,8 +120,8 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 		u:                u,
 	}
 	a.ExtendBaseWidget(a)
-	a.entityList = a.makeEntityList()
 
+	a.entityList = a.makeEntityList()
 	a.sectionList = a.makeSectionList()
 	a.entityMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
 	a.sectionMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
@@ -152,6 +154,7 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
 			a.sb.Show("Started updating all general entities")
 		}),
+		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Update notifications for all characters", func() {
 			var characterIDs []int64
 			for _, x := range a.entities {
@@ -161,10 +164,9 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 				characterIDs = append(characterIDs, x.id)
 			}
 			go func() {
-				ctx := context.Background()
 				for _, id := range characterIDs {
 					go a.u.Character().UpdateCharacterSectionAndRefreshIfNeeded(
-						ctx,
+						context.Background(),
 						id,
 						app.SectionCharacterNotifications,
 						true,
@@ -269,15 +271,14 @@ func (a *updateStatus) makeEntityList() *widget.List {
 
 func (a *updateStatus) makeEntityMenuItems() []*fyne.MenuItem {
 	action := func() {
-		ctx := context.Background()
 		c := a.entities[a.currentEntityID]
 		switch c.category {
 		case sectionGeneral:
-			go a.u.EVEUniverse().UpdateSectionsIfNeeded(ctx, true)
+			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
 		case sectionCharacter:
-			go a.u.Character().UpdateCharacterAndRefreshIfNeeded(ctx, c.id, true)
+			go a.u.Character().UpdateCharacterAndRefreshIfNeeded(context.Background(), c.id, true)
 		case sectionCorporation:
-			go a.u.Corporation().UpdateCorporationAndRefreshIfNeeded(ctx, c.id, true)
+			go a.u.Corporation().UpdateCorporationAndRefreshIfNeeded(context.Background(), c.id, true)
 		default:
 			panic(fmt.Sprintf("makeUpdateAllAction: Undefined category: %v", c.category))
 		}
@@ -288,8 +289,7 @@ func (a *updateStatus) makeEntityMenuItems() []*fyne.MenuItem {
 }
 
 func (a *updateStatus) update(ctx context.Context) {
-	entities, _ := a.updateEntityList(ctx)
-
+	entities := a.updateEntityList(ctx)
 	fyne.Do(func() {
 		a.entities = entities
 		a.entityList.Refresh()
@@ -298,13 +298,11 @@ func (a *updateStatus) update(ctx context.Context) {
 	})
 }
 
-func (a *updateStatus) updateEntityList(_ context.Context) ([]entity, int) {
-	var count int
+func (a *updateStatus) updateEntityList(_ context.Context) []entity {
 	var entities []entity
 	cc := a.u.StatusCache().ListCharacters()
 	if len(cc) > 0 {
 		entities = append(entities, entity{category: sectionHeader, name: "Characters"})
-		count += len(cc)
 		for _, c := range cc {
 			ss := a.u.StatusCache().CharacterSectionSummary(c.ID)
 			o := entity{
@@ -319,7 +317,6 @@ func (a *updateStatus) updateEntityList(_ context.Context) ([]entity, int) {
 	rr := a.u.StatusCache().ListCorporations()
 	if len(rr) > 0 {
 		entities = append(entities, entity{category: sectionHeader, name: "Corporations"})
-		count += len(rr)
 		for _, r := range rr {
 			ss := a.u.StatusCache().CorporationSectionSummary(r.ID)
 			o := entity{
@@ -340,8 +337,7 @@ func (a *updateStatus) updateEntityList(_ context.Context) ([]entity, int) {
 		ss:       ss,
 	}
 	entities = append(entities, o)
-	count++
-	return entities, count
+	return entities
 }
 
 func (a *updateStatus) makeSectionList() *widget.List {
@@ -410,19 +406,18 @@ func (a *updateStatus) refreshDetails() {
 func (a *updateStatus) makeSectionMenuItems(ss app.CacheSectionStatus, c sectionCategory) []*fyne.MenuItem {
 	items := make([]*fyne.MenuItem, 0)
 	action := func() {
-		ctx := context.Background()
 		switch c {
 		case sectionGeneral:
 			go a.u.EVEUniverse().UpdateSectionAndRefreshIfNeeded(
-				ctx, app.EveUniverseSection(ss.SectionID), true,
+				context.Background(), app.EveUniverseSection(ss.SectionID), true,
 			)
 		case sectionCharacter:
 			go a.u.Character().UpdateCharacterSectionAndRefreshIfNeeded(
-				ctx, ss.EntityID, app.CharacterSection(ss.SectionID), true,
+				context.Background(), ss.EntityID, app.CharacterSection(ss.SectionID), true,
 			)
 		case sectionCorporation:
 			go a.u.Corporation().UpdateSectionAndRefreshIfNeeded(
-				ctx, ss.EntityID, app.CorporationSection(ss.SectionID), true,
+				context.Background(), ss.EntityID, app.CorporationSection(ss.SectionID), true,
 			)
 		default:
 			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -122,9 +122,7 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 
 	a.sectionList = a.makeSectionList()
 	a.entityMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
-	a.entityMoreButton.Disable()
 	a.sectionMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), fyne.NewMenu(""))
-	a.sectionMoreButton.Disable()
 
 	menu := fyne.NewMenu("",
 		fyne.NewMenuItem("Update all characters", func() {
@@ -150,9 +148,11 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 			go a.u.EVEUniverse().UpdateSectionsIfNeeded(context.Background(), true)
 		}),
 	)
-	ab := xwidget.NewAppBar("Update status", a.entityList, kxwidget.NewIconButtonWithMenu(
-		theme.MoreVerticalIcon(), menu,
-	))
+	moreButton := kxwidget.NewIconButtonWithMenu(theme.MoreVerticalIcon(), menu)
+	if a.u.IsOffline() {
+		moreButton.Disable()
+	}
+	ab := xwidget.NewAppBar("Update status", a.entityList, moreButton)
 	ab.HideBackground = !a.u.IsMobile()
 	a.nav = xwidget.NewNavigator(ab)
 
@@ -219,8 +219,10 @@ func (a *updateStatus) makeEntityList() *widget.List {
 		a.currentSectionID = -1
 		a.sectionList.UnselectAll()
 
-		if !a.u.IsOffline() {
-			a.entityMoreButton.SetMenuItems(a.makeEntityMenuItems())
+		a.entityMoreButton.SetMenuItems(a.makeEntityMenuItems())
+		if a.u.IsOffline() {
+			a.entityMoreButton.Disable()
+		} else {
 			a.entityMoreButton.Enable()
 		}
 
@@ -370,20 +372,16 @@ func (a *updateStatus) refreshSections() {
 func (a *updateStatus) refreshDetails() {
 	id := a.currentSectionID
 	if id == -1 || id >= len(a.currentSections) {
-		a.sectionStatus.Hide()
-		a.sectionMoreButton.Disable()
 		return
 	}
 	ss := a.currentSections[id]
-	if !a.u.IsOffline() {
-		a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss.EntityID, ss.SectionID))
-		a.sectionMoreButton.Enable()
-	}
+	a.sectionMoreButton.SetMenuItems(a.makeSectionMenuItems(ss.EntityID, ss.SectionID))
 	a.sectionStatus.set(ss)
 	a.sectionStatus.Show()
 }
 
 func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []*fyne.MenuItem {
+	items := make([]*fyne.MenuItem, 0)
 	action := func() {
 		ctx := context.Background()
 		c := a.entities[a.currentEntityID]
@@ -404,8 +402,25 @@ func (a *updateStatus) makeSectionMenuItems(entityID int64, sectionID string) []
 			slog.Error("makeUpdateAllAction: Undefined category", "entity", c)
 		}
 	}
-	item := fyne.NewMenuItem("Update section", action)
-	return []*fyne.MenuItem{item}
+	item1 := fyne.NewMenuItem("Update section", action)
+	if a.u.IsOffline() {
+		item1.Disabled = true
+	}
+	items = append(items, item1)
+	item2 := fyne.NewMenuItem("Copy issue to clipboard", func() {
+		x := a.currentSections[a.currentSectionID]
+		s := fmt.Sprintf(
+			"%s [%d] / %s: %s",
+			x.EntityName,
+			x.EntityID,
+			x.SectionName,
+			x.ErrorMessage,
+		)
+		fyne.CurrentApp().Clipboard().SetContent(s)
+		a.sb.Show("Issue copied to clipboard")
+	})
+	items = append(items, item2)
+	return items
 }
 
 type loadFuncAsync func(int64, int, func(fyne.Resource))


### PR DESCRIPTION
- Overhauled the update status window
  - Same design for desktop and mobile
  - Special actions (e.g. update a section) can now be found in overflow menus
  - User feedback via snackbar for all actions
- Added action to update all notifications
- Added action to copy an issue to the clipboard

## Example screenshot

<img width="540" height="965" alt="Screenshot from 2026-08-07 22-48-14" src="https://github.com/user-attachments/assets/a6afaed0-c9a1-477b-b30c-5459fd67baac" />

