### PR TITLE
perf: remove additional DB calls when constructing Character objects from storage 

### DIFF
--- a/internal/app/character.go
+++ b/internal/app/character.go
@@ -21,15 +21,15 @@ type Character struct {
 	ContractItemsValue optional.Optional[float64]
 	ContractsEscrow    optional.Optional[float64]
 	EveCharacter       *EveCharacter
-	Home               optional.Optional[*EveLocation]
+	HomeLocationID     optional.Optional[int64]
 	ID                 int64
 	IsTrainingWatched  bool
 	LastCloneJumpAt    optional.Optional[time.Time]
 	LastLoginAt        optional.Optional[time.Time]
-	Location           optional.Optional[*EveLocation]
+	LocationID         optional.Optional[int64]
 	OrderItemsValue    optional.Optional[float64]
 	OrdersEscrow       optional.Optional[float64]
-	Ship               optional.Optional[*EveType]
+	ShipTypeID         optional.Optional[int64]
 	SkillPointsValue   optional.Optional[float64]
 	TrainedSP          optional.Optional[int64]
 	UnallocatedSP      optional.Optional[int64]

--- a/internal/app/characterservice/location_internal_test.go
+++ b/internal/app/characterservice/location_internal_test.go
@@ -49,7 +49,7 @@ func TestCharacterService_UpdateLocationESI(t *testing.T) {
 		assert.True(t, changed)
 		c2, err := s.GetCharacter(ctx, c.ID)
 		require.NoError(t, err)
-		xassert.EqualOptional(t, el, c2.Location)
+		xassert.EqualOptional(t, el.ID, c2.LocationID)
 	})
 
 	t.Run("should create new location for a known structure", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestCharacterService_UpdateLocationESI(t *testing.T) {
 		assert.True(t, changed)
 		c2, err := s.GetCharacter(ctx, c.ID)
 		require.NoError(t, err)
-		xassert.EqualOptional(t, el, c2.Location)
+		xassert.EqualOptional(t, el.ID, c2.LocationID)
 	})
 
 	t.Run("should create new location for an unknown structure", func(t *testing.T) {
@@ -113,7 +113,6 @@ func TestCharacterService_UpdateLocationESI(t *testing.T) {
 		assert.True(t, changed)
 		c2, err := s.GetCharacter(ctx, c.ID)
 		require.NoError(t, err)
-		xassert.Equal(t, structureID, c2.Location.MustValue().ID)
-		xassert.EqualOptional(t, es, c2.Location.MustValue().SolarSystem)
+		xassert.EqualOptional(t, structureID, c2.LocationID)
 	})
 }

--- a/internal/app/storage/character.go
+++ b/internal/app/storage/character.go
@@ -3,7 +3,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"slices"
 	"time"
@@ -110,17 +109,13 @@ func (st *Storage) GetCharacter(ctx context.Context, characterID int64) (*app.Ch
 		category: NewNullString(eveEntityFaction),
 		name:     r.RaceFactionName,
 	}
