### PR TITLE
feat: improve tree widget

### DIFF
--- a/internal/app/asset/node.go
+++ b/internal/app/asset/node.go
@@ -1,8 +1,10 @@
 package asset
 
 import (
+	"fmt"
 	"iter"
 	"slices"
+	"sync/atomic"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
@@ -74,11 +76,15 @@ func (c NodeCategory) String() string {
 	return "?"
 }
 
+// sequence provides a sequence of unique numbers for custom categories.
+var sequence atomic.Int64
+
 // Node is a node in an asset tree.
 // A node can represent an Eve asset, an Eve location or a custom node.
 type Node struct {
 	category    NodeCategory
 	children    []*Node
+	id          int64
 	isContainer bool
 	isExcluded  bool
 	isShip      bool
@@ -91,11 +97,13 @@ func newLocationNode(location *app.EveLocation) *Node {
 	if location == nil {
 		panic("must provide a location")
 	}
-	return &Node{
+	n := &Node{
 		category:    NodeLocation,
-		location:    location,
+		id:          location.ID,
 		isContainer: true,
+		location:    location,
 	}
+	return n
 }
 
 func newAssetNode(it Item) *Node {
@@ -108,8 +116,9 @@ func newAssetNode(it Item) *Node {
 	}
 	n := &Node{
 		category:    c,
-		item:        it,
+		id:          it.ID(),
 		isContainer: as.IsContainer(),
+		item:        it,
 	}
 	if as.Type != nil {
 		n.isShip = as.Type.IsShip()
@@ -122,10 +131,12 @@ func newCustomNode(category NodeCategory) *Node {
 	case NodeAsset, NodeLocation, NodeUndefined:
 		panic("invalid category for custom node: " + category.String())
 	}
-	return &Node{
+	n := &Node{
+		id:          sequence.Add(1),
 		category:    category,
 		isContainer: true,
 	}
+	return n
 }
 
 // All returns an iterator over all nodes of a sub tree.
@@ -246,19 +257,20 @@ func (n *Node) ChildrenCount() int {
 	return count
 }
 
-// ID returns the ID of the node. This is the item ID or the location ID.
-// Returns 0 when node has no ID.
+// ID returns the  ID of the node.
 func (n *Node) ID() int64 {
 	if n == nil {
 		return 0
 	}
-	if n.item != nil {
-		return n.item.ID()
+	return n.id
+}
+
+// UID returns the unique ID of the node. This is used by the tree widget.
+func (n *Node) UID() string {
+	if n == nil {
+		return ""
 	}
-	if n.location != nil {
-		return n.location.ID
-	}
-	return 0
+	return fmt.Sprintf("%d-%d", n.category, n.id)
 }
 
 // IsContainer reports whether this node is a container

--- a/internal/app/asset/node_test.go
+++ b/internal/app/asset/node_test.go
@@ -76,9 +76,9 @@ func TestNode_ID(t *testing.T) {
 		})
 		xassert.Equal(t, 123, n.ID())
 	})
-	t.Run("should return 0 of other nodes", func(t *testing.T) {
+	t.Run("should return non-zero ID for custom nodes", func(t *testing.T) {
 		n := newCustomNode(NodeItemHangar)
-		xassert.Equal(t, 0, n.ID())
+		assert.Greater(t, n.ID(), int64(0))
 	})
 }
 
@@ -121,8 +121,8 @@ func TestNode_CharacterAsset(t *testing.T) {
 
 			got, ok := n.CharacterAsset()
 
-		xassert.Equal(t, tt.wantOk, ok)
-		xassert.Equal(t, tt.wantAsset, got)
+			xassert.Equal(t, tt.wantOk, ok)
+			xassert.Equal(t, tt.wantAsset, got)
 		})
 	}
 }
@@ -166,8 +166,8 @@ func TestNode_CorporationAsset(t *testing.T) {
 
 			got, ok := n.CorporationAsset()
 
-		xassert.Equal(t, tt.wantOk, ok)
-		xassert.Equal(t, tt.wantAsset, got)
+			xassert.Equal(t, tt.wantOk, ok)
+			xassert.Equal(t, tt.wantAsset, got)
 		})
 	}
 }

--- a/internal/app/ui/assets/browser.go
+++ b/internal/app/ui/assets/browser.go
@@ -221,7 +221,7 @@ func (n containerNode) String() string {
 }
 
 type filteredTree struct {
-	td         xwidget.TreeData[containerNode]
+	td         *xwidget.TreeData[containerNode]
 	nodeLookup map[*asset.Node]*containerNode
 }
 
@@ -398,10 +398,9 @@ func (w *navItem) set(name string, count optional.Optional[int]) {
 	w.count.SetText(s)
 }
 
-func generateTreeData(trees []*asset.Node, filter assetFilter, isCorporation bool) xwidget.TreeData[containerNode] {
-	var td xwidget.TreeData[containerNode]
-
-	addNodes(&td, nil, trees, filter, isCorporation)
+func generateTreeData(trees []*asset.Node, filter assetFilter, isCorporation bool) *xwidget.TreeData[containerNode] {
+	td := xwidget.NewTreeData[containerNode]()
+	addNodes(td, nil, trees, filter, isCorporation)
 	updateItemCounts(td)
 	return td
 }
@@ -493,7 +492,7 @@ func addNodes(td *xwidget.TreeData[containerNode], parent *containerNode, nodes 
 	}
 }
 
