### PR TITLE
fix: update errors on android

### DIFF
--- a/internal/app/characterservice/token.go
+++ b/internal/app/characterservice/token.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
+const tokenTimeout = time.Second * 60
+
 // HasTokenWithScopes reports whether a character's token has the requested scopes.
 func (s *CharacterService) HasTokenWithScopes(ctx context.Context, characterID int64, scopes set.Set[string]) (bool, error) {
 	missing, err := s.MissingScopes(ctx, characterID, scopes)
@@ -70,7 +72,7 @@ func (s *CharacterService) TokenSourceForCorporation(ctx context.Context, corpor
 	if !ok {
 		return nil, 0, app.ErrNotFound
 	}
-	ts := newTokenSource(token, s.ensureValidToken)
+	ts := newTokenSource(ctx, token, s.ensureValidToken)
 	return ts, token.CharacterID, nil
 }
 
@@ -88,14 +90,13 @@ func (s *CharacterService) TokenSource(ctx context.Context, characterID int64, s
 	if err != nil {
 		return nil, fmt.Errorf("create token source: %w", err)
 	}
-	ts := newTokenSource(token, s.ensureValidToken)
+	ts := newTokenSource(ctx, token, s.ensureValidToken)
 	return ts, nil
 }
 
 // ensureValidToken will try to refresh token if it is about to become invalid
 // and report whether it was refreshed.
 func (s *CharacterService) ensureValidToken(ctx context.Context, token *app.CharacterToken) (bool, error) {
-	const tokenTimeout = time.Second * 60
 	if token.RemainsValid(tokenTimeout) {
 		return false, nil
 	}
@@ -138,11 +139,15 @@ func (s *CharacterService) ensureValidToken(ctx context.Context, token *app.Char
 type tokenSource struct {
 	refresher func(context.Context, *app.CharacterToken) (bool, error)
 
+	ctx   context.Context
 	sfg   singleflight.Group
 	token *app.CharacterToken
 }
 
-func newTokenSource(token *app.CharacterToken, refresher func(context.Context, *app.CharacterToken) (bool, error)) *tokenSource {
+func newTokenSource(ctx context.Context, token *app.CharacterToken, refresher func(context.Context, *app.CharacterToken) (bool, error)) *tokenSource {
+	if ctx == nil {
+		panic("Missing context")
+	}
 	if token == nil {
 		panic("Missing token")
 	}
@@ -150,19 +155,17 @@ func newTokenSource(token *app.CharacterToken, refresher func(context.Context, *
 		panic("Missing refresher func")
 	}
 	ts := &tokenSource{
-		token:     token,
+		ctx:       ctx,
 		refresher: refresher,
+		token:     token,
 	}
 	return ts
 }
 
 func (ts *tokenSource) Token() (*oauth2.Token, error) {
-	if ts.token == nil {
-		return nil, fmt.Errorf("tokenSource: no token defined")
-	}
-	o, err, _ := xsingleflight.Do(&ts.sfg, "KEY", func() (*oauth2.Token, error) {
-		if time.Now().After(ts.token.ExpiresAt) {
-			_, err := ts.refresher(context.Background(), ts.token)
+	o, err, _ := xsingleflight.Do(&ts.sfg, "refresh-token", func() (*oauth2.Token, error) {
+		if !ts.token.RemainsValid(tokenTimeout) {
+			_, err := ts.refresher(ts.ctx, ts.token)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/app/characterservice/token_internal_test.go
+++ b/internal/app/characterservice/token_internal_test.go
@@ -89,80 +89,90 @@ func TestTokenSource_New(t *testing.T) {
 		f := func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
 			return false, nil
 		}
-		ts := newTokenSource(token, f)
+		ts := newTokenSource(t.Context(), token, f)
 		xassert.Equal(t, token, ts.token)
 	})
 	t.Run("should panic when trying to create without token", func(t *testing.T) {
 		assert.Panics(t, func() {
-			newTokenSource(nil, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
+			newTokenSource(t.Context(), nil, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
 				return false, nil
 			})
 		})
 	})
 	t.Run("should panic when trying to create without refresher func", func(t *testing.T) {
 		assert.Panics(t, func() {
-			newTokenSource(token, nil)
+			newTokenSource(t.Context(), token, nil)
 		})
 	})
 
 }
 
 func TestTokenSource_Token(t *testing.T) {
-	token := &app.CharacterToken{
-		AccessToken:  "access",
-		CharacterID:  42,
-		ExpiresAt:    time.Now().Add(20 * time.Minute),
-		RefreshToken: "refresh",
-	}
 	t.Run("should return token", func(t *testing.T) {
-		ts := newTokenSource(token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
+		// given
+		token := &app.CharacterToken{
+			AccessToken:  "access",
+			CharacterID:  42,
+			ExpiresAt:    time.Now().Add(20 * time.Minute),
+			RefreshToken: "refresh",
+		}
+		ts := newTokenSource(t.Context(), token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
 			return false, nil
 		})
+
+		// when
 		x, err := ts.Token()
+
+		// then
 		require.NoError(t, err)
 		xassert.Equal(t, x.AccessToken, token.AccessToken)
 		xassert.Equal(t, x.RefreshToken, token.RefreshToken)
 		xassert.Equal(t, x.Expiry, token.ExpiresAt)
 	})
-	t.Run("should return error when no token undefined", func(t *testing.T) {
-		ts := newTokenSource(token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
-			return false, nil
-		})
-		ts.token = nil
-		_, err := ts.Token()
-		require.Error(t, err)
-	})
-	t.Run("should return refreshed token when expired", func(t *testing.T) {
+
+	t.Run("should return refreshed token when about to expire", func(t *testing.T) {
+		// given
 		token := &app.CharacterToken{
 			AccessToken:  "access",
 			CharacterID:  42,
-			ExpiresAt:    time.Now().Add(-1 * time.Minute),
+			ExpiresAt:    time.Now().Add(59 * time.Second),
 			RefreshToken: "refresh",
 		}
 		expiresAt2 := time.Now().Add(20 * time.Minute)
-		ts := newTokenSource(token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
+		refresher := func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
 			ct.AccessToken = "access2"
 			ct.RefreshToken = "refresh2"
 			ct.ExpiresAt = expiresAt2
 			return true, nil
-		})
+		}
+		ts := newTokenSource(t.Context(), token, refresher)
+
+		// when
 		x, err := ts.Token()
+
+		// then
 		require.NoError(t, err)
 		xassert.Equal(t, x.AccessToken, "access2")
 		xassert.Equal(t, x.RefreshToken, "refresh2")
 		xassert.Equal(t, x.Expiry, expiresAt2)
 	})
-	t.Run("should return error when refresh failedr", func(t *testing.T) {
+
+	t.Run("should return error when refresh failed", func(t *testing.T) {
+		// given
 		token := &app.CharacterToken{
 			AccessToken:  "access",
 			CharacterID:  42,
 			ExpiresAt:    time.Now().Add(-1 * time.Minute),
 			RefreshToken: "refresh",
 		}
-		ts := newTokenSource(token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
+		ts := newTokenSource(t.Context(), token, func(ctx context.Context, ct *app.CharacterToken) (bool, error) {
 			return false, fmt.Errorf("some error")
 		})
+
+		// when
 		_, err := ts.Token()
+
+		// then
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
This PR fixes the following error in Android:

## Issue

When the app has been suspending for a while and is re-opening, it often shows a lot of update errors. 
Those errors vanish quickly after a short while. The logs show 401 errors from ESI.

Example:

```
2026/08/17 02:41:34.188109 WARN HTTP response method=GET url=https://esi.evetech.net/corporations/98397665/wallets/3/transactions status="401 Unauthorized" body="map[error:Unauthorized - Invalid token]"
```

## Fix

Tokens are now refreshed in TokenSource when they have less then 1 minute until they expire.