-	c, err := st.characterFromDBModel(
-		ctx,
+	c, err := characterFromDBModel(
 		r.Character,
 		r.EveCharacter,
 		r.EveEntity,
 		r.EveRace,
 		eea,
 		eef,
-		nullHomeID(r.HomeID),
-		nullLocationID(r.LocationID),
-		nullShipID(r.ShipID),
 		eb,
 		eer,
 	)
@@ -161,8 +156,6 @@ func (st *Storage) GetCharacterAssetValue(ctx context.Context, id int64) (option
 	return optional.FromNullFloat64(v), nil
 }
 
-// TODO: Try to make this operation more efficient
-
 func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error) {
 	rows, err := st.qRO.ListCharacters(ctx)
 	if err != nil {
@@ -189,17 +182,13 @@ func (st *Storage) ListCharacters(ctx context.Context) ([]*app.Character, error)
 			category: NewNullString(eveEntityFaction),
 			name:     r.RaceFactionName,
 		}
-		c, err := st.characterFromDBModel(
-			ctx,
+		c, err := characterFromDBModel(
 			r.Character,
 			r.EveCharacter,
 			r.EveEntity,
 			r.EveRace,
 			eea,
 			eef,
-			nullHomeID(r.HomeID),
-			nullLocationID(r.LocationID),
-			nullShipID(r.ShipID),
 			eb,
 			eer,
 		)
@@ -452,23 +441,13 @@ func (st *Storage) UpdateCharacterWalletBalance(ctx context.Context, characterID
 	return nil
 }
 
-type nullHomeID sql.NullInt64
-type nullLocationID sql.NullInt64
-type nullShipID sql.NullInt64
-
-// TODO: Optimize so additional queries are not needed
-
-func (st *Storage) characterFromDBModel(
-	ctx context.Context,
+func characterFromDBModel(
 	character queries.Character,
 	eveCharacter queries.EveCharacter,
 	corporation queries.EveEntity,
 	race queries.EveRace,
 	eea nullAlliance,
 	eef nullFaction,
-	homeID nullHomeID,
-	locationID nullLocationID,
-	shipID nullShipID,
 	eb nullEntity,
 	eer nullRaceFaction,
 ) (*app.Character, error) {
@@ -495,27 +474,9 @@ func (st *Storage) characterFromDBModel(
 		TrainedSP:         optional.FromNullInt64(character.TotalSp),
 		UnallocatedSP:     optional.FromNullInt64(character.UnallocatedSp),
 		WalletBalance:     optional.FromNullFloat64(character.WalletBalance),
-	}
-	if homeID.Valid {
-		x, err := st.GetLocation(ctx, homeID.Int64)
-		if err != nil {
-			return nil, err
-		}
-		o.Home = optional.New(x)
-	}
-	if locationID.Valid {
-		x, err := st.GetLocation(ctx, locationID.Int64)
-		if err != nil {
-			return nil, err
-		}
-		o.Location = optional.New(x)
-	}
-	if shipID.Valid {
-		x, err := st.GetEveType(ctx, shipID.Int64)
-		if err != nil {
-			return nil, err
-		}
-		o.Ship = optional.New(x)
+		HomeLocationID:    optional.FromNullInt64(character.HomeID),
+		LocationID:        optional.FromNullInt64(character.LocationID),
+		ShipTypeID:        optional.FromNullInt64(character.ShipID),
 	}
 	return &o, nil
 }

--- a/internal/app/storage/character_test.go
+++ b/internal/app/storage/character_test.go
@@ -21,7 +21,7 @@ func TestCharacter(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()
 
-	t.Run("can fetch a character", func(t *testing.T) {
+	t.Run("can fetch a character with all fields", func(t *testing.T) {
 		// given
 		testutil.MustTruncateTables(db)
 		a := factory.CreateEveEntityAlliance()
@@ -42,14 +42,14 @@ func TestCharacter(t *testing.T) {
 		xassert.Equal(t, c1.ContractItemsValue, c2.ContractItemsValue)
 		xassert.Equal(t, c1.ContractsEscrow, c2.ContractsEscrow)
 		xassert.Equal(t, ec, c2.EveCharacter)
-		xassert.Equal(t, c1.Home, c2.Home)
+		xassert.Equal(t, c1.HomeLocationID, c2.HomeLocationID)
 		xassert.Equal(t, c1.IsTrainingWatched, c2.IsTrainingWatched)
 		xassert.Equal(t, c1.LastCloneJumpAt, c2.LastCloneJumpAt)
 		xassert.Equal(t, c1.LastLoginAt, c2.LastLoginAt)
-		xassert.Equal(t, c1.Location, c2.Location)
+		xassert.Equal(t, c1.LocationID, c2.LocationID)
 		xassert.Equal(t, c1.OrderItemsValue, c2.OrderItemsValue)
 		xassert.Equal(t, c1.OrdersEscrow, c2.OrdersEscrow)
-		xassert.Equal(t, c1.Ship, c2.Ship)
+		xassert.Equal(t, c1.ShipTypeID, c2.ShipTypeID)
 		xassert.Equal(t, c1.SkillPointsValue, c2.SkillPointsValue)
 		xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
 		xassert.Equal(t, c1.UnallocatedSP, c2.UnallocatedSP)
@@ -86,7 +86,7 @@ func TestCharacter(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		xassert.Equal(t, c1.ID, c2.ID)
-		xassert.Equal(t, c1.Location, c2.Location)
+		xassert.Equal(t, c1.LocationID, c2.LocationID)
 	})
 }
 
@@ -144,7 +144,7 @@ func TestCharacter_Create(t *testing.T) {
 		ec := factory.CreateEveCharacter()
 		home := factory.CreateEveLocationStructure()
 		location := factory.CreateEveLocationStructure()
-		ship := factory.CreateEveType()
+		shipType := factory.CreateEveType()
 		login := time.Now()
 		cloneJump := time.Now()
 		arg := storage.CreateCharacterParams{
@@ -159,7 +159,7 @@ func TestCharacter_Create(t *testing.T) {
 			LocationID:         optional.New(location.ID),
 			OrderItemsValue:    optional.New(4.0),
 			OrdersEscrow:       optional.New(5.0),
-			ShipID:             optional.New(ship.ID),
+			ShipID:             optional.New(shipType.ID),
 			SkillPointsValue:   optional.New(6.0),
 			TotalSP:            optional.New(123),
 			UnallocatedSP:      optional.New(42),
@@ -183,10 +183,10 @@ func TestCharacter_Create(t *testing.T) {
 		xassert.EqualOptional(t, 5.0, o.OrdersEscrow)
 		xassert.EqualOptional(t, 6.0, o.SkillPointsValue)
 		xassert.EqualOptional(t, cloneJump, o.LastCloneJumpAt)
-		xassert.EqualOptional(t, home, o.Home)
-		xassert.EqualOptional(t, location, o.Location)
+		xassert.EqualOptional(t, home.ID, o.HomeLocationID)
+		xassert.EqualOptional(t, location.ID, o.LocationID)
 		xassert.EqualOptional(t, login, o.LastLoginAt)
-		xassert.EqualOptional(t, ship, o.Ship)
+		xassert.EqualOptional(t, shipType.ID, o.ShipTypeID)
 		xassert.Equal(t, true, o.IsTrainingWatched)
 		xassert.Equal(t, ec, o.EveCharacter)
 	})
@@ -253,8 +253,8 @@ func TestListCharacters(t *testing.T) {
 		if assert.NotNil(t, c2) {
 			xassert.Equal(t, c1.ID, c2.ID)
 			xassert.EqualOptional(t, c1.LastLoginAt.ValueOrZero(), c2.LastLoginAt)
-			xassert.Equal(t, c1.Ship, c2.Ship)
-			xassert.Equal(t, c1.Location, c2.Location)
+			xassert.Equal(t, c1.ShipTypeID, c2.ShipTypeID)
+			xassert.Equal(t, c1.LocationID, c2.LocationID)
 			xassert.Equal(t, c1.TrainedSP, c2.TrainedSP)
 			xassert.Equal(t, c1.WalletBalance, c2.WalletBalance)
 			xassert.Equal(t, c1.EveCharacter, c2.EveCharacter)
@@ -343,7 +343,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		c2, err := st.GetCharacter(t.Context(), c1.ID)
 		require.NoError(t, err)
-		xassert.EqualOptional(t, home, c2.Home)
+		xassert.EqualOptional(t, home.ID, c2.HomeLocationID)
 	})
 
 	t.Run("can update last clone jump with a time", func(t *testing.T) {
@@ -420,7 +420,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		c2, err := st.GetCharacter(t.Context(), c1.ID)
 		require.NoError(t, err)
-		xassert.EqualOptional(t, location, c2.Location)
+		xassert.EqualOptional(t, location.ID, c2.LocationID)
 	})
 
 	t.Run("can update ship", func(t *testing.T) {
@@ -436,7 +436,7 @@ func TestUpdateCharacterFields(t *testing.T) {
 		require.NoError(t, err)
 		c2, err := st.GetCharacter(t.Context(), c1.ID)
 		require.NoError(t, err)
-		xassert.EqualOptional(t, x, c2.Ship)
+		xassert.EqualOptional(t, x.ID, c2.ShipTypeID)
 	})
 
 	t.Run("can update is training watched", func(t *testing.T) {

--- a/internal/app/storage/planetpin.go
+++ b/internal/app/storage/planetpin.go
@@ -92,6 +92,8 @@ func (st *Storage) ListPlanetPins(ctx context.Context, characterPlanetID int64) 
 	return oo, nil
 }
 
+// TODO: Consider removing the additional DB call
+
 func (st *Storage) planetPinFromDBModel(ctx context.Context, r queries.GetPlanetPinRow) (*app.PlanetPin, error) {
 	o := &app.PlanetPin{
 		ID:             r.PlanetPin.PinID,

--- a/internal/app/ui/characters/charactersheet.go
+++ b/internal/app/ui/characters/charactersheet.go
@@ -184,6 +184,33 @@ func (a *CharacterSheet) update(ctx context.Context) {
 		clearAll()
 		return
 	}
+	var home *app.EveLocation
+	if v, ok := c.HomeLocationID.Value(); ok {
+		el, err := a.u.EVEUniverse().GetLocation(ctx, v)
+		if err != nil {
+			slog.Error("Failed to fetch home for character", "characterID", c.ID, "err", err)
+		} else {
+			home = el
+		}
+	}
+	var location *app.EveLocation
+	if v, ok := c.LocationID.Value(); ok {
+		el, err := a.u.EVEUniverse().GetLocation(ctx, v)
+		if err != nil {
+			slog.Error("Failed to fetch location for character", "characterID", c.ID, "err", err)
+		} else {
+			location = el
+		}
+	}
+	var shipType *app.EveType
+	if v, ok := c.ShipTypeID.Value(); ok {
+		et, err := a.u.EVEUniverse().GetType(ctx, v)
+		if err != nil {
+			slog.Error("Failed to fetch ship type for character", "characterID", c.ID, "err", err)
+		} else {
+			shipType = et
+		}
+	}
 	a.character.Store(c2)
 	c = c2
 
@@ -206,12 +233,11 @@ func (a *CharacterSheet) update(ctx context.Context) {
 		a.u.EVEImage().CharacterPortraitAsync(c.ID, 512, func(r fyne.Resource) {
 			a.portrait.SetResource(r)
 		})
-		el, ok := c.Location.Value()
-		if !ok {
+		if location == nil {
 			a.location.Clear()
 			return
 		}
-		a.location.SetLocation(el)
+		a.location.SetLocation(location)
 	})
 	fyne.Do(func() {
 		v, ok := c.EveCharacter.Bloodline.Value()
@@ -222,16 +248,14 @@ func (a *CharacterSheet) update(ctx context.Context) {
 		a.bloodline.SetBloodline(v)
 	})
 	fyne.Do(func() {
-		ship, ok := c.Ship.Value()
-		if !ok {
+		if shipType == nil {
 			a.ship.Clear()
 			return
 		}
-		a.ship.Set(ship.ToEveEntity())
+		a.ship.Set(shipType.ToEveEntity())
 	})
 	fyne.Do(func() {
-		home, ok := c.Home.Value()
-		if !ok {
+		if home == nil {
 			a.home.Clear()
 			return
 		}

--- a/internal/app/ui/characters/overview.go
+++ b/internal/app/ui/characters/overview.go
@@ -497,18 +497,29 @@ func (a *Overview) fetchRow(ctx context.Context, c *app.Character) (characterOve
 		corporation:   c.EveCharacter.Corporation,
 		faction:       c.EveCharacter.Faction,
 		isWatched:     c.IsTrainingWatched,
-		location:      c.Location,
 		searchTarget:  strings.ToLower(c.EveCharacter.Name),
-		ship:          c.Ship,
 		skillpoints:   c.TrainedSP,
 		walletBalance: c.WalletBalance,
 	}
-	if el, ok := c.Location.Value(); ok {
+	if id, ok := c.LocationID.Value(); ok {
+		el, err := a.u.EVEUniverse().GetLocation(ctx, id)
+		if err != nil {
+			slog.Error("Failed to load location for character in overview", "characterID", c.ID, "error", err)
+		} else {
+			r.location.Set(el)
+		}
 		if es, ok := el.SolarSystem.Value(); ok {
 			r.regionName = es.Constellation.Region.Name
 			r.solarSystemName = es.Name
 			r.searchTarget += "~" + strings.ToLower(es.Name)
 		}
+	}
+	if id, ok := c.ShipTypeID.Value(); ok {
+		et, err := a.u.EVEUniverse().GetType(ctx, id)
+		if err != nil {
+			slog.Error("Failed to load ship for character in overview", "characterID", c.ID, "error", err)
+		}
+		r.ship.Set(et)
 	}
 	total, unread, err := a.u.Character().GetMailCounts(ctx, c.ID)
 	if err != nil {

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -758,12 +758,12 @@ func (u *DesktopUI) defineShortcuts() {
 					u.ShowSnackbar("ERROR: No character selected")
 					return
 				}
-				el, ok := c.Location.Value()
+				id, ok := c.LocationID.Value()
 				if !ok {
 					u.ShowSnackbar("ERROR: Missing location for current character.")
 					return
 				}
-				u.InfoViewer().ShowLocation(el.ID)
+				u.InfoViewer().ShowLocation(id)
 			}},
 		"currentShip": {
 			&desktop.CustomShortcut{
@@ -776,12 +776,12 @@ func (u *DesktopUI) defineShortcuts() {
 					u.ShowSnackbar("ERROR: No character selected")
 					return
 				}
-				ship, ok := c.Ship.Value()
+				shipTypeID, ok := c.ShipTypeID.Value()
 				if !ok {
 					u.ShowSnackbar("ERROR: Missing ship for current character.")
 					return
 				}
-				u.InfoViewer().ShowType(ship.ID, 0)
+				u.InfoViewer().ShowType(shipTypeID, 0)
 			}},
 		"search": {
 			&desktop.CustomShortcut{

--- a/internal/app/ui/infoviewer/characterinfo.go
+++ b/internal/app/ui/infoviewer/characterinfo.go
@@ -287,10 +287,10 @@ func (a *characterInfo) makeAttributes(ctx context.Context, o *app.EveCharacter,
 		if err != nil {
 			return nil, err
 		}
-		if v, ok := c.Home.Value(); ok {
+		if v, ok := c.HomeLocationID.Value(); ok {
 			attributes = append(attributes, newAttributeItem("Home", v))
 		}
-		if v, ok := c.Location.Value(); ok {
+		if v, ok := c.LocationID.Value(); ok {
 			attributes = append(attributes, newAttributeItem("Location", v))
 		}
 		if v, ok := c.LastLoginAt.Value(); ok {


### PR DESCRIPTION
Removed the need to make additional DB calls when constructing a Character from storage.
Those objects were only needed occasionally. 
The related fields (Home, Location, Ship) have there demoted to IDs and the objects are now loaded on-demand when needed.