-func updateItemCounts(td xwidget.TreeData[containerNode]) {
+func updateItemCounts(td *xwidget.TreeData[containerNode]) {
 	td.Walk(nil, func(n *containerNode) bool {
 		if k := n.node.ChildrenCount(); k > 0 && !n.node.IsShip() {
 			n.itemCount.Set(k)
@@ -545,7 +544,7 @@ func (a *browserNavigation) filterLocationsAsync() {
 	search := strings.ToLower(a.search.Text)
 
 	go func() {
-		var td xwidget.TreeData[containerNode]
+		var td *xwidget.TreeData[containerNode]
 		if len(search) > 1 {
 			td = ft.td.Clone()
 			td.DeleteChildrenFunc(nil, func(n *containerNode) bool {

--- a/internal/app/ui/assets/browser.go
+++ b/internal/app/ui/assets/browser.go
@@ -220,6 +220,13 @@ func (n containerNode) String() string {
 	return n.node.String()
 }
 
+func (n containerNode) UID() widget.TreeNodeID {
+	if n.node == nil {
+		return ""
+	}
+	return n.node.UID()
+}
+
 type filteredTree struct {
 	td         *xwidget.TreeData[containerNode]
 	nodeLookup map[*asset.Node]*containerNode

--- a/internal/app/ui/assets/browser_internal_test.go
+++ b/internal/app/ui/assets/browser_internal_test.go
@@ -527,7 +527,7 @@ func TestGenerateTreeData_Corporation(t *testing.T) {
 
 var sequence atomic.Int64
 
-func makeCountsPath(ac asset.Tree, td iwidget.TreeData[containerNode], it asset.Item) []int {
+func makeCountsPath(ac asset.Tree, td *iwidget.TreeData[containerNode], it asset.Item) []int {
 	n, ok := ac.Node(it.ID())
 	if !ok {
 		return nil
@@ -541,7 +541,7 @@ func makeCountsPath(ac asset.Tree, td iwidget.TreeData[containerNode], it asset.
 	})
 }
 
-func findContainer(td iwidget.TreeData[containerNode], node *asset.Node) (*containerNode, bool) {
+func findContainer(td *iwidget.TreeData[containerNode], node *asset.Node) (*containerNode, bool) {
 	var found *containerNode
 	td.Walk(nil, func(n *containerNode) bool {
 		if n.node == node {
@@ -671,7 +671,7 @@ func createAsset(arg assetParams) app.Asset {
 // 	})
 // }
 
-func allPaths(td iwidget.TreeData[containerNode]) [][]string {
+func allPaths(td *iwidget.TreeData[containerNode]) [][]string {
 	return td.AllPaths(nil, func(n *containerNode) string {
 		return n.String()
 	})

--- a/internal/app/ui/characters/mails.go
+++ b/internal/app/ui/characters/mails.go
@@ -331,11 +331,12 @@ func (a *Mails) updateDownloaded(ctx context.Context) {
 	})
 }
 
-func (a *Mails) fetchFolders(ctx context.Context, characterID int64) (xwidget.TreeData[mailFolderNode], *mailFolderNode, error) {
-	var td xwidget.TreeData[mailFolderNode]
+func (a *Mails) fetchFolders(ctx context.Context, characterID int64) (*xwidget.TreeData[mailFolderNode], *mailFolderNode, error) {
 	if characterID == 0 {
-		return td, nil, nil
+		return nil, nil, nil
 	}
+
+	td := xwidget.NewTreeData[mailFolderNode]()
 
 	// Add unread folder
 	err := td.Add(nil, &mailFolderNode{
@@ -462,7 +463,7 @@ func (a *Mails) updateUnreadCounts(ctx context.Context) {
 	})
 }
 
-func (a *Mails) updateCountsInTree(ctx context.Context, characterID int64, td xwidget.TreeData[mailFolderNode]) (int, error) {
+func (a *Mails) updateCountsInTree(ctx context.Context, characterID int64, td *xwidget.TreeData[mailFolderNode]) (int, error) {
 	if td.IsEmpty() {
 		return 0, nil
 	}

--- a/internal/app/ui/characters/mails.go
+++ b/internal/app/ui/characters/mails.go
@@ -61,16 +61,16 @@ type mailFolderNode struct {
 	UnreadCount int
 }
 
-func (f mailFolderNode) IsEmpty() bool {
-	return f.CharacterID == 0
+func (n *mailFolderNode) IsEmpty() bool {
+	return n.CharacterID == 0
 }
 
-func (f mailFolderNode) isBranch() bool {
-	return f.Category == nodeCategoryBranch
+func (n *mailFolderNode) isBranch() bool {
+	return n.Category == nodeCategoryBranch
 }
 
-func (f mailFolderNode) icon() fyne.Resource {
-	switch f.Type {
+func (n *mailFolderNode) icon() fyne.Resource {
+	switch n.Type {
 	case folderNodeInbox:
 		return theme.DownloadIcon()
 	case folderNodeSent:
@@ -79,6 +79,10 @@ func (f mailFolderNode) icon() fyne.Resource {
 		return theme.DeleteIcon()
 	}
 	return theme.FolderIcon()
+}
+
+func (n mailFolderNode) UID() widget.TreeNodeID {
+	return fmt.Sprintf("%d-%d-%d", n.CharacterID, n.Type, n.ObjID)
 }
 
 type Mails struct {

--- a/internal/app/ui/clones/augmentations.go
+++ b/internal/app/ui/clones/augmentations.go
@@ -34,8 +34,12 @@ type augmentationNode struct {
 	tags                   set.Set[string]
 }
 
-func (n augmentationNode) IsTop() bool {
+func (n *augmentationNode) IsTop() bool {
 	return n.implantTypeID == 0
+}
+
+func (n augmentationNode) UID() widget.TreeNodeID {
+	return fmt.Sprintf("%d-%d", n.characterID, n.implantTypeID)
 }
 
 const (

--- a/internal/app/ui/clones/augmentations.go
+++ b/internal/app/ui/clones/augmentations.go
@@ -51,7 +51,7 @@ type Augmentations struct {
 	selectImplants   *kxwidget.FilterChipSelect
 	selectTag        *kxwidget.FilterChipSelect
 	tree             *xwidget.Tree[augmentationNode]
-	treeData         xwidget.TreeData[augmentationNode]
+	treeData         *xwidget.TreeData[augmentationNode]
 	u                baseUI
 }
 
@@ -213,11 +213,10 @@ func (a *Augmentations) update(ctx context.Context) {
 	})
 }
 
-func (a *Augmentations) fetchData(ctx context.Context) (xwidget.TreeData[augmentationNode], error) {
-	var td xwidget.TreeData[augmentationNode]
+func (a *Augmentations) fetchData(ctx context.Context) (*xwidget.TreeData[augmentationNode], error) {
 	characters, err := a.u.Character().CharacterNames(ctx)
 	if err != nil {
-		return td, err
+		return nil, err
 	}
 	characterImplants := make(map[int64][]*app.CharacterImplant)
 	for id := range characters {
@@ -225,7 +224,7 @@ func (a *Augmentations) fetchData(ctx context.Context) (xwidget.TreeData[augment
 	}
 	implants, err := a.u.Character().ListAllImplants(ctx)
 	if err != nil {
-		return td, err
+		return nil, err
 	}
 	for _, im := range implants {
 		characterImplants[im.CharacterID] = append(characterImplants[im.CharacterID], im)
@@ -236,6 +235,7 @@ func (a *Augmentations) fetchData(ctx context.Context) (xwidget.TreeData[augment
 		})
 	}
 
+	td := xwidget.NewTreeData[augmentationNode]()
 	for characterID, implants := range characterImplants {
 		tags, err := a.u.Character().ListTagsForCharacter(ctx, characterID)
 		if err != nil {

--- a/internal/app/ui/clones/characterclones.go
+++ b/internal/app/ui/clones/characterclones.go
@@ -38,15 +38,12 @@ type characterCloneNode struct {
 	systemSecurityValue    float32
 }
 
-func (n characterCloneNode) isTop() bool {
+func (n *characterCloneNode) isTop() bool {
 	return n.implantTypeID == 0
 }
 
 func (n characterCloneNode) UID() widget.TreeNodeID {
-	if n.jumpCloneID == 0 {
-		panic("some IDs are not set")
-	}
-	return fmt.Sprintf("%d-%d", n.jumpCloneID, n.implantTypeID)
+	return fmt.Sprintf("%d-%d-%d", n.characterID, n.jumpCloneID, n.implantTypeID)
 }
 
 type CharacterClones struct {

--- a/internal/app/ui/clones/characterclones.go
+++ b/internal/app/ui/clones/characterclones.go
@@ -148,12 +148,13 @@ func (a *CharacterClones) update(ctx context.Context) {
 	})
 }
 
-func (a *CharacterClones) fetchData(ctx context.Context, characterID int64) (xwidget.TreeData[characterCloneNode], error) {
-	var td xwidget.TreeData[characterCloneNode]
+func (a *CharacterClones) fetchData(ctx context.Context, characterID int64) (*xwidget.TreeData[characterCloneNode], error) {
 	clones, err := a.u.Character().ListJumpClones(ctx, characterID)
 	if err != nil {
-		return td, err
+		return nil, err
 	}
+
+	td := xwidget.NewTreeData[characterCloneNode]()
 	for _, c := range clones {
 		clone := &characterCloneNode{
 			characterID:   characterID,

--- a/internal/app/ui/gamesearch/gamesearch.go
+++ b/internal/app/ui/gamesearch/gamesearch.go
@@ -47,21 +47,25 @@ type baseUI interface {
 	Signals() *app.Signals
 }
 
-type resultNode struct {
+type searchResultNode struct {
 	category app.SearchCategory
 	count    int
 	ee       *app.EveEntity
 }
 
-func (sn resultNode) isCategory() bool {
-	return sn.ee == nil
+func (r *searchResultNode) isCategory() bool {
+	return r.ee == nil
 }
 
-func (sn resultNode) String() string {
-	if sn.isCategory() {
-		return fmt.Sprintf("%s (%d)", sn.category.String(), sn.count)
+func (r searchResultNode) String() string {
+	if r.isCategory() {
+		return fmt.Sprintf("%s (%d)", r.category.String(), r.count)
 	}
-	return sn.ee.Name
+	return r.ee.Name
+}
+
+func (r searchResultNode) UID() widget.TreeNodeID {
+	return fmt.Sprintf("%s-%d", r.category, r.ee.IDOrZero())
 }
 
 type GameSearch struct {
@@ -76,7 +80,7 @@ type GameSearch struct {
 	recentItems         []*app.EveEntity
 	recentPage          *fyne.Container
 	resultCount         *widget.Label
-	results             *xwidget.Tree[resultNode]
+	results             *xwidget.Tree[searchResultNode]
 	resultsPage         *fyne.Container
 	searchOptions       *widget.Accordion
 	strict              *kxwidget.Switch
@@ -295,7 +299,7 @@ func (a *GameSearch) loadIconFunc() func(o *app.EveEntity, setIcon func(r fyne.R
 	}
 }
 
-func (a *GameSearch) makeResults() *xwidget.Tree[resultNode] {
+func (a *GameSearch) makeResults() *xwidget.Tree[searchResultNode] {
 	t := xwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			if isBranch {
@@ -303,7 +307,7 @@ func (a *GameSearch) makeResults() *xwidget.Tree[resultNode] {
 			}
 			return newSearchResult(a.loadIconFunc(), a.supportedCategories)
 		},
-		func(n *resultNode, isBranch bool, co fyne.CanvasObject) {
+		func(n *searchResultNode, isBranch bool, co fyne.CanvasObject) {
 			if isBranch {
 				co.(*widget.Label).SetText(n.String())
 				return
@@ -311,7 +315,7 @@ func (a *GameSearch) makeResults() *xwidget.Tree[resultNode] {
 			co.(*searchResult).set(n.ee)
 		},
 	)
-	t.OnSelectedNode = func(n *resultNode) {
+	t.OnSelectedNode = func(n *searchResultNode) {
 		defer t.UnselectAll()
 		if n.isCategory() {
 			t.ToggleBranchNode(n)
@@ -440,7 +444,7 @@ func (a *GameSearch) DoSearch(ctx context.Context, search string) {
 	if total == 0 {
 		return
 	}
-	td := xwidget.NewTreeData[resultNode]()
+	td := xwidget.NewTreeData[searchResultNode]()
 	var categoriesFound int
 	for _, c := range categories {
 		items, ok := results[c]
@@ -449,15 +453,19 @@ func (a *GameSearch) DoSearch(ctx context.Context, search string) {
 		}
 		categoriesFound++
 		itemsCount := len(items)
-		category := &resultNode{category: c, count: itemsCount}
+		category := &searchResultNode{category: c, count: itemsCount}
 		err := td.Add(nil, category, itemsCount > 0)
 		if err != nil {
-			slog.Error("game search: adding node", "node", category)
+			slog.Error("game search: adding category node", "node", category)
 			continue
 		}
 		for _, o := range items {
-			entity := &resultNode{ee: o}
-			td.Add(category, entity, false)
+			entity := &searchResultNode{ee: o}
+			err := td.Add(category, entity, false)
+			if err != nil {
+				slog.Error("game search: adding item node", "node", category)
+				continue
+			}
 		}
 	}
 	fyne.Do(func() {

--- a/internal/app/ui/gamesearch/gamesearch.go
+++ b/internal/app/ui/gamesearch/gamesearch.go
@@ -440,7 +440,7 @@ func (a *GameSearch) DoSearch(ctx context.Context, search string) {
 	if total == 0 {
 		return
 	}
-	var td xwidget.TreeData[resultNode]
+	td := xwidget.NewTreeData[resultNode]()
 	var categoriesFound int
 	for _, c := range categories {
 		items, ok := results[c]

--- a/internal/app/ui/wallets/loyaltypoints.go
+++ b/internal/app/ui/wallets/loyaltypoints.go
@@ -34,10 +34,11 @@ type loyaltyPointsNode struct {
 	searchTarget    string
 	totalPoints     int64
 	tags            set.Set[string]
+	isCorporation   bool
 }
 
-func (n loyaltyPointsNode) IsTop() bool {
-	return n.characterID == 0
+func (n loyaltyPointsNode) UID() widget.TreeNodeID {
+	return fmt.Sprintf("%v-%d-%d", n.isCorporation, n.characterID, n.corporationID)
 }
 
 type LoyaltyPoints struct {
@@ -166,7 +167,7 @@ func (a *LoyaltyPoints) makeTree() *xwidget.Tree[loyaltyPointsNode] {
 		},
 		func(n *loyaltyPointsNode, _ bool, co fyne.CanvasObject) {
 			x := co.(*loyaltyPointsListItem)
-			if n.IsTop() {
+			if n.isCorporation {
 				o := &app.EveEntity{
 					Category: app.EveEntityCorporation,
 					ID:       n.corporationID,
@@ -185,7 +186,7 @@ func (a *LoyaltyPoints) makeTree() *xwidget.Tree[loyaltyPointsNode] {
 	)
 	t.OnSelectedNode = func(n *loyaltyPointsNode) {
 		defer t.UnselectAll()
-		if n.IsTop() {
+		if n.isCorporation {
 			t.ToggleBranchNode(n)
 		}
 	}
@@ -331,6 +332,7 @@ func (a *LoyaltyPoints) fetchData(ctx context.Context) (map[*loyaltyPointsNode][
 		k := o.Corporation.ID
 		if corporationEntries[k] == nil {
 			c := &loyaltyPointsNode{
+				isCorporation:   true,
 				corporationID:   o.Corporation.ID,
 				corporationName: o.Corporation.Name,
 				searchTarget:    strings.ToLower(o.Corporation.Name),
@@ -347,6 +349,8 @@ func (a *LoyaltyPoints) fetchData(ctx context.Context) (map[*loyaltyPointsNode][
 	for _, c := range corporations {
 		for _, o := range corporationEntries[c.corporationID] {
 			character := &loyaltyPointsNode{
+				isCorporation: false,
+				corporationID: o.Corporation.ID,
 				characterID:   o.CharacterID,
 				characterName: characterNames[o.CharacterID],
 				points:        o.LoyaltyPoints,

--- a/internal/app/ui/wallets/loyaltypoints.go
+++ b/internal/app/ui/wallets/loyaltypoints.go
@@ -241,7 +241,7 @@ func (a *LoyaltyPoints) filterTreeAsync() {
 		a.columnSorter.SortRows(corporations, sortCol, dir, doSort)
 
 		// build tree
-		var td xwidget.TreeData[loyaltyPointsNode]
+		td := xwidget.NewTreeData[loyaltyPointsNode]()
 		var factionOptions, characterOptions []string
 		var tags set.Set[string]
 		for _, c := range corporations {

--- a/internal/xwidget/tree.go
+++ b/internal/xwidget/tree.go
@@ -92,10 +92,8 @@ func NewTree[T any](
 // Clear removes all nodes of the tree.
 func (w *Tree[T]) Clear() {
 	if w == nil {
-		fyne.LogError("Tree.Clear: nil object", ErrInvalid)
 		return
 	}
-
 	w.td.Clear()
 	w.Refresh()
 }
@@ -202,8 +200,6 @@ func (w *Tree[T]) callWhenFound(n *T, f func(widget.TreeNodeID)) {
 //
 // A tree is constructed by adding nodes to a virtual root node.
 // The root node always exists and is represented by the nil node.
-//
-// The zero value is an empty tree ready to use.
 type TreeData[T any] struct {
 	children  map[widget.TreeNodeID][]widget.TreeNodeID
 	isBranch  map[widget.TreeNodeID]bool
@@ -213,6 +209,7 @@ type TreeData[T any] struct {
 	uidLookup map[*T]widget.TreeNodeID
 }
 
+// NewTreeData returns a new TreeData object.
 func NewTreeData[T any]() *TreeData[T] {
 	td := &TreeData[T]{}
 	td.init()
@@ -293,7 +290,6 @@ func (td *TreeData[T]) ChildrenCount(parent *T) int {
 // Clear removes all nodes.
 func (td *TreeData[T]) Clear() {
 	if td == nil {
-		fyne.LogError("TreeData.Clear: nil object", ErrInvalid)
 		return
 	}
 	if td.IsEmpty() {
@@ -310,7 +306,7 @@ func (td *TreeData[T]) Clone() *TreeData[T] {
 		return nil
 	}
 	t2 := &TreeData[T]{
-		children:  make(map[widget.TreeNodeID][]widget.TreeNodeID),
+		children:  make(map[widget.TreeNodeID][]widget.TreeNodeID, len(td.children)),
 		isBranch:  maps.Clone(td.isBranch),
 		lastID:    td.lastID,
 		nodes:     maps.Clone(td.nodes),
@@ -328,15 +324,15 @@ func (td *TreeData[T]) Clone() *TreeData[T] {
 // The root node can not be removed.
 func (td *TreeData[T]) Delete(node ...*T) error {
 	if td == nil {
-		return fmt.Errorf("TreeData: nil object: %w", ErrInvalid)
+		return fmt.Errorf("TreeData.Delete: nil object: %w", ErrInvalid)
 	}
 	for _, n := range node {
 		if n == nil {
-			return fmt.Errorf("TreeData: can not remove root node: %w", ErrInvalid)
+			return fmt.Errorf("TreeData.Delete: can not remove root node: %w", ErrInvalid)
 		}
 		uid, found := td.uidLookup[n]
 		if !found {
-			return fmt.Errorf("TreeData: uid %s: %w", uid, ErrNotFound)
+			return fmt.Errorf("TreeData.Deletes: %w", ErrNotFound)
 		}
 		td.delete(uid)
 	}
@@ -345,7 +341,6 @@ func (td *TreeData[T]) Delete(node ...*T) error {
 
 func (td *TreeData[T]) delete(uid widget.TreeNodeID) {
 	if td == nil {
-		fyne.LogError("TreeData.delete: : nil object: "+uid, ErrInvalid)
 		return
 	}
 	s, found := td.children[uid]
@@ -369,27 +364,34 @@ func (td *TreeData[T]) delete(uid widget.TreeNodeID) {
 		return x == uid
 	})
 	delete(td.parents, uid)
-	delete(td.nodes, uid)
 	n, found := td.nodes[uid]
 	if found {
 		delete(td.uidLookup, n)
+		delete(td.nodes, uid)
 	}
+	delete(td.isBranch, uid)
 }
 
 // DeleteChildrenFunc removes any nodes from parent for which del returns true.
 // It does nothing when parent is not found.
 func (td *TreeData[T]) DeleteChildrenFunc(parent *T, del func(n *T) bool) {
 	if td == nil {
-		fyne.LogError("TreeData.DeleteChildrenFunc: nil object: ", ErrInvalid)
 		return
 	}
 	uid, ok := td.UID(parent)
 	if !ok {
 		return
 	}
-	td.children[uid] = slices.DeleteFunc(td.children[uid], func(n widget.TreeNodeID) bool {
-		return del(td.nodes[n])
-	})
+	var toDelete []widget.TreeNodeID
+	for _, childUID := range td.children[uid] {
+		if del(td.nodes[childUID]) {
+			toDelete = append(toDelete, childUID)
+		}
+	}
+
+	for _, childUID := range toDelete {
+		td.delete(childUID)
+	}
 }
 
 // Exists reports whether a node exists.
@@ -457,22 +459,25 @@ func (td *TreeData[T]) Path(parent, n *T) []*T {
 	if td == nil || n == nil {
 		return nil
 	}
-	aUID, ok := td.UID(n)
+	a, ok := td.UID(n)
 	if !ok {
 		return nil
 	}
-	bUID, ok := td.UID(parent)
+	b, ok := td.UID(parent)
 	if !ok {
 		return nil
 	}
 	path := []*T{n}
 	for {
-		aUID = td.parents[aUID]
-		if aUID != treeRootID {
-			path = append(path, td.nodes[aUID])
+		a = td.parents[a]
+		if a != treeRootID {
+			path = append(path, td.nodes[a])
 		}
-		if aUID == bUID {
+		if a == b {
 			break
+		}
+		if a == treeRootID {
+			return nil // parent was not an ancestor
 		}
 	}
 	slices.Reverse(path)
@@ -531,8 +536,9 @@ func (td *TreeData[T]) Print(n *T, stringify func(*T) string) {
 		} else {
 			indent += "|  "
 		}
-		for _, id := range td.children[uid] {
-			printTreeData(id, indent, len(td.children[id]) == 0)
+		children := td.children[uid]
+		for i, id := range td.children[uid] {
+			printTreeData(id, indent, i == len(children)-1)
 		}
 	}
 
@@ -545,7 +551,6 @@ func (td *TreeData[T]) Print(n *T, stringify func(*T) string) {
 // It does nothing when parent is not found.
 func (td *TreeData[T]) SortChildrenFunc(parent *T, cmp func(a *T, b *T) int) {
 	if td == nil {
-		fyne.LogError("TreeData.SortChildrenFunc: nil object: ", ErrInvalid)
 		return
 	}
 	uid, ok := td.UID(parent)
@@ -587,7 +592,7 @@ func (td *TreeData[T]) Size() int {
 // Nil represents the root node and is valid.
 func (td *TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
 	if td == nil {
-		return widget.TreeNodeID("invalid"), false
+		return "", false
 	}
 	if node == nil {
 		return treeRootID, true
@@ -605,7 +610,6 @@ func (td *TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
 // Walk does nothing if parent is not found.
 func (td *TreeData[T]) Walk(parent *T, f func(n *T) bool) {
 	if td == nil {
-		fyne.LogError("TreeData.Walk: nil object: ", ErrInvalid)
 		return
 	}
 	var traverse func(widget.TreeNodeID) bool

--- a/internal/xwidget/tree.go
+++ b/internal/xwidget/tree.go
@@ -39,7 +39,7 @@ type Tree[T any] struct {
 	OnSelectedNode     func(n *T) // Called when the given node is selected.
 	OnUnselectedNode   func(n *T) // Called when the given node is unselected.
 
-	td TreeData[T]
+	td *TreeData[T]
 }
 
 // NewTree returns a new Tree2 object.
@@ -48,7 +48,7 @@ func NewTree[T any](
 	update func(n *T, isBranch bool, co fyne.CanvasObject),
 ) *Tree[T] {
 	w := &Tree[T]{
-		td: newTreeData[T](),
+		td: NewTreeData[T](),
 	}
 	w.Root = treeRootID
 	w.ChildUIDs = func(uid widget.TreeNodeID) []widget.TreeNodeID {
@@ -91,17 +91,29 @@ func NewTree[T any](
 
 // Clear removes all nodes of the tree.
 func (w *Tree[T]) Clear() {
+	if w == nil {
+		fyne.LogError("Tree.Clear: nil object", ErrInvalid)
+		return
+	}
+
 	w.td.Clear()
 	w.Refresh()
 }
 
 // Data returns the tree's data.
-func (w *Tree[T]) Data() TreeData[T] {
+func (w *Tree[T]) Data() *TreeData[T] {
+	if w == nil {
+		return nil
+	}
 	return w.td
 }
 
 // Set replaces the tree's data, resets and refreshes it.
-func (w *Tree[T]) Set(data TreeData[T]) {
+func (w *Tree[T]) Set(data *TreeData[T]) {
+	if w == nil {
+		fyne.LogError("Tree.Set: nil object", ErrInvalid)
+		return
+	}
 	w.UnselectAll()
 	w.CloseAllBranches()
 	w.td = data
@@ -113,11 +125,17 @@ func (w *Tree[T]) Set(data TreeData[T]) {
 
 // CloseBranchNode closes the branch of node n.
 func (w *Tree[T]) CloseBranchNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.CloseBranch)
 }
 
 // IsBranchOpenNode reports whether the given branch is expanded.
 func (w *Tree[T]) IsBranchOpenNode(n *T) bool {
+	if w == nil {
+		return false
+	}
 	if uid, ok := w.td.uidLookup[n]; ok {
 		return w.IsBranchOpen(uid)
 	}
@@ -126,31 +144,49 @@ func (w *Tree[T]) IsBranchOpenNode(n *T) bool {
 
 // OpenBranchNode opens the branch of node n.
 func (w *Tree[T]) OpenBranchNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.OpenBranch)
 }
 
 // RefreshNode refreshes the given node.
 func (w *Tree[T]) RefreshNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.RefreshItem)
 }
 
 // ScrollToNode scrolls to node n.
 func (w *Tree[T]) ScrollToNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.ScrollTo)
 }
 
 // SelectNode marks node n to be selected.
 func (w *Tree[T]) SelectNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.Select)
 }
 
 // ToggleBranchNode flips the state of branch node n.
 func (w *Tree[T]) ToggleBranchNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.ToggleBranch)
 }
 
 // UnselectNode marks node n to be not selected.
 func (w *Tree[T]) UnselectNode(n *T) {
+	if w == nil {
+		return
+	}
 	w.callWhenFound(n, w.Unselect)
 }
 
@@ -177,8 +213,8 @@ type TreeData[T any] struct {
 	uidLookup map[*T]widget.TreeNodeID
 }
 
-func newTreeData[T any]() TreeData[T] {
-	td := TreeData[T]{}
+func NewTreeData[T any]() *TreeData[T] {
+	td := &TreeData[T]{}
 	td.init()
 	return td
 }
@@ -226,7 +262,10 @@ func (td *TreeData[T]) Add(parent *T, node *T, isBranch bool) error {
 // Children returns a new slice with the direct children of node parent.
 // The children are returned in the same order as they were added.
 // When parent was not found a nil slice is returned.
-func (td TreeData[T]) Children(parent *T) []*T {
+func (td *TreeData[T]) Children(parent *T) []*T {
+	if td == nil {
+		return nil
+	}
 	uid, ok := td.UID(parent)
 	if !ok {
 		return nil
@@ -240,7 +279,10 @@ func (td TreeData[T]) Children(parent *T) []*T {
 
 // ChildrenCount returns the number of direct children of node parent.
 // It returns 0 when the node is not found.
-func (td TreeData[T]) ChildrenCount(parent *T) int {
+func (td *TreeData[T]) ChildrenCount(parent *T) int {
+	if td == nil {
+		return 0
+	}
 	uid, found := td.UID(parent)
 	if !found {
 		return 0
@@ -251,7 +293,7 @@ func (td TreeData[T]) ChildrenCount(parent *T) int {
 // Clear removes all nodes.
 func (td *TreeData[T]) Clear() {
 	if td == nil {
-		fyne.LogError("Trying to clear a nil tree", ErrInvalid)
+		fyne.LogError("TreeData.Clear: nil object", ErrInvalid)
 		return
 	}
 	if td.IsEmpty() {
@@ -263,8 +305,11 @@ func (td *TreeData[T]) Clear() {
 // Clone returns a shallow copy of the tree data object.
 // A clone can be used to modify the structure of a tree separately
 // and then update the tree widget later in one operation.
-func (td TreeData[T]) Clone() TreeData[T] {
-	t2 := TreeData[T]{
+func (td *TreeData[T]) Clone() *TreeData[T] {
+	if td == nil {
+		return nil
+	}
+	t2 := &TreeData[T]{
 		children:  make(map[widget.TreeNodeID][]widget.TreeNodeID),
 		isBranch:  maps.Clone(td.isBranch),
 		lastID:    td.lastID,
@@ -281,27 +326,34 @@ func (td TreeData[T]) Clone() TreeData[T] {
 // Delete deletes the given nodes including their subtrees.
 // It will return an error if a node can not be deleted.
 // The root node can not be removed.
-func (td TreeData[T]) Delete(node ...*T) error {
+func (td *TreeData[T]) Delete(node ...*T) error {
+	if td == nil {
+		return fmt.Errorf("TreeData: nil object: %w", ErrInvalid)
+	}
 	for _, n := range node {
 		if n == nil {
-			return fmt.Errorf("Delete: can not remove root node: %w", ErrInvalid)
+			return fmt.Errorf("TreeData: can not remove root node: %w", ErrInvalid)
 		}
 		uid, found := td.uidLookup[n]
 		if !found {
-			return fmt.Errorf("Delete: uid %s: %w", uid, ErrNotFound)
+			return fmt.Errorf("TreeData: uid %s: %w", uid, ErrNotFound)
 		}
 		td.delete(uid)
 	}
 	return nil
 }
 
-func (td TreeData[T]) delete(uid widget.TreeNodeID) {
+func (td *TreeData[T]) delete(uid widget.TreeNodeID) {
+	if td == nil {
+		fyne.LogError("TreeData.delete: : nil object: "+uid, ErrInvalid)
+		return
+	}
 	s, found := td.children[uid]
 	if found {
 		s2 := slices.Clone(s)
 		for _, n := range s2 {
 			if n == treeRootID {
-				fyne.LogError("root ID found in children: "+uid, ErrInvalid)
+				fyne.LogError("TreeData.delete: root ID found in children: "+uid, ErrInvalid)
 				return
 			}
 			td.delete(n)
@@ -310,7 +362,7 @@ func (td TreeData[T]) delete(uid widget.TreeNodeID) {
 	}
 	parent, found := td.parents[uid]
 	if !found {
-		fyne.LogError("Parent not found for UID: "+uid, ErrInvalid)
+		fyne.LogError("TreeData.delete: Parent not found for UID: "+uid, ErrInvalid)
 		return
 	}
 	td.children[parent] = slices.DeleteFunc(td.children[parent], func(x widget.TreeNodeID) bool {
@@ -326,7 +378,11 @@ func (td TreeData[T]) delete(uid widget.TreeNodeID) {
 
 // DeleteChildrenFunc removes any nodes from parent for which del returns true.
 // It does nothing when parent is not found.
-func (td TreeData[T]) DeleteChildrenFunc(parent *T, del func(n *T) bool) {
+func (td *TreeData[T]) DeleteChildrenFunc(parent *T, del func(n *T) bool) {
+	if td == nil {
+		fyne.LogError("TreeData.DeleteChildrenFunc: nil object: ", ErrInvalid)
+		return
+	}
 	uid, ok := td.UID(parent)
 	if !ok {
 		return
@@ -338,7 +394,10 @@ func (td TreeData[T]) DeleteChildrenFunc(parent *T, del func(n *T) bool) {
 
 // Exists reports whether a node exists.
 // Nil will also return represents the root node and will also return true.
-func (td TreeData[T]) Exists(node *T) bool {
+func (td *TreeData[T]) Exists(node *T) bool {
+	if td == nil {
+		return false
+	}
 	if node == nil {
 		return true
 	}
@@ -347,11 +406,14 @@ func (td TreeData[T]) Exists(node *T) bool {
 }
 
 // IsEmpty reports whether the tree has any nodes (other then the root node).
-func (td TreeData[T]) IsEmpty() bool {
-	return len(td.nodes) == 0
+func (td *TreeData[T]) IsEmpty() bool {
+	return td == nil || len(td.nodes) == 0
 }
 
-func (td TreeData[T]) IsBranch(node *T) bool {
+func (td *TreeData[T]) IsBranch(node *T) bool {
+	if td == nil {
+		return false
+	}
 	if node == nil {
 		return true // root is always a branch
 	}
@@ -363,7 +425,10 @@ func (td TreeData[T]) IsBranch(node *T) bool {
 
 // Node returns a node by UID and reports whether it was found.
 // The root node will be returned as nil.
-func (td TreeData[T]) Node(uid widget.TreeNodeID) (node *T, ok bool) {
+func (td *TreeData[T]) Node(uid widget.TreeNodeID) (node *T, ok bool) {
+	if td == nil {
+		return nil, false
+	}
 	if uid == treeRootID {
 		return nil, true
 	}
@@ -372,7 +437,10 @@ func (td TreeData[T]) Node(uid widget.TreeNodeID) (node *T, ok bool) {
 }
 
 // Parent returns the parent of a node and reports whether the operation succeeded.
-func (td TreeData[T]) Parent(node *T) (*T, bool) {
+func (td *TreeData[T]) Parent(node *T) (*T, bool) {
+	if td == nil {
+		return nil, false
+	}
 	uid, ok := td.uidLookup[node]
 	if !ok {
 		return nil, false
@@ -385,8 +453,8 @@ func (td TreeData[T]) Parent(node *T) (*T, bool) {
 // The path includes parent (except root) and n.
 // Parent must be an ancestor of n or nil for the root node.
 // Returns a nil slice when no path can be found.
-func (td TreeData[T]) Path(parent, n *T) []*T {
-	if n == nil {
+func (td *TreeData[T]) Path(parent, n *T) []*T {
+	if td == nil || n == nil {
 		return nil
 	}
 	aUID, ok := td.UID(n)
@@ -416,7 +484,10 @@ func (td TreeData[T]) Path(parent, n *T) []*T {
 // This is a type of linearization and can be useful for comparing trees in tests.
 //
 // Will return all paths from root when parent is nil.
-func (td TreeData[T]) AllPaths(parent *T, stringify func(*T) string) [][]string {
+func (td *TreeData[T]) AllPaths(parent *T, stringify func(*T) string) [][]string {
+	if td == nil {
+		return nil
+	}
 	var all [][]string
 	td.Walk(parent, func(n *T) bool {
 		if td.ChildrenCount(n) == 0 {
@@ -433,9 +504,15 @@ func (td TreeData[T]) AllPaths(parent *T, stringify func(*T) string) [][]string 
 
 // Print prints a sub tree of node n to the console using stringify for each node.
 // This can be useful to visualize a tree for debugging.
-func (td TreeData[T]) Print(n *T, stringify func(*T) string) {
+func (td *TreeData[T]) Print(n *T, stringify func(*T) string) {
+	if td == nil {
+		fyne.LogError("TreeData.Print: nil object: ", ErrInvalid)
+		return
+	}
+
 	uid, ok := td.UID(n)
 	if !ok {
+		fyne.LogError("TreeData.Print: node not found: ", ErrInvalid)
 		return
 	}
 
@@ -466,7 +543,11 @@ func (td TreeData[T]) Print(n *T, stringify func(*T) string) {
 // SortChildrenFunc sorts the direct children of parent in ascending order
 // as determined by the cmp function.
 // It does nothing when parent is not found.
-func (td TreeData[T]) SortChildrenFunc(parent *T, cmp func(a *T, b *T) int) {
+func (td *TreeData[T]) SortChildrenFunc(parent *T, cmp func(a *T, b *T) int) {
+	if td == nil {
+		fyne.LogError("TreeData.SortChildrenFunc: nil object: ", ErrInvalid)
+		return
+	}
 	uid, ok := td.UID(parent)
 	if !ok {
 		return
@@ -476,7 +557,10 @@ func (td TreeData[T]) SortChildrenFunc(parent *T, cmp func(a *T, b *T) int) {
 	})
 }
 
-func (td TreeData[T]) SetBranch(node *T, isBranch bool) error {
+func (td *TreeData[T]) SetBranch(node *T, isBranch bool) error {
+	if td == nil {
+		return fmt.Errorf("SetBranch: nil object: %w", ErrInvalid)
+	}
 	if node == nil {
 		return fmt.Errorf("SetBranch: can not set root: %w", ErrInvalid)
 	}
@@ -492,13 +576,19 @@ func (td TreeData[T]) SetBranch(node *T, isBranch bool) error {
 }
 
 // Size returns the number of nodes in the tree excluding the virtual root node.
-func (td TreeData[T]) Size() int {
+func (td *TreeData[T]) Size() int {
+	if td == nil {
+		return 0
+	}
 	return len(td.nodes)
 }
 
 // UID returns the UID for a node and reports whether it was found.
 // Nil represents the root node and is valid.
-func (td TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
+func (td *TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
+	if td == nil {
+		return widget.TreeNodeID("invalid"), false
+	}
 	if node == nil {
 		return treeRootID, true
 	}
@@ -513,7 +603,11 @@ func (td TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
 // The nodes are walked in depth first order.
 // Walk starts at the root when parent is nil.
 // Walk does nothing if parent is not found.
-func (td TreeData[T]) Walk(parent *T, f func(n *T) bool) {
+func (td *TreeData[T]) Walk(parent *T, f func(n *T) bool) {
+	if td == nil {
+		fyne.LogError("TreeData.Walk: nil object: ", ErrInvalid)
+		return
+	}
 	var traverse func(widget.TreeNodeID) bool
 	traverse = func(curr widget.TreeNodeID) bool {
 		if curr != treeRootID {

--- a/internal/xwidget/tree.go
+++ b/internal/xwidget/tree.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/widget"
@@ -15,9 +14,15 @@ const (
 	treeRootID widget.TreeNodeID = "" // UID of the root node in a Tree widget
 )
 
+// A TreeNode for [Tree].
+type TreeNode interface {
+	UID() widget.TreeNodeID
+}
+
 var (
-	ErrInvalid  = errors.New("invalid operation")
-	ErrNotFound = errors.New("not found")
+	ErrInvalid       = errors.New("invalid operation")
+	ErrNotFound      = errors.New("not found")
+	ErrAlreadyExists = errors.New("already exists")
 )
 
 // Tree is an extension of Fyne's Tree widget that allows to create trees from nodes.
@@ -31,7 +36,7 @@ var (
 //
 // Do not set any of the original callbacks as this would disable the functionality
 // of this widget.
-type Tree[T any] struct {
+type Tree[T TreeNode] struct {
 	widget.Tree
 
 	OnBranchClosedNode func(n *T) // Called when a Branch is closed
@@ -43,7 +48,7 @@ type Tree[T any] struct {
 }
 
 // NewTree returns a new Tree2 object.
-func NewTree[T any](
+func NewTree[T TreeNode](
 	create func(isBranch bool) fyne.CanvasObject,
 	update func(n *T, isBranch bool, co fyne.CanvasObject),
 ) *Tree[T] {
@@ -126,7 +131,7 @@ func (w *Tree[T]) CloseBranchNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.CloseBranch)
+	w.CloseBranch(treeNodeUID(n))
 }
 
 // IsBranchOpenNode reports whether the given branch is expanded.
@@ -134,10 +139,7 @@ func (w *Tree[T]) IsBranchOpenNode(n *T) bool {
 	if w == nil {
 		return false
 	}
-	if uid, ok := w.td.uidLookup[n]; ok {
-		return w.IsBranchOpen(uid)
-	}
-	return false
+	return w.IsBranchOpen(treeNodeUID(n))
 }
 
 // OpenBranchNode opens the branch of node n.
@@ -145,7 +147,7 @@ func (w *Tree[T]) OpenBranchNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.OpenBranch)
+	w.OpenBranch(treeNodeUID(n))
 }
 
 // RefreshNode refreshes the given node.
@@ -153,7 +155,7 @@ func (w *Tree[T]) RefreshNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.RefreshItem)
+	w.RefreshItem(treeNodeUID(n))
 }
 
 // ScrollToNode scrolls to node n.
@@ -161,7 +163,7 @@ func (w *Tree[T]) ScrollToNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.ScrollTo)
+	w.ScrollTo(treeNodeUID(n))
 }
 
 // SelectNode marks node n to be selected.
@@ -169,7 +171,7 @@ func (w *Tree[T]) SelectNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.Select)
+	w.Select(treeNodeUID(n))
 }
 
 // ToggleBranchNode flips the state of branch node n.
@@ -177,7 +179,7 @@ func (w *Tree[T]) ToggleBranchNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.ToggleBranch)
+	w.ToggleBranch(treeNodeUID(n))
 }
 
 // UnselectNode marks node n to be not selected.
@@ -185,13 +187,7 @@ func (w *Tree[T]) UnselectNode(n *T) {
 	if w == nil {
 		return
 	}
-	w.callWhenFound(n, w.Unselect)
-}
-
-func (w *Tree[T]) callWhenFound(n *T, f func(widget.TreeNodeID)) {
-	if uid, ok := w.td.uidLookup[n]; ok {
-		f(uid)
-	}
+	w.Unselect(treeNodeUID(n))
 }
 
 // TreeData represents the data for rendering a [Tree] widget
@@ -200,17 +196,15 @@ func (w *Tree[T]) callWhenFound(n *T, f func(widget.TreeNodeID)) {
 //
 // A tree is constructed by adding nodes to a virtual root node.
 // The root node always exists and is represented by the nil node.
-type TreeData[T any] struct {
-	children  map[widget.TreeNodeID][]widget.TreeNodeID
-	isBranch  map[widget.TreeNodeID]bool
-	lastID    int
-	nodes     map[widget.TreeNodeID]*T
-	parents   map[widget.TreeNodeID]widget.TreeNodeID
-	uidLookup map[*T]widget.TreeNodeID
+type TreeData[T TreeNode] struct {
+	children map[widget.TreeNodeID][]widget.TreeNodeID
+	isBranch map[widget.TreeNodeID]bool
+	nodes    map[widget.TreeNodeID]*T
+	parents  map[widget.TreeNodeID]widget.TreeNodeID
 }
 
 // NewTreeData returns a new TreeData object.
-func NewTreeData[T any]() *TreeData[T] {
+func NewTreeData[T TreeNode]() *TreeData[T] {
 	td := &TreeData[T]{}
 	td.init()
 	return td
@@ -218,22 +212,20 @@ func NewTreeData[T any]() *TreeData[T] {
 
 func (td *TreeData[T]) init() {
 	td.children = make(map[widget.TreeNodeID][]widget.TreeNodeID)
-	td.lastID = 0
 	td.isBranch = make(map[widget.TreeNodeID]bool)
 	td.nodes = make(map[widget.TreeNodeID]*T)
 	td.parents = make(map[widget.TreeNodeID]widget.TreeNodeID)
-	td.uidLookup = make(map[*T]widget.TreeNodeID)
 }
 
-// Add adds a node to parent.
-//
+// Add adds a node n to parent.
+// //
 // The order in which nodes are added is preserved.
 // Add performs sanity checks to ensure the resulting tree structure is valid
 // and returns an error when a problem was found.
 //
 // Nodes can be added to the root by providing nil for parent.
-func (td *TreeData[T]) Add(parent *T, node *T, isBranch bool) error {
-	if td == nil || node == nil {
+func (td *TreeData[T]) Add(parent *T, n *T, isBranch bool) error {
+	if td == nil || n == nil {
 		return ErrInvalid
 	}
 	if td.children == nil {
@@ -241,17 +233,18 @@ func (td *TreeData[T]) Add(parent *T, node *T, isBranch bool) error {
 	}
 	parentUID, ok := td.UID(parent)
 	if !ok {
-		return fmt.Errorf("parent not found: %w", ErrNotFound)
+		return fmt.Errorf("TreeData.Add: parent not found: %w", ErrNotFound)
 	}
 	if parentUID != treeRootID && !td.isBranch[parentUID] {
-		return fmt.Errorf("can not add to non-branch: %w", ErrInvalid)
+		return fmt.Errorf("TreeData.Add: parent must be a branch: %w", ErrInvalid)
 	}
-	td.lastID++
-	uid := strconv.Itoa(td.lastID)
+	uid := treeNodeUID(n)
+	if _, found := td.nodes[uid]; found {
+		return fmt.Errorf("TreeData.Add: node %s: %w", uid, ErrAlreadyExists)
+	}
 	td.children[parentUID] = append(td.children[parentUID], uid)
-	td.nodes[uid] = node
+	td.nodes[uid] = n
 	td.parents[uid] = parentUID
-	td.uidLookup[node] = uid
 	td.isBranch[uid] = isBranch
 	return nil
 }
@@ -259,11 +252,11 @@ func (td *TreeData[T]) Add(parent *T, node *T, isBranch bool) error {
 // Children returns a new slice with the direct children of node parent.
 // The children are returned in the same order as they were added.
 // When parent was not found a nil slice is returned.
-func (td *TreeData[T]) Children(parent *T) []*T {
+func (td *TreeData[T]) Children(n *T) []*T {
 	if td == nil {
 		return nil
 	}
-	uid, ok := td.UID(parent)
+	uid, ok := td.UID(n)
 	if !ok {
 		return nil
 	}
@@ -276,11 +269,11 @@ func (td *TreeData[T]) Children(parent *T) []*T {
 
 // ChildrenCount returns the number of direct children of node parent.
 // It returns 0 when the node is not found.
-func (td *TreeData[T]) ChildrenCount(parent *T) int {
+func (td *TreeData[T]) ChildrenCount(n *T) int {
 	if td == nil {
 		return 0
 	}
-	uid, found := td.UID(parent)
+	uid, found := td.UID(n)
 	if !found {
 		return 0
 	}
@@ -306,12 +299,10 @@ func (td *TreeData[T]) Clone() *TreeData[T] {
 		return nil
 	}
 	t2 := &TreeData[T]{
-		children:  make(map[widget.TreeNodeID][]widget.TreeNodeID, len(td.children)),
-		isBranch:  maps.Clone(td.isBranch),
-		lastID:    td.lastID,
-		nodes:     maps.Clone(td.nodes),
-		parents:   maps.Clone(td.parents),
-		uidLookup: maps.Clone(td.uidLookup),
+		children: make(map[widget.TreeNodeID][]widget.TreeNodeID, len(td.children)),
+		isBranch: maps.Clone(td.isBranch),
+		nodes:    maps.Clone(td.nodes),
+		parents:  maps.Clone(td.parents),
 	}
 	for k, v := range td.children {
 		t2.children[k] = slices.Clone(v)
@@ -322,17 +313,17 @@ func (td *TreeData[T]) Clone() *TreeData[T] {
 // Delete deletes the given nodes including their subtrees.
 // It will return an error if a node can not be deleted.
 // The root node can not be removed.
-func (td *TreeData[T]) Delete(node ...*T) error {
+func (td *TreeData[T]) Delete(nodes ...*T) error {
 	if td == nil {
 		return fmt.Errorf("TreeData.Delete: nil object: %w", ErrInvalid)
 	}
-	for _, n := range node {
+	for _, n := range nodes {
 		if n == nil {
 			return fmt.Errorf("TreeData.Delete: can not remove root node: %w", ErrInvalid)
 		}
-		uid, found := td.uidLookup[n]
+		uid, found := td.UID(n)
 		if !found {
-			return fmt.Errorf("TreeData.Deletes: %w", ErrNotFound)
+			return fmt.Errorf("TreeData.Delete: %w", ErrNotFound)
 		}
 		td.delete(uid)
 	}
@@ -364,11 +355,7 @@ func (td *TreeData[T]) delete(uid widget.TreeNodeID) {
 		return x == uid
 	})
 	delete(td.parents, uid)
-	n, found := td.nodes[uid]
-	if found {
-		delete(td.uidLookup, n)
-		delete(td.nodes, uid)
-	}
+	delete(td.nodes, uid)
 	delete(td.isBranch, uid)
 }
 
@@ -396,14 +383,8 @@ func (td *TreeData[T]) DeleteChildrenFunc(parent *T, del func(n *T) bool) {
 
 // Exists reports whether a node exists.
 // Nil will also return represents the root node and will also return true.
-func (td *TreeData[T]) Exists(node *T) bool {
-	if td == nil {
-		return false
-	}
-	if node == nil {
-		return true
-	}
-	_, ok := td.uidLookup[node]
+func (td *TreeData[T]) Exists(n *T) bool {
+	_, ok := td.UID(n)
 	return ok
 }
 
@@ -412,14 +393,14 @@ func (td *TreeData[T]) IsEmpty() bool {
 	return td == nil || len(td.nodes) == 0
 }
 
-func (td *TreeData[T]) IsBranch(node *T) bool {
+func (td *TreeData[T]) IsBranch(n *T) bool {
 	if td == nil {
 		return false
 	}
-	if node == nil {
+	if n == nil {
 		return true // root is always a branch
 	}
-	if uid, ok := td.uidLookup[node]; ok {
+	if uid, ok := td.UID(n); ok {
 		return td.isBranch[uid]
 	}
 	return false
@@ -427,27 +408,30 @@ func (td *TreeData[T]) IsBranch(node *T) bool {
 
 // Node returns a node by UID and reports whether it was found.
 // The root node will be returned as nil.
-func (td *TreeData[T]) Node(uid widget.TreeNodeID) (node *T, ok bool) {
+func (td *TreeData[T]) Node(uid widget.TreeNodeID) (*T, bool) {
 	if td == nil {
 		return nil, false
 	}
 	if uid == treeRootID {
 		return nil, true
 	}
-	node, ok = td.nodes[uid]
-	return
+	n, ok := td.nodes[uid]
+	return n, ok
 }
 
 // Parent returns the parent of a node and reports whether the operation succeeded.
-func (td *TreeData[T]) Parent(node *T) (*T, bool) {
+func (td *TreeData[T]) Parent(n *T) (*T, bool) {
 	if td == nil {
 		return nil, false
 	}
-	uid, ok := td.uidLookup[node]
+	uid, ok := td.UID(n)
 	if !ok {
 		return nil, false
 	}
-	parent := td.parents[uid]
+	parent, ok2 := td.parents[uid]
+	if !ok2 {
+		return nil, false
+	}
 	return td.nodes[parent], true
 }
 
@@ -562,14 +546,14 @@ func (td *TreeData[T]) SortChildrenFunc(parent *T, cmp func(a *T, b *T) int) {
 	})
 }
 
-func (td *TreeData[T]) SetBranch(node *T, isBranch bool) error {
+func (td *TreeData[T]) SetBranch(n *T, isBranch bool) error {
 	if td == nil {
 		return fmt.Errorf("SetBranch: nil object: %w", ErrInvalid)
 	}
-	if node == nil {
+	if n == nil {
 		return fmt.Errorf("SetBranch: can not set root: %w", ErrInvalid)
 	}
-	uid, ok := td.uidLookup[node]
+	uid, ok := td.UID(n)
 	if !ok {
 		return fmt.Errorf("SetBranch: %w", ErrNotFound)
 	}
@@ -588,17 +572,21 @@ func (td *TreeData[T]) Size() int {
 	return len(td.nodes)
 }
 
-// UID returns the UID for a node and reports whether it was found.
-// Nil represents the root node and is valid.
-func (td *TreeData[T]) UID(node *T) (uid widget.TreeNodeID, ok bool) {
+// UID returns the UID of node n when it exists and reports whether it exists.
+// Nil returns the root node.
+func (td *TreeData[T]) UID(n *T) (widget.TreeNodeID, bool) {
 	if td == nil {
 		return "", false
 	}
-	if node == nil {
+	if n == nil {
 		return treeRootID, true
 	}
-	uid, ok = td.uidLookup[node]
-	return
+	uid := treeNodeUID(n)
+	_, ok := td.nodes[uid]
+	if !ok {
+		return "", false
+	}
+	return uid, true
 }
 
 // Walk walks the sub tree of parent, calling f for each node in the tree,
@@ -635,4 +623,13 @@ func (td *TreeData[T]) Walk(parent *T, f func(n *T) bool) {
 		return
 	}
 	traverse(uid)
+}
+
+// treeNodeUID returns the UID for a tree node.
+// It return the root node for nil.
+func treeNodeUID[T TreeNode](n *T) widget.TreeNodeID {
+	if n == nil {
+		return treeRootID
+	}
+	return (*n).UID()
 }

--- a/internal/xwidget/tree_internal_test.go
+++ b/internal/xwidget/tree_internal_test.go
@@ -81,7 +81,7 @@ func TestTreeData_Node(t *testing.T) {
 func TestTreeData_Clone(t *testing.T) {
 	t.Run("can clone a td object", func(t *testing.T) {
 		// given
-		var td TreeData[MyNode2]
+		td := NewTreeData[MyNode2]()
 		top := &MyNode2{"Top"}
 		td.Add(nil, top, true)
 		alpha := &MyNode2{"Alpha"}
@@ -95,7 +95,7 @@ func TestTreeData_Clone(t *testing.T) {
 	})
 	t.Run("can clone a empty td object", func(t *testing.T) {
 		// given
-		td := newTreeData[MyNode2]()
+		td := NewTreeData[MyNode2]()
 		// when
 		got := td.Clone()
 		// then
@@ -103,7 +103,7 @@ func TestTreeData_Clone(t *testing.T) {
 	})
 }
 
-func equalTreeData[T any](t *testing.T, want, got TreeData[T]) {
+func equalTreeData[T any](t *testing.T, want, got *TreeData[T]) {
 	t.Helper()
 	assert.Equal(t, want.children, got.children)
 	assert.Equal(t, want.isBranch, got.isBranch)

--- a/internal/xwidget/tree_internal_test.go
+++ b/internal/xwidget/tree_internal_test.go
@@ -6,10 +6,16 @@ import (
 	"fyne.io/fyne/v2/widget"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
 type MyNode2 struct {
 	Text string
+}
+
+func (n MyNode2) UID() widget.TreeNodeID {
+	return n.Text
 }
 
 func TestTreeData_CanCreateFullTree(t *testing.T) {
@@ -103,12 +109,26 @@ func TestTreeData_Clone(t *testing.T) {
 	})
 }
 
-func equalTreeData[T any](t *testing.T, want, got *TreeData[T]) {
+func equalTreeData[T TreeNode](t *testing.T, want, got *TreeData[T]) {
 	t.Helper()
 	assert.Equal(t, want.children, got.children)
 	assert.Equal(t, want.isBranch, got.isBranch)
-	assert.Equal(t, want.lastID, got.lastID)
 	assert.Equal(t, want.nodes, got.nodes)
 	assert.Equal(t, want.parents, got.parents)
-	assert.Equal(t, want.uidLookup, got.uidLookup)
+}
+
+type node2 struct {
+	uid string
+}
+
+func (n node2) UID() string {
+	return n.uid
+}
+
+func TestTreeData_UID(t *testing.T) {
+	t.Run("should return uid when node note has UID method", func(t *testing.T) {
+		a := node2{uid: "uid"}
+		uid := treeNodeUID(&a)
+		xassert.Equal(t, "uid", uid)
+	})
 }

--- a/internal/xwidget/tree_test.go
+++ b/internal/xwidget/tree_test.go
@@ -373,7 +373,7 @@ func TestTreeData_Parent(t *testing.T) {
 }
 
 func TestTreeData_Path(t *testing.T) {
-	t.Run("should return path for an existing node2", func(t *testing.T) {
+	t.Run("should return path to root and not include root", func(t *testing.T) {
 		td := iwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
@@ -383,6 +383,39 @@ func TestTreeData_Path(t *testing.T) {
 		td.Add(b, c, false)
 		p := td.Path(nil, c)
 		assert.Equal(t, []*Node{a, b, c}, p)
+	})
+	t.Run("should return path when parent is ancestor", func(t *testing.T) {
+		td := iwidget.NewTreeData[Node]()
+		a := &Node{"Alpha"}
+		td.Add(nil, a, true)
+		b := &Node{"Bravo"}
+		td.Add(a, b, true)
+		c := &Node{"Charlie"}
+		td.Add(b, c, false)
+		p := td.Path(a, c)
+		assert.Equal(t, []*Node{a, b, c}, p)
+	})
+	t.Run("should return nil when parent is not ancestor 1", func(t *testing.T) {
+		td := iwidget.NewTreeData[Node]()
+		a := &Node{"Alpha"}
+		td.Add(nil, a, true)
+		b := &Node{"Bravo"}
+		td.Add(a, b, true)
+		c := &Node{"Charlie"}
+		td.Add(b, c, false)
+		p := td.Path(c, b)
+		assert.Empty(t, p)
+	})
+	t.Run("should return nil when parent is not ancestor 2", func(t *testing.T) {
+		td := iwidget.NewTreeData[Node]()
+		a := &Node{"Alpha"}
+		td.Add(nil, a, true)
+		b := &Node{"Bravo"}
+		td.Add(a, b, true)
+		c := &Node{"Charlie"}
+		td.Add(a, c, false)
+		p := td.Path(b, c)
+		assert.Empty(t, p)
 	})
 	t.Run("should return empty slice for root node", func(t *testing.T) {
 		td := iwidget.NewTreeData[Node]()

--- a/internal/xwidget/tree_test.go
+++ b/internal/xwidget/tree_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	iwidget "github.com/ErikKalkoken/evebuddy/internal/xwidget"
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
 type Node struct {
@@ -22,11 +22,44 @@ func (n Node) String() string {
 	return n.Text
 }
 
+func (n Node) UID() widget.TreeNodeID {
+	return n.Text
+}
+
+func ExampleTree() {
+	a := app.New()
+	w := a.NewWindow("Tree Example")
+
+	// Create tree widget
+	tree := xwidget.NewTree(
+		func(_ bool) fyne.CanvasObject {
+			return widget.NewLabel("Template")
+		},
+		func(n *Node, _ bool, co fyne.CanvasObject) {
+			co.(*widget.Label).SetText(n.Text)
+		},
+	)
+
+	// Create tree data
+	td := xwidget.NewTreeData[Node]()
+	top := &Node{"Top"}
+	td.Add(nil, top, true) // adds to root
+	td.Add(top, &Node{"Alpha"}, false)
+	td.Add(top, &Node{"Bravo"}, false)
+
+	// Update tree
+	tree.Set(td)
+
+	w.SetContent(tree)
+	w.Resize(fyne.NewSize(600, 400))
+	w.ShowAndRun()
+}
+
 func TestTree_CanCreate(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())
 
-	tree := iwidget.NewTree(
+	tree := xwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			return widget.NewLabel("Template")
 		},
@@ -34,7 +67,7 @@ func TestTree_CanCreate(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	nodes := iwidget.NewTreeData[Node]()
+	nodes := xwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
@@ -51,7 +84,7 @@ func TestTree_CanCreate(t *testing.T) {
 func TestTree_CanReturnNodes(t *testing.T) {
 	test.NewTempApp(t)
 
-	tree := iwidget.NewTree(
+	tree := xwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			return widget.NewLabel("Template")
 		},
@@ -59,20 +92,20 @@ func TestTree_CanReturnNodes(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	nodes := iwidget.NewTreeData[Node]()
+	nodes := xwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
 	nodes.Add(root, &Node{"Bravo"}, false)
 	tree.Set(nodes)
 
-	assert.IsType(t, &iwidget.TreeData[Node]{}, tree.Data())
+	assert.IsType(t, &xwidget.TreeData[Node]{}, tree.Data())
 }
 
 func TestTree_CanClear(t *testing.T) {
 	test.NewTempApp(t)
 
-	tree := iwidget.NewTree(
+	tree := xwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			return widget.NewLabel("Template")
 		},
@@ -80,7 +113,7 @@ func TestTree_CanClear(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	nodes := iwidget.NewTreeData[Node]()
+	nodes := xwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
@@ -97,7 +130,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())
 
-	tree := iwidget.NewTree(
+	tree := xwidget.NewTree(
 		func(isBranch bool) fyne.CanvasObject {
 			return widget.NewLabel("Template")
 		},
@@ -109,7 +142,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	tree.OnSelectedNode = func(n *Node) {
 		selected = n
 	}
-	nodes := iwidget.NewTreeData[Node]()
+	nodes := xwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	alpha := &Node{"Alpha"}
@@ -124,7 +157,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 
 func TestTreeData_Add(t *testing.T) {
 	t.Run("can add a leaf node to root", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		n := &Node{"Alpha"}
 		err := td.Add(nil, n, false)
 		require.NoError(t, err)
@@ -132,7 +165,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.False(t, td.IsBranch(n))
 	})
 	t.Run("can add a branch node to root", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		n := &Node{"Alpha"}
 		err := td.Add(nil, n, true)
 		require.NoError(t, err)
@@ -140,7 +173,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.True(t, td.IsBranch(n))
 	})
 	t.Run("can add a node to another node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		b := &Node{"Bravo"}
 		err := td.Add(nil, a, true)
@@ -150,30 +183,38 @@ func TestTreeData_Add(t *testing.T) {
 		assert.True(t, td.Exists(b))
 	})
 	t.Run("should return error when parent does not exist", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		err := td.Add(invalid, &Node{"Alpha"}, false)
-		assert.ErrorIs(t, err, iwidget.ErrNotFound)
+		assert.ErrorIs(t, err, xwidget.ErrNotFound)
 	})
 	t.Run("should return error when trying to add a nil node", func(t *testing.T) {
-		var td *iwidget.TreeData[Node]
+		var td *xwidget.TreeData[Node]
 		err := td.Add(nil, nil, true)
-		assert.ErrorIs(t, err, iwidget.ErrInvalid)
+		assert.ErrorIs(t, err, xwidget.ErrInvalid)
 	})
 	t.Run("should return error when trying to add a node to a non-branch", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		b := &Node{"Bravo"}
 		err := td.Add(nil, a, false)
 		require.NoError(t, err)
 		err = td.Add(a, b, false)
-		assert.ErrorIs(t, err, iwidget.ErrInvalid)
+		assert.ErrorIs(t, err, xwidget.ErrInvalid)
+	})
+	t.Run("should return error when trying to add the same node again", func(t *testing.T) {
+		td := xwidget.NewTreeData[Node]()
+		n := &Node{"Alpha"}
+		err := td.Add(nil, n, true)
+		require.NoError(t, err)
+		err2 := td.Add(nil, n, true)
+		assert.ErrorIs(t, err2, xwidget.ErrAlreadyExists)
 	})
 }
 
 func TestTreeData_Children(t *testing.T) {
 	t.Run("can return children of a node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		td.Add(top, &Node{"Alpha"}, false)
@@ -183,7 +224,7 @@ func TestTreeData_Children(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("can return children of root", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		td.Add(top, &Node{"Alpha"}, false)
@@ -193,19 +234,19 @@ func TestTreeData_Children(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("returns empty when a node has no children", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		got := td.Children(top)
 		assert.Len(t, got, 0)
 	})
 	t.Run("the root always exists", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		got := td.Children(nil)
 		assert.Len(t, got, 0)
 	})
 	t.Run("should return empty slice when node was not found", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		got := td.Children(invalid)
 		assert.Len(t, got, 0)
@@ -214,7 +255,7 @@ func TestTreeData_Children(t *testing.T) {
 
 func TestTreeData_ChildrenCount(t *testing.T) {
 	t.Run("can return count for a node2", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		branch1 := &Node{"Branch1"}
 		td.Add(nil, branch1, true)
 		td.Add(branch1, &Node{"Alpha"}, false)
@@ -227,7 +268,7 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 		assert.Equal(t, 2, got)
 	})
 	t.Run("can return count for a root node2", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		branch1 := &Node{"Branch1"}
 		td.Add(nil, branch1, true)
 		td.Add(branch1, &Node{"Alpha"}, false)
@@ -238,12 +279,12 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 		assert.Equal(t, 2, got)
 	})
 	t.Run("can return the count for of an empty td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		got := td.ChildrenCount(nil)
 		assert.Equal(t, 0, got)
 	})
 	t.Run("should return error when node was not found", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		got := td.ChildrenCount(invalid)
 		assert.Equal(t, 0, got)
@@ -252,7 +293,7 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 
 func TestTreeData_Delete(t *testing.T) {
 	t.Run("can remove a node from a simple td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		n2 := &Node{"Bravo"}
@@ -267,7 +308,7 @@ func TestTreeData_Delete(t *testing.T) {
 		assert.ElementsMatch(t, want, []*Node{alpha})
 	})
 	t.Run("can remove node from a complex td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		n1 := &Node{"Branch1"}
 		td.Add(nil, n1, true)
 		td.Add(n1, &Node{"Alpha"}, false)
@@ -291,39 +332,39 @@ func TestTreeData_Delete(t *testing.T) {
 		// t.Fail()
 	})
 	t.Run("can not remove the root node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		err := td.Delete(nil)
-		assert.ErrorIs(t, err, iwidget.ErrInvalid)
+		assert.ErrorIs(t, err, xwidget.ErrInvalid)
 	})
 	t.Run("can not remove a node from an empty td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		err := td.Delete(&Node{})
-		assert.ErrorIs(t, err, iwidget.ErrNotFound)
+		assert.ErrorIs(t, err, xwidget.ErrNotFound)
 	})
 	t.Run("return error when trying to remove non-existing node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		invalid := &Node{}
 		err := td.Delete(invalid)
-		assert.ErrorIs(t, err, iwidget.ErrNotFound)
+		assert.ErrorIs(t, err, xwidget.ErrNotFound)
 	})
 }
 
 func TestTreeData_IsEmpty(t *testing.T) {
 	t.Run("can report non-empty td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Root1"}, true)
 		assert.Equal(t, false, td.IsEmpty())
 	})
 	t.Run("can report empty td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		assert.Equal(t, true, td.IsEmpty())
 	})
 }
 
 func TestTreeData_Node(t *testing.T) {
 	t.Run("should return node2 when it exists", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		n1 := &Node{"Alpha"}
 		td.Add(nil, n1, true)
 		uid, ok := td.UID(n1)
@@ -334,7 +375,7 @@ func TestTreeData_Node(t *testing.T) {
 
 	})
 	t.Run("should report when node does not exist", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		_, ok := td.Node("invalid")
 		assert.False(t, ok)
 	})
@@ -342,7 +383,7 @@ func TestTreeData_Node(t *testing.T) {
 
 func TestTreeData_Parent(t *testing.T) {
 	t.Run("can return parent of a node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		bravo := &Node{"Bravo"}
@@ -352,7 +393,7 @@ func TestTreeData_Parent(t *testing.T) {
 		assert.Equal(t, alpha, p)
 	})
 	t.Run("the parent of a top node is the root node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		p, ok := td.Parent(alpha)
@@ -360,13 +401,13 @@ func TestTreeData_Parent(t *testing.T) {
 		assert.Nil(t, p)
 	})
 	t.Run("can report when a parent does not exist", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		_, ok := td.Parent(invalid)
 		assert.False(t, ok)
 	})
 	t.Run("the root node has no parents", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		_, ok := td.Parent(nil)
 		assert.False(t, ok)
 	})
@@ -374,7 +415,7 @@ func TestTreeData_Parent(t *testing.T) {
 
 func TestTreeData_Path(t *testing.T) {
 	t.Run("should return path to root and not include root", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
 		b := &Node{"Bravo"}
@@ -385,7 +426,7 @@ func TestTreeData_Path(t *testing.T) {
 		assert.Equal(t, []*Node{a, b, c}, p)
 	})
 	t.Run("should return path when parent is ancestor", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
 		b := &Node{"Bravo"}
@@ -396,7 +437,7 @@ func TestTreeData_Path(t *testing.T) {
 		assert.Equal(t, []*Node{a, b, c}, p)
 	})
 	t.Run("should return nil when parent is not ancestor 1", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
 		b := &Node{"Bravo"}
@@ -407,7 +448,7 @@ func TestTreeData_Path(t *testing.T) {
 		assert.Empty(t, p)
 	})
 	t.Run("should return nil when parent is not ancestor 2", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
 		b := &Node{"Bravo"}
@@ -418,14 +459,14 @@ func TestTreeData_Path(t *testing.T) {
 		assert.Empty(t, p)
 	})
 	t.Run("should return empty slice for root node", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		p := td.Path(nil, nil)
 		assert.Empty(t, p)
 	})
 }
 
 func TestTreeData_Values(t *testing.T) {
-	td := iwidget.NewTreeData[Node]()
+	td := xwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	td.Add(nil, root, true)
 	alpha := &Node{"Alpha"}
@@ -444,38 +485,38 @@ func TestTreeData_Values(t *testing.T) {
 
 func TestTreeData_Clear(t *testing.T) {
 	t.Run("can clear td with nodes", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		td.Clear()
 		assert.True(t, td.IsEmpty())
 	})
 	t.Run("can clear empty td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		td.Clear()
 		assert.True(t, td.IsEmpty())
 	})
 	t.Run("can clear nill td", func(t *testing.T) {
-		var td *iwidget.TreeData[Node]
+		var td *xwidget.TreeData[Node]
 		td.Clear()
 	})
 }
 
 func TestTreeData_Size(t *testing.T) {
 	t.Run("can return size of td with nodes", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		got := td.Size()
 		assert.Equal(t, 1, got)
 	})
 	t.Run("can return size of zero td", func(t *testing.T) {
-		td := iwidget.NewTreeData[Node]()
+		td := xwidget.NewTreeData[Node]()
 		got := td.Size()
 		assert.Equal(t, 0, got)
 	})
 }
 
 func TestTreeData_Walk(t *testing.T) {
-	td := iwidget.NewTreeData[Node]()
+	td := xwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -498,7 +539,7 @@ func TestTreeData_Walk(t *testing.T) {
 }
 
 func TestTreeData_AllPaths(t *testing.T) {
-	td := iwidget.NewTreeData[Node]()
+	td := xwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -530,7 +571,7 @@ func TestTreeData_AllPaths(t *testing.T) {
 }
 
 func TestTreeData_SortChildren(t *testing.T) {
-	td := iwidget.NewTreeData[Node]()
+	td := xwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -549,7 +590,7 @@ func TestTreeData_SortChildren(t *testing.T) {
 }
 
 func TestTreeData_DeleteChildren(t *testing.T) {
-	td := iwidget.NewTreeData[Node]()
+	td := xwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -565,33 +606,4 @@ func TestTreeData_DeleteChildren(t *testing.T) {
 	got := td.Children(top)
 	want := []*Node{b}
 	assert.ElementsMatch(t, want, got)
-}
-
-func ExampleTree() {
-	a := app.New()
-	w := a.NewWindow("Tree Example")
-
-	// Create tree widget
-	tree := iwidget.NewTree(
-		func(_ bool) fyne.CanvasObject {
-			return widget.NewLabel("Template")
-		},
-		func(n *Node, _ bool, co fyne.CanvasObject) {
-			co.(*widget.Label).SetText(n.Text)
-		},
-	)
-
-	// Create tree data
-	td := iwidget.NewTreeData[Node]()
-	top := &Node{"Top"}
-	td.Add(nil, top, true) // adds to root
-	td.Add(top, &Node{"Alpha"}, false)
-	td.Add(top, &Node{"Bravo"}, false)
-
-	// Update tree
-	tree.Set(td)
-
-	w.SetContent(tree)
-	w.Resize(fyne.NewSize(600, 400))
-	w.ShowAndRun()
 }

--- a/internal/xwidget/tree_test.go
+++ b/internal/xwidget/tree_test.go
@@ -34,7 +34,7 @@ func TestTree_CanCreate(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	var nodes iwidget.TreeData[Node]
+	nodes := iwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
@@ -59,14 +59,14 @@ func TestTree_CanReturnNodes(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	var nodes iwidget.TreeData[Node]
+	nodes := iwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
 	nodes.Add(root, &Node{"Bravo"}, false)
 	tree.Set(nodes)
 
-	assert.IsType(t, iwidget.TreeData[Node]{}, tree.Data())
+	assert.IsType(t, &iwidget.TreeData[Node]{}, tree.Data())
 }
 
 func TestTree_CanClear(t *testing.T) {
@@ -80,7 +80,7 @@ func TestTree_CanClear(t *testing.T) {
 			co.(*widget.Label).SetText(n.Text)
 		},
 	)
-	var nodes iwidget.TreeData[Node]
+	nodes := iwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	nodes.Add(root, &Node{"Alpha"}, false)
@@ -109,7 +109,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 	tree.OnSelectedNode = func(n *Node) {
 		selected = n
 	}
-	var nodes iwidget.TreeData[Node]
+	nodes := iwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	nodes.Add(nil, root, true)
 	alpha := &Node{"Alpha"}
@@ -124,7 +124,7 @@ func TestTree_OnSelectedNode(t *testing.T) {
 
 func TestTreeData_Add(t *testing.T) {
 	t.Run("can add a leaf node to root", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		n := &Node{"Alpha"}
 		err := td.Add(nil, n, false)
 		require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.False(t, td.IsBranch(n))
 	})
 	t.Run("can add a branch node to root", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		n := &Node{"Alpha"}
 		err := td.Add(nil, n, true)
 		require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.True(t, td.IsBranch(n))
 	})
 	t.Run("can add a node to another node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		b := &Node{"Bravo"}
 		err := td.Add(nil, a, true)
@@ -150,7 +150,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.True(t, td.Exists(b))
 	})
 	t.Run("should return error when parent does not exist", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		err := td.Add(invalid, &Node{"Alpha"}, false)
 		assert.ErrorIs(t, err, iwidget.ErrNotFound)
@@ -161,7 +161,7 @@ func TestTreeData_Add(t *testing.T) {
 		assert.ErrorIs(t, err, iwidget.ErrInvalid)
 	})
 	t.Run("should return error when trying to add a node to a non-branch", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		b := &Node{"Bravo"}
 		err := td.Add(nil, a, false)
@@ -173,7 +173,7 @@ func TestTreeData_Add(t *testing.T) {
 
 func TestTreeData_Children(t *testing.T) {
 	t.Run("can return children of a node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		td.Add(top, &Node{"Alpha"}, false)
@@ -183,7 +183,7 @@ func TestTreeData_Children(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("can return children of root", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		td.Add(top, &Node{"Alpha"}, false)
@@ -193,19 +193,19 @@ func TestTreeData_Children(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("returns empty when a node has no children", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		top := &Node{"Top"}
 		td.Add(nil, top, true)
 		got := td.Children(top)
 		assert.Len(t, got, 0)
 	})
 	t.Run("the root always exists", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		got := td.Children(nil)
 		assert.Len(t, got, 0)
 	})
 	t.Run("should return empty slice when node was not found", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		got := td.Children(invalid)
 		assert.Len(t, got, 0)
@@ -214,7 +214,7 @@ func TestTreeData_Children(t *testing.T) {
 
 func TestTreeData_ChildrenCount(t *testing.T) {
 	t.Run("can return count for a node2", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		branch1 := &Node{"Branch1"}
 		td.Add(nil, branch1, true)
 		td.Add(branch1, &Node{"Alpha"}, false)
@@ -227,7 +227,7 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 		assert.Equal(t, 2, got)
 	})
 	t.Run("can return count for a root node2", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		branch1 := &Node{"Branch1"}
 		td.Add(nil, branch1, true)
 		td.Add(branch1, &Node{"Alpha"}, false)
@@ -238,12 +238,12 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 		assert.Equal(t, 2, got)
 	})
 	t.Run("can return the count for of an empty td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		got := td.ChildrenCount(nil)
 		assert.Equal(t, 0, got)
 	})
 	t.Run("should return error when node was not found", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		got := td.ChildrenCount(invalid)
 		assert.Equal(t, 0, got)
@@ -252,7 +252,7 @@ func TestTreeData_ChildrenCount(t *testing.T) {
 
 func TestTreeData_Delete(t *testing.T) {
 	t.Run("can remove a node from a simple td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		n2 := &Node{"Bravo"}
@@ -267,7 +267,7 @@ func TestTreeData_Delete(t *testing.T) {
 		assert.ElementsMatch(t, want, []*Node{alpha})
 	})
 	t.Run("can remove node from a complex td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		n1 := &Node{"Branch1"}
 		td.Add(nil, n1, true)
 		td.Add(n1, &Node{"Alpha"}, false)
@@ -291,17 +291,17 @@ func TestTreeData_Delete(t *testing.T) {
 		// t.Fail()
 	})
 	t.Run("can not remove the root node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		err := td.Delete(nil)
 		assert.ErrorIs(t, err, iwidget.ErrInvalid)
 	})
 	t.Run("can not remove a node from an empty td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		err := td.Delete(&Node{})
 		assert.ErrorIs(t, err, iwidget.ErrNotFound)
 	})
 	t.Run("return error when trying to remove non-existing node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		invalid := &Node{}
 		err := td.Delete(invalid)
@@ -311,19 +311,19 @@ func TestTreeData_Delete(t *testing.T) {
 
 func TestTreeData_IsEmpty(t *testing.T) {
 	t.Run("can report non-empty td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Root1"}, true)
 		assert.Equal(t, false, td.IsEmpty())
 	})
 	t.Run("can report empty td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		assert.Equal(t, true, td.IsEmpty())
 	})
 }
 
 func TestTreeData_Node(t *testing.T) {
 	t.Run("should return node2 when it exists", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		n1 := &Node{"Alpha"}
 		td.Add(nil, n1, true)
 		uid, ok := td.UID(n1)
@@ -334,7 +334,7 @@ func TestTreeData_Node(t *testing.T) {
 
 	})
 	t.Run("should report when node does not exist", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		_, ok := td.Node("invalid")
 		assert.False(t, ok)
 	})
@@ -342,7 +342,7 @@ func TestTreeData_Node(t *testing.T) {
 
 func TestTreeData_Parent(t *testing.T) {
 	t.Run("can return parent of a node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		bravo := &Node{"Bravo"}
@@ -352,7 +352,7 @@ func TestTreeData_Parent(t *testing.T) {
 		assert.Equal(t, alpha, p)
 	})
 	t.Run("the parent of a top node is the root node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		alpha := &Node{"Alpha"}
 		td.Add(nil, alpha, true)
 		p, ok := td.Parent(alpha)
@@ -360,13 +360,13 @@ func TestTreeData_Parent(t *testing.T) {
 		assert.Nil(t, p)
 	})
 	t.Run("can report when a parent does not exist", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		invalid := &Node{}
 		_, ok := td.Parent(invalid)
 		assert.False(t, ok)
 	})
 	t.Run("the root node has no parents", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		_, ok := td.Parent(nil)
 		assert.False(t, ok)
 	})
@@ -374,7 +374,7 @@ func TestTreeData_Parent(t *testing.T) {
 
 func TestTreeData_Path(t *testing.T) {
 	t.Run("should return path for an existing node2", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		a := &Node{"Alpha"}
 		td.Add(nil, a, true)
 		b := &Node{"Bravo"}
@@ -385,14 +385,14 @@ func TestTreeData_Path(t *testing.T) {
 		assert.Equal(t, []*Node{a, b, c}, p)
 	})
 	t.Run("should return empty slice for root node", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		p := td.Path(nil, nil)
 		assert.Empty(t, p)
 	})
 }
 
 func TestTreeData_Values(t *testing.T) {
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	root := &Node{"Root"}
 	td.Add(nil, root, true)
 	alpha := &Node{"Alpha"}
@@ -411,13 +411,13 @@ func TestTreeData_Values(t *testing.T) {
 
 func TestTreeData_Clear(t *testing.T) {
 	t.Run("can clear td with nodes", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		td.Clear()
 		assert.True(t, td.IsEmpty())
 	})
 	t.Run("can clear empty td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		td.Clear()
 		assert.True(t, td.IsEmpty())
 	})
@@ -429,20 +429,20 @@ func TestTreeData_Clear(t *testing.T) {
 
 func TestTreeData_Size(t *testing.T) {
 	t.Run("can return size of td with nodes", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		td.Add(nil, &Node{"Alpha"}, true)
 		got := td.Size()
 		assert.Equal(t, 1, got)
 	})
 	t.Run("can return size of zero td", func(t *testing.T) {
-		var td iwidget.TreeData[Node]
+		td := iwidget.NewTreeData[Node]()
 		got := td.Size()
 		assert.Equal(t, 0, got)
 	})
 }
 
 func TestTreeData_Walk(t *testing.T) {
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -465,7 +465,7 @@ func TestTreeData_Walk(t *testing.T) {
 }
 
 func TestTreeData_AllPaths(t *testing.T) {
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -497,7 +497,7 @@ func TestTreeData_AllPaths(t *testing.T) {
 }
 
 func TestTreeData_SortChildren(t *testing.T) {
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -516,7 +516,7 @@ func TestTreeData_SortChildren(t *testing.T) {
 }
 
 func TestTreeData_DeleteChildren(t *testing.T) {
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true)
 
@@ -549,7 +549,7 @@ func ExampleTree() {
 	)
 
 	// Create tree data
-	var td iwidget.TreeData[Node]
+	td := iwidget.NewTreeData[Node]()
 	top := &Node{"Top"}
 	td.Add(nil, top, true) // adds to root
 	td.Add(top, &Node{"Alpha"}, false)


### PR DESCRIPTION
This PR improves the `xwidget.Tree` tree widget. The new version provides better identity handling of nodes, which might help fix related issues, e.g. in the asset browser.

- Converted `xwidget.Tree` and `xwidget.TreeData` to pointer structs and most methods to pointer receivers
- Replaced the internal generation of UIDs with a new interface requirement for nodes. That allows different node types to produce their own UIDs and the tree widget can now correctly distinguish which nodes are the same.
- Fixed various bugs in the tree widget
- Added a UID() method to asset.Node so that asset nodes can be identified
- Added UIDs() methods to all node types in the app

Potentially related to #406 