### PR TITLE
Feat add asset export

### DIFF
--- a/internal/app/asset.go
+++ b/internal/app/asset.go
@@ -165,6 +165,21 @@ const (
 	VariantSKIN
 )
 
+func (v InventoryTypeVariant) String() string {
+	switch v {
+	case VariantRegular:
+		return "Regular"
+	case VariantBPO:
+		return "BPO"
+	case VariantBPC:
+		return "BPC"
+	case VariantSKIN:
+		return "SKIN"
+	default:
+		return ""
+	}
+}
+
 // Asset represents a generic asset in EVE Online.
 type Asset struct {
 	IsBlueprintCopy optional.Optional[bool]

--- a/internal/app/characterservice/skills.go
+++ b/internal/app/characterservice/skills.go
@@ -2,14 +2,10 @@ package characterservice
 
 import (
 	"context"
-	"encoding/csv"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"maps"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/ErikKalkoken/go-set"
@@ -23,11 +19,6 @@ import (
 )
 
 const cacheKeyTrainingNotified = "expired-training-notified"
-
-type skillExportItem struct {
-	Name  string
-	Level int64
-}
 
 func (s *CharacterService) GetAttributes(ctx context.Context, characterID int64) (*app.CharacterAttributes, error) {
 	return s.st.GetCharacterAttributes(ctx, characterID)
@@ -123,63 +114,6 @@ func (s *CharacterService) ListSkills(ctx context.Context, characterID int64) ([
 		skills2 = append(skills2, o)
 	}
 	return skills2, nil
-}
-
-// getSkillsForExport returns active skills sorted by name for export.
-func (s *CharacterService) getSkillsForExport(ctx context.Context, characterID int64) ([]skillExportItem, error) {
-	skills, err := s.ListSkills(ctx, characterID)
-	if err != nil {
-		return nil, err
-	}
-	items := make([]skillExportItem, 0, len(skills))
-	for _, o := range skills {
-		if o.ActiveSkillLevel == 0 {
-			continue
-		}
-		items = append(items, skillExportItem{
-			Name:  o.Skill.Type.Name,
-			Level: o.ActiveSkillLevel,
-		})
-	}
-	slices.SortFunc(items, func(a, b skillExportItem) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-	return items, nil
-}
-
-// MakeSkillsExportLines returns PyFA-compatible export lines from active skills.
-func (s *CharacterService) MakeSkillsExportLines(ctx context.Context, characterID int64) (string, error) {
-	items, err := s.getSkillsForExport(ctx, characterID)
-	if err != nil {
-		return "", err
-	}
-	var sb strings.Builder
-	for _, r := range items {
-		fmt.Fprintf(&sb, "%s %d\n", r.Name, r.Level)
-	}
-	return sb.String(), nil
-}
-
-// WriteSkillsExportCSV writes active skills as CSV to the provided writer.
-func (s *CharacterService) WriteSkillsExportCSV(ctx context.Context, characterID int64, w io.Writer) error {
-	items, err := s.getSkillsForExport(ctx, characterID)
-	if err != nil {
-		return err
-	}
-	cw := csv.NewWriter(w)
-	if err := cw.Write([]string{"Name", "Level"}); err != nil {
-		return err
-	}
-	for _, r := range items {
-		if err := cw.Write([]string{r.Name, fmt.Sprintf("%d", r.Level)}); err != nil {
-			return err
-		}
-	}
-	cw.Flush()
-	if err := cw.Error(); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (s *CharacterService) updateSkillsESI(ctx context.Context, arg characterSectionUpdateParams) (bool, error) {

--- a/internal/app/characterservice/skills_test.go
+++ b/internal/app/characterservice/skills_test.go
@@ -1,7 +1,6 @@
 package characterservice_test
 
 import (
-	"bytes"
 	"context"
 	"maps"
 	"testing"
@@ -244,71 +243,5 @@ func TestCharacterService_ListSkills(t *testing.T) {
 
 		o1 := m[es1.ID]
 		assert.False(t, o1.HasPrerequisites)
-	})
-}
-
-func TestCharacterService_MakeSkillsExportLines(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
-	defer db.Close()
-	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	t.Run("should return pyfa compatible lines", func(t *testing.T) {
-		// given
-		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
-		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
-		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
-		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 6002, GroupID: group.ID, Name: "Delta Skill", IsPublished: true})
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skill1.ID,
-			ActiveSkillLevel: 4,
-		}))
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skill2.ID,
-			ActiveSkillLevel: 2,
-		}))
-
-		// when
-		text, err := cs.MakeSkillsExportLines(t.Context(), c.ID)
-
-		// then
-		require.NoError(t, err)
-		xassert.Equal(t, "Delta Skill 2\nGamma Skill 4\n", text)
-	})
-}
-
-func TestCharacterService_WriteSkillsExportCSV(t *testing.T) {
-	db, st, factory := testutil.NewDBInMemory()
-	defer db.Close()
-	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
-	t.Run("should write active skills CSV with header", func(t *testing.T) {
-		// given
-		testutil.MustTruncateTables(db)
-		c := factory.CreateCharacter()
-		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill})
-		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID, IsPublished: true})
-		skill1 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7001, GroupID: group.ID, Name: "Gamma Skill", IsPublished: true})
-		skill2 := factory.CreateEveType(storage.CreateEveTypeParams{ID: 7002, GroupID: group.ID, Name: "Alpha Skill", IsPublished: true})
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skill1.ID,
-			ActiveSkillLevel: 4,
-		}))
-		require.NoError(t, st.UpdateOrCreateCharacterSkill(t.Context(), storage.UpdateOrCreateCharacterSkillParams{
-			CharacterID:      c.ID,
-			TypeID:           skill2.ID,
-			ActiveSkillLevel: 2,
-		}))
-
-		var b bytes.Buffer
-
-		// when
-		err := cs.WriteSkillsExportCSV(t.Context(), c.ID, &b)
-
-		// then
-		require.NoError(t, err)
-		xassert.Equal(t, "Name,Level\nAlpha Skill,2\nGamma Skill,4\n", b.String())
 	})
 }

--- a/internal/app/ui/core/desktopui.go
+++ b/internal/app/ui/core/desktopui.go
@@ -100,10 +100,13 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 	}
 
 	const assetsTitle = "Assets"
-	allAssets := xwidget.NewNavPage(
+	assetSearch := xwidget.NewNavPage(
 		assetsTitle,
 		theme.NewThemedResource(icons.Inventory2Svg),
-		newContentPage(assetsTitle, u.assetSearchAll),
+		newContentPage(assetsTitle, u.assetSearchAll, xwidget.NewIconButtonWithMenu(
+			theme.MoreHorizontalIcon(),
+			fyne.NewMenu("", u.assetSearchAll.MoreItems()...),
+		)),
 	)
 
 	unifiedCommunications := xwidget.NewNavPage(
@@ -205,7 +208,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 
 	homeNav = xwidget.NewNavDrawer(
 		overview,
-		allAssets,
+		assetSearch,
 		xwidget.NewNavPage(
 			"Clones",
 			theme.NewThemedResource(icons.HeadSnowflakeSvg),
@@ -228,7 +231,7 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		wealth,
 	)
 	homeNav.OnSelectItem = func(it *xwidget.NavItem) {
-		if it == allAssets {
+		if it == assetSearch {
 			u.assetSearchAll.Focus()
 		}
 	}
@@ -326,6 +329,9 @@ func NewDesktopUI(params UIParams) *DesktopUI {
 		newContentPage("Assets", container.NewAppTabs(
 			container.NewTabItem("Browse", u.corporationAssetBrowser),
 			container.NewTabItem("Search", u.corporationAssetSearch),
+		), xwidget.NewIconButtonWithMenu(
+			theme.MoreHorizontalIcon(),
+			fyne.NewMenu("", u.corporationAssetSearch.MoreItems()...),
 		)),
 	)
 

--- a/internal/app/ui/core/mobileui.go
+++ b/internal/app/ui/core/mobileui.go
@@ -255,7 +255,12 @@ func NewMobileUI(params UIParams) *MobileUI {
 		corpAssetSearchTitle,
 		theme.NewThemedResource(icons.Inventory2Svg),
 		func() {
-			corpNav.Push(xwidget.NewAppBar(corpAssetSearchTitle, u.corporationAssetSearch))
+			corpNav.Push(xwidget.NewAppBar(corpAssetSearchTitle, u.corporationAssetSearch,
+				kxwidget.NewIconButtonWithMenu(
+					theme.MoreHorizontalIcon(),
+					fyne.NewMenu("", u.corporationAssetSearch.MoreItems()...),
+				),
+			))
 			u.corporationAssetSearch.Focus()
 		},
 	)
@@ -850,11 +855,16 @@ func makeHomeNav(u *MobileUI) (*xwidget.Navigator, *StatusBarItem) {
 		navItemWealth.Refresh()
 	}
 
-	navItemAssets := xwidget.NewNavListItem(
+	navItemAssetSearch := xwidget.NewNavListItem(
 		"Assets",
 		theme.NewThemedResource(icons.Inventory2Svg),
 		func() {
-			homeNav.Push(xwidget.NewAppBar("Assets", u.assetSearchAll))
+			homeNav.Push(xwidget.NewAppBar("Assets", u.assetSearchAll,
+				kxwidget.NewIconButtonWithMenu(
+					theme.MoreHorizontalIcon(),
+					fyne.NewMenu("", u.assetSearchAll.MoreItems()...),
+				),
+			))
 			u.assetSearchAll.Focus()
 		},
 	)
@@ -924,7 +934,7 @@ func makeHomeNav(u *MobileUI) (*xwidget.Navigator, *StatusBarItem) {
 
 	homeList = xwidget.NewNavList(
 		navItemCharacters,
-		navItemAssets,
+		navItemAssetSearch,
 		xwidget.NewNavListItem(
 			"Clones",
 			theme.NewThemedResource(icons.HeadSnowflakeSvg),

--- a/internal/app/ui/screens/assetdetailwindow.go
+++ b/internal/app/ui/screens/assetdetailwindow.go
@@ -104,7 +104,7 @@ func ShowAssetDetails(u baseUI, r assetRow) {
 			}
 		},
 		MinSize: fyne.NewSize(500, 450),
-		Title:   r.name,
+		Title:   r.displayName,
 		Window:  w,
 	})
 	w.Show()

--- a/internal/app/ui/screens/assetsearch.go
+++ b/internal/app/ui/screens/assetsearch.go
@@ -1,11 +1,11 @@
 package screens
 
 import (
-	"bytes"
 	"cmp"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"iter"
 	"log/slog"
 	"slices"
@@ -607,14 +607,13 @@ func (a *AssetSearch) exportAsCSV() {
 	} else {
 		filename = "assets.csv"
 	}
-	exportRowsAsCSV(a.u, "assets", filename, a.rowsFiltered, func(rows []assetRow) ([]byte, error) {
-		return makeCSVFromRows(a.forCorporation, rows)
+	exportRowsAsCSV(a.u, "assets", filename, a.rowsFiltered, func(w io.Writer, rows []assetRow) error {
+		return writeAssetRowsToCSV(w, rows, a.forCorporation)
 	})
 }
 
-func makeCSVFromRows(forCorporation bool, rows []assetRow) ([]byte, error) {
-	var buf bytes.Buffer
-	w := csv.NewWriter(&buf)
+func writeAssetRowsToCSV(w io.Writer, rows []assetRow, forCorporation bool) error {
+	cw := csv.NewWriter(w)
 	header := []string{
 		"Item ID", "Type ID", "Type Name", "Item Name", "Group ID", "Group Name", "Category ID", "Category Name",
 		"Location Name", "Location Flag", "State", "Quantity", "Is Singleton", "Variant",
@@ -624,7 +623,9 @@ func makeCSVFromRows(forCorporation bool, rows []assetRow) ([]byte, error) {
 	if !forCorporation {
 		header = append(header, "Tags")
 	}
-	_ = w.Write(header)
+	if err := cw.Write(header); err != nil {
+		return err
+	}
 	for _, r := range rows {
 		var price string
 		if v, ok := r.price.Value(); ok {
@@ -665,10 +666,16 @@ func makeCSVFromRows(forCorporation bool, rows []assetRow) ([]byte, error) {
 		if !forCorporation {
 			record = append(record, r.tagsDisplay)
 		}
-		_ = w.Write(record)
+		if err := cw.Write(record); err != nil {
+			return err
+		}
+
 	}
-	w.Flush()
-	return buf.Bytes(), nil
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (a *AssetSearch) filterRowsAsync(sortCol string) {

--- a/internal/app/ui/screens/assetsearch.go
+++ b/internal/app/ui/screens/assetsearch.go
@@ -16,9 +16,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -561,21 +559,16 @@ func (a *AssetSearch) Focus() {
 // MoreItems returns the list of menu items for the overflow menu.
 func (a *AssetSearch) MoreItems() []*fyne.MenuItem {
 	return []*fyne.MenuItem{
-		fyne.NewMenuItem("Consolidate to Clipboard", a.consolidateToClipboard),
-		fyne.NewMenuItem("Export as CSV", a.exportAsCSV),
+		fyne.NewMenuItem("Copy assets to clipboard", a.consolidateToClipboard),
+		fyne.NewMenuItem("Export assets as CSV", a.exportAsCSV),
 	}
 }
 
 func (a *AssetSearch) consolidateToClipboard() {
-	rows := slices.Clone(a.rowsFiltered)
-	go func() {
-		s := a.consolidateRowsToString(rows)
-		fyne.CurrentApp().Clipboard().SetContent(s)
-		a.u.ShowSnackbar("Assets copied to clipboard")
-	}()
+	copyRowsToClipboard(a.u, "assets", a.rowsFiltered, consolidateAssetRows)
 }
 
-func (*AssetSearch) consolidateRowsToString(rows []assetRow) string {
+func consolidateAssetRows(rows []assetRow) (string, error) {
 	type assetItem struct {
 		name     string
 		quantity int
@@ -600,67 +593,36 @@ func (*AssetSearch) consolidateRowsToString(rows []assetRow) string {
 	})
 	var b strings.Builder
 	for _, it := range items {
-		fmt.Fprintf(&b, "%s %d\n", it.name, it.quantity)
+		if _, err := fmt.Fprintf(&b, "%s %d\n", it.name, it.quantity); err != nil {
+			return "", err
+		}
 	}
-	return b.String()
+	return b.String(), nil
 }
 
 func (a *AssetSearch) exportAsCSV() {
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if writer == nil {
-			return
-		}
-		showError := func(err error) {
-			ui.ShowErrorAndLog("Failed to export assets", err, a.u.IsDeveloperMode(), a.u.MainWindow())
-		}
-		if err != nil {
-			writer.Close()
-			showError(err)
-			return
-		}
-		rows := slices.Clone(a.rowsFiltered)
-		go func() {
-			defer writer.Close()
-			data := a.makeCSVFromRows(rows)
-			_, err := writer.Write(data)
-			if err != nil {
-				fyne.Do(func() {
-					showError(err)
-				})
-				return
-			}
-			a.u.ShowSnackbar("Assets exported to CSV")
-		}()
-	}, a.u.MainWindow())
-
 	var filename string
 	if a.forCorporation {
 		filename = fmt.Sprintf("assets_%d.csv", a.corporation.Load().IDOrZero())
 	} else {
 		filename = "assets.csv"
 	}
-
-	d.SetFileName(filename)
-	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
-	d.SetTitleText("Export as CSV")
-	d.Show()
-
-	_, s := a.u.MainWindow().Canvas().InteractiveArea()
-	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
-	d.Resize(winSize)
+	exportRowsAsCSV(a.u, "assets", filename, a.rowsFiltered, func(rows []assetRow) ([]byte, error) {
+		return makeCSVFromRows(a.forCorporation, rows)
+	})
 }
 
-func (a *AssetSearch) makeCSVFromRows(rows []assetRow) []byte {
+func makeCSVFromRows(forCorporation bool, rows []assetRow) ([]byte, error) {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
 	header := []string{
-		"item_id", "type_id", "type", "name", "group_id", "group", "category_id", "category",
-		"location", "location_flag", "state", "quantity", "is_singleton", "variant",
-		"solar_system_id", "solar_system", "region_id", "region", "price", "total",
-		"owner_id", "owner",
+		"Item ID", "Type ID", "Type Name", "Item Name", "Group ID", "Group Name", "Category ID", "Category Name",
+		"Location Name", "Location Flag", "State", "Quantity", "Is Singleton", "Variant",
+		"Solar System ID", "Solar System Name", "Region ID", "Region Name", "Price", "Total",
+		"Owner ID", "Owner Name",
 	}
-	if !a.forCorporation {
-		header = append(header, "tags")
+	if !forCorporation {
+		header = append(header, "Tags")
 	}
 	_ = w.Write(header)
 	for _, r := range rows {
@@ -700,13 +662,13 @@ func (a *AssetSearch) makeCSVFromRows(rows []assetRow) []byte {
 			strconv.FormatInt(r.owner.ID, 10),
 			r.owner.Name,
 		}
-		if !a.forCorporation {
+		if !forCorporation {
 			record = append(record, r.tagsDisplay)
 		}
 		_ = w.Write(record)
 	}
 	w.Flush()
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 func (a *AssetSearch) filterRowsAsync(sortCol string) {

--- a/internal/app/ui/screens/assetsearch.go
+++ b/internal/app/ui/screens/assetsearch.go
@@ -1,19 +1,24 @@
 package screens
 
 import (
+	"bytes"
 	"cmp"
 	"context"
+	"encoding/csv"
 	"fmt"
 	"iter"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -34,12 +39,14 @@ import (
 )
 
 const (
-	totalYes = "Has total"
-	totalNo  = "Has no total"
+	assetSearchTotalYes = "Has total"
+	assetSearchTotalNo  = "Has no total"
 )
 
 type assetRow struct {
+	categoryID      int64
 	categoryName    string
+	displayName     string
 	groupID         int64
 	groupName       string
 	isSingleton     bool
@@ -58,6 +65,9 @@ type assetRow struct {
 	regionID        int64
 	regionName      string
 	searchTarget    string
+	solarSystemID   int64
+	solarSystemName string
+	state           string
 	tags            set.Set[string]
 	tagsDisplay     string
 	total           optional.Optional[float64]
@@ -65,25 +75,27 @@ type assetRow struct {
 	typeID          int64
 	typeName        string
 	variant         app.InventoryTypeVariant
-	state           string
 }
 
 func newCharacterAssetRow(ca *app.CharacterAsset, ac asset.Tree, characterName func(int64) string) assetRow {
+	owner := &app.EveEntity{
+		ID:       ca.CharacterID,
+		Name:     characterName(ca.CharacterID),
+		Category: app.EveEntityCharacter,
+	}
 	r := assetRow{
+		categoryID:   ca.Type.Group.Category.ID,
 		categoryName: ca.Type.Group.Category.Name,
+		displayName:  ca.DisplayName2(),
 		groupID:      ca.Type.Group.ID,
 		groupName:    ca.Type.Group.Name,
 		isSingleton:  ca.IsSingleton,
 		itemID:       ca.ItemID,
+		name:         ca.Name,
+		owner:        owner,
 		typeID:       ca.Type.ID,
 		typeName:     ca.Type.Name,
-		name:         ca.DisplayName2(),
 		variant:      ca.Variant(),
-		owner: &app.EveEntity{
-			ID:       ca.CharacterID,
-			Name:     characterName(ca.CharacterID),
-			Category: app.EveEntityCharacter,
-		},
 	}
 	r.setQuantity(ca.IsSingleton, ca.Quantity)
 	r.setLocation(ac, ca.ItemID)
@@ -93,21 +105,24 @@ func newCharacterAssetRow(ca *app.CharacterAsset, ac asset.Tree, characterName f
 }
 
 func newCorporationAssetRow(ca *app.CorporationAsset, ac asset.Tree, corporationName string) assetRow {
+	owner := &app.EveEntity{
+		ID:       ca.CorporationID,
+		Name:     corporationName,
+		Category: app.EveEntityCorporation,
+	}
 	r := assetRow{
+		categoryID:   ca.Type.Group.Category.ID,
 		categoryName: ca.Type.Group.Category.Name,
+		displayName:  ca.DisplayName2(),
 		groupID:      ca.Type.Group.ID,
 		groupName:    ca.Type.Group.Name,
 		isSingleton:  ca.IsSingleton,
 		itemID:       ca.ItemID,
+		name:         ca.Name,
+		owner:        owner,
 		typeID:       ca.Type.ID,
 		typeName:     ca.Type.Name,
-		name:         ca.DisplayName2(),
 		variant:      ca.Variant(),
-		owner: &app.EveEntity{
-			ID:       ca.CorporationID,
-			Name:     corporationName,
-			Category: app.EveEntityCorporation,
-		},
 	}
 	r.setQuantity(ca.IsSingleton, ca.Quantity)
 	r.setLocation(ac, ca.ItemID)
@@ -169,6 +184,8 @@ func (r *assetRow) setLocation(ac asset.Tree, itemID int64) {
 		}
 	}
 	if v, ok := el.SolarSystem.Value(); ok {
+		r.solarSystemID = v.ID
+		r.solarSystemName = v.Name
 		r.regionName = v.Constellation.Region.Name
 		r.regionID = v.Constellation.Region.ID
 	}
@@ -237,7 +254,7 @@ func newAssetSearch(u baseUI, forCorporation bool) *AssetSearch {
 		Label: "Item",
 		Width: 300,
 		Sort: func(a, b assetRow) int {
-			return strings.Compare(a.name, b.name)
+			return strings.Compare(a.displayName, b.displayName)
 		},
 		Create: func() fyne.CanvasObject {
 			icon := xwidget.NewImageFromResource(
@@ -389,8 +406,8 @@ func newAssetSearch(u baseUI, forCorporation bool) *AssetSearch {
 	})
 	a.selectTotal = kxwidget.NewFilterChipSelect("Total",
 		[]string{
-			totalYes,
-			totalNo,
+			assetSearchTotalYes,
+			assetSearchTotalNo,
 		},
 		func(_ string) {
 			a.filterRowsAsync("")
@@ -516,9 +533,9 @@ func (a *AssetSearch) makeDataList() *xwidget.StripedList {
 			box := co.(*fyne.Container).Objects
 			var title string
 			if r.isSingleton {
-				title = r.name
+				title = r.displayName
 			} else {
-				title = fmt.Sprintf("%s x%s", r.name, r.quantityDisplay)
+				title = fmt.Sprintf("%s x%s", r.displayName, r.quantityDisplay)
 			}
 			box[0].(*widget.Label).SetText(title)
 			box[1].(*xwidget.RichText).Set(r.locationDisplay)
@@ -539,6 +556,157 @@ func (a *AssetSearch) makeDataList() *xwidget.StripedList {
 
 func (a *AssetSearch) Focus() {
 	a.u.MainWindow().Canvas().Focus(a.searchEntry)
+}
+
+// MoreItems returns the list of menu items for the overflow menu.
+func (a *AssetSearch) MoreItems() []*fyne.MenuItem {
+	return []*fyne.MenuItem{
+		fyne.NewMenuItem("Consolidate to Clipboard", a.consolidateToClipboard),
+		fyne.NewMenuItem("Export as CSV", a.exportAsCSV),
+	}
+}
+
+func (a *AssetSearch) consolidateToClipboard() {
+	rows := slices.Clone(a.rowsFiltered)
+	go func() {
+		s := a.consolidateRowsToString(rows)
+		fyne.CurrentApp().Clipboard().SetContent(s)
+		a.u.ShowSnackbar("Assets copied to clipboard")
+	}()
+}
+
+func (*AssetSearch) consolidateRowsToString(rows []assetRow) string {
+	type assetItem struct {
+		name     string
+		quantity int
+	}
+	quantities := make(map[int64]int)
+	names := make(map[int64]string)
+	for _, r := range rows {
+		quantities[r.typeID] += r.quantity
+		if _, found := names[r.typeID]; !found {
+			names[r.typeID] = r.typeName
+		}
+	}
+	var items []assetItem
+	for id, name := range names {
+		items = append(items, assetItem{
+			name:     name,
+			quantity: quantities[id],
+		})
+	}
+	slices.SortFunc(items, func(a, b assetItem) int {
+		return strings.Compare(a.name, b.name)
+	})
+	var b strings.Builder
+	for _, it := range items {
+		fmt.Fprintf(&b, "%s %d\n", it.name, it.quantity)
+	}
+	return b.String()
+}
+
+func (a *AssetSearch) exportAsCSV() {
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		if writer == nil {
+			return
+		}
+		showError := func(err error) {
+			ui.ShowErrorAndLog("Failed to export assets", err, a.u.IsDeveloperMode(), a.u.MainWindow())
+		}
+		if err != nil {
+			writer.Close()
+			showError(err)
+			return
+		}
+		rows := slices.Clone(a.rowsFiltered)
+		go func() {
+			defer writer.Close()
+			data := a.makeCSVFromRows(rows)
+			_, err := writer.Write(data)
+			if err != nil {
+				fyne.Do(func() {
+					showError(err)
+				})
+				return
+			}
+			a.u.ShowSnackbar("Assets exported to CSV")
+		}()
+	}, a.u.MainWindow())
+
+	var filename string
+	if a.forCorporation {
+		filename = fmt.Sprintf("assets_%d.csv", a.corporation.Load().IDOrZero())
+	} else {
+		filename = "assets.csv"
+	}
+
+	d.SetFileName(filename)
+	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
+	d.SetTitleText("Export as CSV")
+	d.Show()
+
+	_, s := a.u.MainWindow().Canvas().InteractiveArea()
+	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
+	d.Resize(winSize)
+}
+
+func (a *AssetSearch) makeCSVFromRows(rows []assetRow) []byte {
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	header := []string{
+		"item_id", "type_id", "type", "name", "group_id", "group", "category_id", "category",
+		"location", "location_flag", "state", "quantity", "is_singleton", "variant",
+		"solar_system_id", "solar_system", "region_id", "region", "price", "total",
+		"owner_id", "owner",
+	}
+	if !a.forCorporation {
+		header = append(header, "tags")
+	}
+	_ = w.Write(header)
+	for _, r := range rows {
+		var price string
+		if v, ok := r.price.Value(); ok {
+			price = strconv.FormatFloat(v, 'f', -1, 64)
+		}
+		var total string
+		if v, ok := r.total.Value(); ok {
+			total = strconv.FormatFloat(v, 'f', -1, 64)
+		}
+		var variant string
+		if r.variant != app.VariantRegular {
+			variant = r.variant.String()
+		}
+		record := []string{
+			strconv.FormatInt(r.itemID, 10),
+			strconv.FormatInt(r.typeID, 10),
+			r.typeName,
+			r.name,
+			strconv.FormatInt(r.groupID, 10),
+			r.groupName,
+			strconv.FormatInt(r.categoryID, 10),
+			r.categoryName,
+			r.locationName,
+			r.locationFlag.String(),
+			r.state,
+			strconv.Itoa(r.quantity),
+			strconv.FormatBool(r.isSingleton),
+			variant,
+			strconv.FormatInt(r.solarSystemID, 10),
+			r.solarSystemName,
+			strconv.FormatInt(r.regionID, 10),
+			r.regionName,
+			price,
+			total,
+			strconv.FormatInt(r.owner.ID, 10),
+			r.owner.Name,
+		}
+		if !a.forCorporation {
+			record = append(record, r.tagsDisplay)
+		}
+		_ = w.Write(record)
+	}
+	w.Flush()
+	return buf.Bytes()
 }
 
 func (a *AssetSearch) filterRowsAsync(sortCol string) {
@@ -589,9 +757,9 @@ func (a *AssetSearch) filterRowsAsync(sortCol string) {
 		if total != "" {
 			rows = slices.DeleteFunc(rows, func(r assetRow) bool {
 				switch total {
-				case totalYes:
+				case assetSearchTotalYes:
 					return r.total.IsEmpty()
-				case totalNo:
+				case assetSearchTotalNo:
 					return !r.total.IsEmpty()
 				}
 				return true
@@ -753,7 +921,7 @@ func (a *AssetSearch) fetchRowsForCharacters(ctx context.Context) ([]assetRow, e
 		r := newCharacterAssetRow(ca, ac, func(id int64) string {
 			return characters[id]
 		})
-		r.searchTarget = strings.ToLower(r.name)
+		r.searchTarget = strings.ToLower(r.displayName)
 		r.tags = tagsPerCharacter[ca.CharacterID]
 		r.tagsDisplay = strings.Join(slices.Sorted(r.tags.All()), ", ")
 		rows = append(rows, r)
@@ -805,7 +973,7 @@ func (a *AssetSearch) fetchRowsForCorporations2(ctx context.Context, assets []*a
 			continue // filter out office item
 		}
 		r := newCorporationAssetRow(ca, ac, corporationNames[ca.CorporationID])
-		r.searchTarget = strings.ToLower(r.name)
+		r.searchTarget = strings.ToLower(r.displayName)
 		rows = append(rows, r)
 		value += r.total.ValueOrZero()
 	}

--- a/internal/app/ui/screens/assetsearch_internal_test.go
+++ b/internal/app/ui/screens/assetsearch_internal_test.go
@@ -45,8 +45,7 @@ func TestCompileRowsForClipboard(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &AssetSearch{}
-			got := a.consolidateRowsToString(tt.rows)
+			got, _ := consolidateAssetRows(tt.rows)
 			xassert.Equal(t, tt.want, got)
 		})
 	}
@@ -91,25 +90,25 @@ func TestMakeCSVFromRows(t *testing.T) {
 		},
 	}
 	t.Run("for character includes owner and tags", func(t *testing.T) {
-		a := &AssetSearch{forCorporation: false}
-		got := string(a.makeCSVFromRows(rows))
-		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner,tags\n" +
+		b, _ := makeCSVFromRows(false, rows)
+		got := string(b)
+		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name,Tags\n" +
 			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne,PVE\n" +
 			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne,\n"
 		xassert.Equal(t, want, got)
 	})
 	t.Run("for corporation includes owner but omits tags", func(t *testing.T) {
-		a := &AssetSearch{forCorporation: true}
-		got := string(a.makeCSVFromRows(rows))
-		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner\n" +
+		b, _ := makeCSVFromRows(true, rows)
+		got := string(b)
+		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name\n" +
 			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne\n" +
 			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne\n"
 		xassert.Equal(t, want, got)
 	})
 	t.Run("no rows returns only header", func(t *testing.T) {
-		a := &AssetSearch{forCorporation: false}
-		got := string(a.makeCSVFromRows(nil))
-		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner,tags\n"
+		b, _ := makeCSVFromRows(false, nil)
+		got := string(b)
+		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name,Tags\n"
 		xassert.Equal(t, want, got)
 	})
 }

--- a/internal/app/ui/screens/assetsearch_internal_test.go
+++ b/internal/app/ui/screens/assetsearch_internal_test.go
@@ -1,0 +1,115 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+)
+
+func TestCompileRowsForClipboard(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []assetRow
+		want string
+	}{
+		{
+			name: "no rows",
+			rows: nil,
+			want: "",
+		},
+		{
+			name: "single row",
+			rows: []assetRow{
+				{typeID: 1, typeName: "Tritanium", quantity: 100},
+			},
+			want: "Tritanium 100\n",
+		},
+		{
+			name: "aggregates quantities for same type",
+			rows: []assetRow{
+				{typeID: 1, typeName: "Tritanium", quantity: 100},
+				{typeID: 1, typeName: "Tritanium", quantity: 50},
+			},
+			want: "Tritanium 150\n",
+		},
+		{
+			name: "sorts multiple types by name",
+			rows: []assetRow{
+				{typeID: 1, typeName: "Tritanium", quantity: 100},
+				{typeID: 2, typeName: "Pyerite", quantity: 20},
+			},
+			want: "Pyerite 20\nTritanium 100\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AssetSearch{}
+			got := a.consolidateRowsToString(tt.rows)
+			xassert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMakeCSVFromRows(t *testing.T) {
+	rows := []assetRow{
+		{
+			itemID:          1000000000001,
+			typeID:          34,
+			typeName:        "Tritanium",
+			name:            "Tritanium Stack",
+			groupID:         18,
+			groupName:       "Mineral",
+			categoryID:      4,
+			categoryName:    "Material",
+			locationName:    "Jita IV - Moon 4",
+			locationFlag:    app.FlagHangar,
+			state:           "Personal",
+			quantity:        1000,
+			isSingleton:     true,
+			variant:         app.VariantBPO,
+			solarSystemID:   30000142,
+			solarSystemName: "Jita",
+			regionID:        10000002,
+			regionName:      "The Forge",
+			price:           optional.New(5.5),
+			total:           optional.New(5500.0),
+			owner:           &app.EveEntity{ID: 1001, Name: "Bruce Wayne"},
+			tagsDisplay:     "PVE",
+		},
+		{
+			itemID:       1000000000002,
+			typeID:       35,
+			typeName:     "Pyerite",
+			groupID:      18,
+			groupName:    "Mineral",
+			locationName: "Jita IV - Moon 4",
+			state:        "Personal",
+			quantity:     50,
+			owner:        &app.EveEntity{ID: 1001, Name: "Bruce Wayne"},
+		},
+	}
+	t.Run("for character includes owner and tags", func(t *testing.T) {
+		a := &AssetSearch{forCorporation: false}
+		got := string(a.makeCSVFromRows(rows))
+		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner,tags\n" +
+			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne,PVE\n" +
+			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne,\n"
+		xassert.Equal(t, want, got)
+	})
+	t.Run("for corporation includes owner but omits tags", func(t *testing.T) {
+		a := &AssetSearch{forCorporation: true}
+		got := string(a.makeCSVFromRows(rows))
+		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner\n" +
+			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne\n" +
+			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne\n"
+		xassert.Equal(t, want, got)
+	})
+	t.Run("no rows returns only header", func(t *testing.T) {
+		a := &AssetSearch{forCorporation: false}
+		got := string(a.makeCSVFromRows(nil))
+		want := "item_id,type_id,type,name,group_id,group,category_id,category,location,location_flag,state,quantity,is_singleton,variant,solar_system_id,solar_system,region_id,region,price,total,owner_id,owner,tags\n"
+		xassert.Equal(t, want, got)
+	})
+}

--- a/internal/app/ui/screens/assetsearch_internal_test.go
+++ b/internal/app/ui/screens/assetsearch_internal_test.go
@@ -1,7 +1,10 @@
 package screens
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
@@ -90,24 +93,30 @@ func TestMakeCSVFromRows(t *testing.T) {
 		},
 	}
 	t.Run("for character includes owner and tags", func(t *testing.T) {
-		b, _ := makeCSVFromRows(false, rows)
-		got := string(b)
+		var b bytes.Buffer
+		err := writeAssetRowsToCSV(&b, rows, false)
+		require.NoError(t, err)
+		got := b.String()
 		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name,Tags\n" +
 			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne,PVE\n" +
 			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne,\n"
 		xassert.Equal(t, want, got)
 	})
 	t.Run("for corporation includes owner but omits tags", func(t *testing.T) {
-		b, _ := makeCSVFromRows(true, rows)
-		got := string(b)
+		var b bytes.Buffer
+		err := writeAssetRowsToCSV(&b, rows, true)
+		require.NoError(t, err)
+		got := b.String()
 		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name\n" +
 			"1000000000001,34,Tritanium,Tritanium Stack,18,Mineral,4,Material,Jita IV - Moon 4,FlagHangar,Personal,1000,true,BPO,30000142,Jita,10000002,The Forge,5.5,5500,1001,Bruce Wayne\n" +
 			"1000000000002,35,Pyerite,,18,Mineral,0,,Jita IV - Moon 4,FlagUndefined,Personal,50,false,,0,,0,,,,1001,Bruce Wayne\n"
 		xassert.Equal(t, want, got)
 	})
 	t.Run("no rows returns only header", func(t *testing.T) {
-		b, _ := makeCSVFromRows(false, nil)
-		got := string(b)
+		var b bytes.Buffer
+		err := writeAssetRowsToCSV(&b, nil, false)
+		require.NoError(t, err)
+		got := b.String()
 		want := "Item ID,Type ID,Type Name,Item Name,Group ID,Group Name,Category ID,Category Name,Location Name,Location Flag,State,Quantity,Is Singleton,Variant,Solar System ID,Solar System Name,Region ID,Region Name,Price,Total,Owner ID,Owner Name,Tags\n"
 		xassert.Equal(t, want, got)
 	})

--- a/internal/app/ui/screens/helper.go
+++ b/internal/app/ui/screens/helper.go
@@ -1,0 +1,79 @@
+package screens
+
+import (
+	"log/slog"
+	"slices"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+)
+
+// copyRowsToClipboard copies rows from a data table to clipboard.
+//
+// The function can be called within the Fyne draw thread.
+func copyRowsToClipboard[T any](u baseUI, topic string, rows []T, transform func([]T) (string, error)) {
+	rows2 := slices.Clone(rows)
+	go func() {
+		s, err := transform(rows2)
+		if err != nil {
+			slog.Error("Failed to copy to clipboard", "topic", topic, "error", err)
+			u.ShowSnackbar("ERROR: Failed to copy " + topic + " to clipboard")
+			return
+		}
+		fyne.DoAndWait(func() {
+			fyne.CurrentApp().Clipboard().SetContent(s)
+		})
+		u.ShowSnackbar("Copied " + topic + " to clipboard")
+	}()
+}
+
+// exportRowsAsCSV exports rows from a datatable to a CSV file.
+//
+// The function can be called within the Fyne draw thread.
+func exportRowsAsCSV[T any](u baseUI, topic string, filename string, rows []T, transform func([]T) ([]byte, error)) {
+	w := u.MainWindow()
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		if writer == nil {
+			return
+		}
+		showError := func(err error) {
+			ui.ShowErrorAndLog("Failed to export "+topic, err, u.IsDeveloperMode(), w)
+		}
+		if err != nil {
+			writer.Close()
+			showError(err)
+			return
+		}
+		rows2 := slices.Clone(rows)
+		go func() {
+			defer writer.Close()
+			data, err := transform(rows2)
+			if err != nil {
+				fyne.Do(func() {
+					showError(err)
+				})
+				return
+			}
+			_, err = writer.Write(data)
+			if err != nil {
+				fyne.Do(func() {
+					showError(err)
+				})
+				return
+			}
+			u.ShowSnackbar("Exported " + topic + " to CSV")
+		}()
+	}, w)
+
+	d.SetFileName(filename)
+	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
+	d.SetTitleText("Export " + topic + " as CSV")
+	d.Show()
+
+	_, s := w.Canvas().InteractiveArea()
+	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
+	d.Resize(winSize)
+}

--- a/internal/app/ui/screens/helper.go
+++ b/internal/app/ui/screens/helper.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"io"
 	"log/slog"
 	"slices"
 
@@ -13,7 +14,7 @@ import (
 
 // copyRowsToClipboard copies rows from a data table to clipboard.
 //
-// The function can be called within the Fyne draw thread.
+// The function can be called in the main thread.
 func copyRowsToClipboard[T any](u baseUI, topic string, rows []T, transform func([]T) (string, error)) {
 	rows2 := slices.Clone(rows)
 	go func() {
@@ -32,8 +33,8 @@ func copyRowsToClipboard[T any](u baseUI, topic string, rows []T, transform func
 
 // exportRowsAsCSV exports rows from a datatable to a CSV file.
 //
-// The function can be called within the Fyne draw thread.
-func exportRowsAsCSV[T any](u baseUI, topic string, filename string, rows []T, transform func([]T) ([]byte, error)) {
+// The function can be called in the main thread.
+func exportRowsAsCSV[T any](u baseUI, topic string, filename string, rows []T, writeRows func(io.Writer, []T) error) {
 	w := u.MainWindow()
 	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
 		if writer == nil {
@@ -50,14 +51,7 @@ func exportRowsAsCSV[T any](u baseUI, topic string, filename string, rows []T, t
 		rows2 := slices.Clone(rows)
 		go func() {
 			defer writer.Close()
-			data, err := transform(rows2)
-			if err != nil {
-				fyne.Do(func() {
-					showError(err)
-				})
-				return
-			}
-			_, err = writer.Write(data)
+			err := writeRows(writer, rows2)
 			if err != nil {
 				fyne.Do(func() {
 					showError(err)

--- a/internal/app/ui/screens/skillcatalogue.go
+++ b/internal/app/ui/screens/skillcatalogue.go
@@ -1,8 +1,10 @@
 package screens
 
 import (
+	"bytes"
 	"cmp"
 	"context"
+	"encoding/csv"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -13,7 +15,6 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -24,6 +25,7 @@ import (
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
+	"github.com/ErikKalkoken/evebuddy/internal/xstrings"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
 )
 
@@ -129,10 +131,10 @@ func NewSkillCatalogue(u baseUI) *SkillCatalogue {
 		theme.MoreHorizontalIcon(),
 		fyne.NewMenu("",
 			fyne.NewMenuItem("Copy skills to clipboard", func() {
-				a.copySkillsToClipboard()
+				a.copyToClipboard()
 			}),
-			fyne.NewMenuItem("Save skills as CSV", func() {
-				a.exportSkillsToCSV()
+			fyne.NewMenuItem("Export skills as CSV", func() {
+				a.exportAsCSV()
 			}),
 		),
 	)
@@ -436,56 +438,67 @@ func makeGridOrList(isMobile bool, length func() int, makeCreateItem func(trunc 
 	return w
 }
 
-func (a *SkillCatalogue) copySkillsToClipboard() {
-	characterID := a.character.Load().IDOrZero()
-	if characterID == 0 {
-		a.u.ShowSnackbar("No skills to copy")
-		return
-	}
-	text, err := a.u.Character().MakeSkillsExportLines(context.Background(), characterID)
-	if err != nil {
-		slog.Error("Failed to generate skill export lines", "characterID", characterID, "err", err)
-		a.u.ShowSnackbar("Failed to copy skills to clipboard")
-		return
-	}
-	fyne.CurrentApp().Clipboard().SetContent(text)
-	a.u.ShowSnackbar("Skills copied to clipboard")
+func (a *SkillCatalogue) copyToClipboard() {
+	copyRowsToClipboard(a.u, "skills", a.rowsFiltered, skillsForClipboard)
 }
 
-func (a *SkillCatalogue) exportSkillsToCSV() {
+type skillExportItem struct {
+	name  string
+	level int64
+}
+
+func skillsForClipboard(rows []skillCatalogueRow) (string, error) {
+	var sb strings.Builder
+	for _, s := range skillCatalogueRowsToItems(rows) {
+		_, _ = fmt.Fprintf(&sb, "%s %d\n", s.name, s.level)
+	}
+	return sb.String(), nil
+
+}
+
+func skillCatalogueRowsToItems(rows []skillCatalogueRow) []skillExportItem {
+	var skills []skillExportItem
+	for _, r := range rows {
+		if r.levelActive == 0 {
+			continue
+		}
+		skills = append(skills, skillExportItem{
+			name:  r.name,
+			level: r.levelActive,
+		})
+	}
+	slices.SortFunc(skills, func(a, b skillExportItem) int {
+		return strings.Compare(a.name, b.name)
+	})
+	return skills
+}
+
+func (a *SkillCatalogue) exportAsCSV() {
 	character := a.character.Load()
 	if character == nil {
-		a.u.ShowSnackbar("No skills to export")
+		a.u.ShowSnackbar("No character")
 		return
 	}
+	fileName := xstrings.SanitizeFilename("skills_" + strings.ReplaceAll(character.NameOrZero(), " ", "") + ".csv")
+	exportRowsAsCSV(a.u, "skills", fileName, a.rowsFiltered, skillCatalogueRowsToCSV)
+}
 
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if writer == nil {
-			return
+func skillCatalogueRowsToCSV(rows []skillCatalogueRow) ([]byte, error) {
+	var buf bytes.Buffer
+	cw := csv.NewWriter(&buf)
+	if err := cw.Write([]string{"Name", "Level"}); err != nil {
+		return nil, err
+	}
+	for _, r := range skillCatalogueRowsToItems(rows) {
+		if err := cw.Write([]string{r.name, fmt.Sprintf("%d", r.level)}); err != nil {
+			return nil, err
 		}
-		defer writer.Close()
-		if err != nil {
-			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
-			return
-		}
-		if err := a.u.Character().WriteSkillsExportCSV(context.Background(), character.ID, writer); err != nil {
-			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
-			return
-		}
-		slog.Info("Skills exported to file", "uri", writer.URI())
-		a.u.ShowSnackbar("Skills saved")
-	}, a.u.MainWindow())
-
-	characterName := character.NameOrZero()
-	fileName := "skills_" + strings.ReplaceAll(characterName, " ", "") + ".csv"
-	d.SetFileName(fileName)
-	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
-	d.SetTitleText("Save skills as CSV - " + characterName)
-	d.Show()
-
-	_, s := a.u.MainWindow().Canvas().InteractiveArea()
-	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
-	d.Resize(winSize)
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // dialogFillLayout is a fyne.Layout that resizes a dialog to match its

--- a/internal/app/ui/screens/skillcatalogue.go
+++ b/internal/app/ui/screens/skillcatalogue.go
@@ -168,7 +168,7 @@ func (a *SkillCatalogue) CreateRenderer() fyne.WidgetRenderer {
 	filter := container.NewHBox(a.selectGroup, a.selectMain, a.sortChip)
 	topBox := container.NewVBox()
 	if a.u.IsMobile() {
-		topBox.Add(a.top)
+		topBox.Add(container.NewBorder(nil, nil, nil, a.moreButton, a.top))
 		topBox.Add(a.searchEntry)
 		topBox.Add(container.NewHScroll(filter))
 	} else {

--- a/internal/app/ui/screens/skillcatalogue.go
+++ b/internal/app/ui/screens/skillcatalogue.go
@@ -1,11 +1,11 @@
 package screens
 
 import (
-	"bytes"
 	"cmp"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"log/slog"
 	"slices"
 	"strings"
@@ -480,25 +480,24 @@ func (a *SkillCatalogue) exportAsCSV() {
 		return
 	}
 	fileName := xstrings.SanitizeFilename("skills_" + strings.ReplaceAll(character.NameOrZero(), " ", "") + ".csv")
-	exportRowsAsCSV(a.u, "skills", fileName, a.rowsFiltered, skillCatalogueRowsToCSV)
+	exportRowsAsCSV(a.u, "skills", fileName, a.rowsFiltered, writeSkillCatalogueRowsToCSV)
 }
 
-func skillCatalogueRowsToCSV(rows []skillCatalogueRow) ([]byte, error) {
-	var buf bytes.Buffer
-	cw := csv.NewWriter(&buf)
+func writeSkillCatalogueRowsToCSV(w io.Writer, rows []skillCatalogueRow) error {
+	cw := csv.NewWriter(w)
 	if err := cw.Write([]string{"Name", "Level"}); err != nil {
-		return nil, err
+		return err
 	}
 	for _, r := range skillCatalogueRowsToItems(rows) {
 		if err := cw.Write([]string{r.name, fmt.Sprintf("%d", r.level)}); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	cw.Flush()
 	if err := cw.Error(); err != nil {
-		return nil, err
+		return err
 	}
-	return buf.Bytes(), nil
+	return nil
 }
 
 // dialogFillLayout is a fyne.Layout that resizes a dialog to match its

--- a/internal/app/ui/screens/skillcatalogue_internal_test.go
+++ b/internal/app/ui/screens/skillcatalogue_internal_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,41 @@ func TestSkillsForClipboard(t *testing.T) {
 		got, err := skillsForClipboard(nil)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", got)
+		}
+	})
+}
+
+func TestWriteSkillCatalogueRowsToCSV(t *testing.T) {
+	t.Run("writes sorted active skills as CSV", func(t *testing.T) {
+		rows := []skillCatalogueRow{
+			{name: "Gunnery", levelActive: 4},
+			{name: "Caldari Frigate", levelActive: 5},
+			{name: "Spaceship Command", levelActive: 3},
+		}
+		var b bytes.Buffer
+		err := writeSkillCatalogueRowsToCSV(&b, rows)
+		if assert.NoError(t, err) {
+			want := "Name,Level\nCaldari Frigate,5\nGunnery,4\nSpaceship Command,3\n"
+			assert.Equal(t, want, b.String())
+		}
+	})
+	t.Run("skips skills that are not active", func(t *testing.T) {
+		rows := []skillCatalogueRow{
+			{name: "Gunnery", levelActive: 4},
+			{name: "Caldari Frigate", levelActive: 0},
+		}
+		var b bytes.Buffer
+		err := writeSkillCatalogueRowsToCSV(&b, rows)
+		if assert.NoError(t, err) {
+			want := "Name,Level\nGunnery,4\n"
+			assert.Equal(t, want, b.String())
+		}
+	})
+	t.Run("no rows returns only header", func(t *testing.T) {
+		var b bytes.Buffer
+		err := writeSkillCatalogueRowsToCSV(&b, nil)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "Name,Level\n", b.String())
 		}
 	})
 }

--- a/internal/app/ui/screens/skillcatalogue_internal_test.go
+++ b/internal/app/ui/screens/skillcatalogue_internal_test.go
@@ -1,0 +1,39 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkillsForClipboard(t *testing.T) {
+	t.Run("formats sorted active skills as name and level", func(t *testing.T) {
+		rows := []skillCatalogueRow{
+			{name: "Gunnery", levelActive: 4},
+			{name: "Caldari Frigate", levelActive: 5},
+			{name: "Spaceship Command", levelActive: 3},
+		}
+		got, err := skillsForClipboard(rows)
+		if assert.NoError(t, err) {
+			want := "Caldari Frigate 5\nGunnery 4\nSpaceship Command 3\n"
+			assert.Equal(t, want, got)
+		}
+	})
+	t.Run("skips skills that are not active", func(t *testing.T) {
+		rows := []skillCatalogueRow{
+			{name: "Gunnery", levelActive: 4},
+			{name: "Caldari Frigate", levelActive: 0},
+		}
+		got, err := skillsForClipboard(rows)
+		if assert.NoError(t, err) {
+			want := "Gunnery 4\n"
+			assert.Equal(t, want, got)
+		}
+	})
+	t.Run("returns empty string for no rows", func(t *testing.T) {
+		got, err := skillsForClipboard(nil)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "", got)
+		}
+	})
+}

--- a/internal/app/ui/screens/training.go
+++ b/internal/app/ui/screens/training.go
@@ -14,9 +14,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -128,7 +126,7 @@ type Training struct {
 	searchEntry  *xwidget.SearchEntry
 	selectStatus *kxwidget.FilterChipSelect
 	selectTag    *kxwidget.FilterChipSelect
-	sortChip *kxwidget.SortChip
+	sortChip     *kxwidget.SortChip
 	u            baseUI
 }
 
@@ -335,15 +333,6 @@ func (a *Training) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(c)
 }
 
-// MoreItems returns the list of menu items for the overflow menu.
-func (a *Training) MoreItems() []*fyne.MenuItem {
-	items := []*fyne.MenuItem{
-		fyne.NewMenuItem("Copy training data to clipboard", a.copyTrainingToClipboard),
-		fyne.NewMenuItem("Save training data as file", a.saveTrainingAsCSV),
-	}
-	return items
-}
-
 func (a *Training) makeDataList() *xwidget.StripedList {
 	p := theme.Padding()
 	l := xwidget.NewStripedList(
@@ -430,8 +419,30 @@ func (a *Training) makeDataList() *xwidget.StripedList {
 	return l
 }
 
-func (a *Training) makeTrainingCSVString() string {
-	rows := a.rowsFiltered
+// MoreItems returns the list of menu items for the overflow menu.
+func (a *Training) MoreItems() []*fyne.MenuItem {
+	items := []*fyne.MenuItem{
+		fyne.NewMenuItem("Copy training to clipboard", a.copyTrainingToClipboard),
+		fyne.NewMenuItem("Export training as CSV", a.saveTrainingAsCSV),
+	}
+	return items
+}
+
+func (a *Training) copyTrainingToClipboard() {
+	copyRowsToClipboard(a.u, "training", a.rowsFiltered, func(rows []trainingRow) (string, error) {
+		b, err := makeTrainingCSVString(rows)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	})
+}
+
+func (a *Training) saveTrainingAsCSV() {
+	exportRowsAsCSV(a.u, "training", "training.csv", a.rowsFiltered, makeTrainingCSVString)
+}
+
+func makeTrainingCSVString(rows []trainingRow) ([]byte, error) {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
 	_ = w.Write([]string{
@@ -453,41 +464,7 @@ func (a *Training) makeTrainingCSVString() string {
 		})
 	}
 	w.Flush()
-	return buf.String()
-}
-
-func (a *Training) copyTrainingToClipboard() {
-	fyne.CurrentApp().Clipboard().SetContent(a.makeTrainingCSVString())
-	a.u.ShowSnackbar("Training data copied to clipboard")
-}
-
-func (a *Training) saveTrainingAsCSV() {
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if writer == nil {
-			return
-		}
-		defer writer.Close()
-		if err != nil {
-			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
-			return
-		}
-		_, err = writer.Write([]byte(a.makeTrainingCSVString()))
-		if err != nil {
-			ui.ShowErrorAndLog("Failed to save file", err, a.u.IsDeveloperMode(), a.u.MainWindow())
-			return
-		}
-		slog.Info("Training data exported to file", "uri", writer.URI())
-		a.u.ShowSnackbar("Training data saved to file")
-	}, a.u.MainWindow())
-
-	d.SetFileName("training.csv")
-	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
-	d.SetTitleText("Save training data")
-	d.Show()
-
-	_, s := a.u.MainWindow().Canvas().InteractiveArea()
-	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
-	d.Resize(winSize)
+	return buf.Bytes(), nil
 }
 
 func (a *Training) filterRowsAsync(sortCol string) {

--- a/internal/app/ui/screens/training.go
+++ b/internal/app/ui/screens/training.go
@@ -430,7 +430,7 @@ func (a *Training) MoreItems() []*fyne.MenuItem {
 
 func (a *Training) copyTrainingToClipboard() {
 	copyRowsToClipboard(a.u, "training", a.rowsFiltered, func(rows []trainingRow) (string, error) {
-		b, err := makeTrainingCSVString(rows)
+		b, err := trainingRowsToCSV(rows)
 		if err != nil {
 			return "", err
 		}
@@ -439,10 +439,10 @@ func (a *Training) copyTrainingToClipboard() {
 }
 
 func (a *Training) saveTrainingAsCSV() {
-	exportRowsAsCSV(a.u, "training", "training.csv", a.rowsFiltered, makeTrainingCSVString)
+	exportRowsAsCSV(a.u, "training", "training.csv", a.rowsFiltered, trainingRowsToCSV)
 }
 
-func makeTrainingCSVString(rows []trainingRow) ([]byte, error) {
+func trainingRowsToCSV(rows []trainingRow) ([]byte, error) {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
 	_ = w.Write([]string{

--- a/internal/app/ui/screens/training.go
+++ b/internal/app/ui/screens/training.go
@@ -7,6 +7,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"slices"
 	"strings"
@@ -430,28 +431,29 @@ func (a *Training) MoreItems() []*fyne.MenuItem {
 
 func (a *Training) copyTrainingToClipboard() {
 	copyRowsToClipboard(a.u, "training", a.rowsFiltered, func(rows []trainingRow) (string, error) {
-		b, err := trainingRowsToCSV(rows)
-		if err != nil {
+		var buf bytes.Buffer
+		if err := writeTrainingRowsToCSV(&buf, rows); err != nil {
 			return "", err
 		}
-		return string(b), nil
+		return buf.String(), nil
 	})
 }
 
 func (a *Training) saveTrainingAsCSV() {
-	exportRowsAsCSV(a.u, "training", "training.csv", a.rowsFiltered, trainingRowsToCSV)
+	exportRowsAsCSV(a.u, "training", "training.csv", a.rowsFiltered, writeTrainingRowsToCSV)
 }
 
-func trainingRowsToCSV(rows []trainingRow) ([]byte, error) {
-	var buf bytes.Buffer
-	w := csv.NewWriter(&buf)
-	_ = w.Write([]string{
+func writeTrainingRowsToCSV(w io.Writer, rows []trainingRow) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{
 		"Character", "Tags", "Current Skill", "Current Remaining",
 		"Queued", "Queue Time", "Trained SP", "Unallocated SP", "Total SP",
-	})
+	}); err != nil {
+		return err
+	}
 	for _, r := range rows {
 		tags := strings.Join(slices.Sorted(r.tags.All()), ";")
-		_ = w.Write([]string{
+		if err := cw.Write([]string{
 			r.characterName,
 			tags,
 			r.skillName,
@@ -461,10 +463,12 @@ func trainingRowsToCSV(rows []trainingRow) ([]byte, error) {
 			r.trainedSPDisplay,
 			r.unallocatedSPDisplay,
 			r.totalSPDisplay,
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	w.Flush()
-	return buf.Bytes(), nil
+	cw.Flush()
+	return cw.Error()
 }
 
 func (a *Training) filterRowsAsync(sortCol string) {

--- a/internal/app/ui/screens/training_internal_test.go
+++ b/internal/app/ui/screens/training_internal_test.go
@@ -129,7 +129,7 @@ func TestTraining_MakeTrainingCSVString(t *testing.T) {
 			},
 		},
 	}
-	got, _ := makeTrainingCSVString(a.rowsFiltered)
+	got, _ := trainingRowsToCSV(a.rowsFiltered)
 	want := "Character,Tags,Current Skill,Current Remaining,Queued,Queue Time,Trained SP,Unallocated SP,Total SP\n" +
 		"Alpha,logistics;pilot,Gunnery V,N/A,3,N/A,10000000,1000000,11000000\n" +
 		"Bravo,,N/A,N/A,,N/A,5000000,0,5000000\n"

--- a/internal/app/ui/screens/training_internal_test.go
+++ b/internal/app/ui/screens/training_internal_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -129,7 +130,10 @@ func TestTraining_MakeTrainingCSVString(t *testing.T) {
 			},
 		},
 	}
-	got, _ := trainingRowsToCSV(a.rowsFiltered)
+	var b bytes.Buffer
+	err := writeTrainingRowsToCSV(&b, a.rowsFiltered)
+	assert.NoError(t, err)
+	got := b.String()
 	want := "Character,Tags,Current Skill,Current Remaining,Queued,Queue Time,Trained SP,Unallocated SP,Total SP\n" +
 		"Alpha,logistics;pilot,Gunnery V,N/A,3,N/A,10000000,1000000,11000000\n" +
 		"Bravo,,N/A,N/A,,N/A,5000000,0,5000000\n"

--- a/internal/app/ui/screens/training_internal_test.go
+++ b/internal/app/ui/screens/training_internal_test.go
@@ -129,7 +129,7 @@ func TestTraining_MakeTrainingCSVString(t *testing.T) {
 			},
 		},
 	}
-	got := a.makeTrainingCSVString()
+	got, _ := makeTrainingCSVString(a.rowsFiltered)
 	want := "Character,Tags,Current Skill,Current Remaining,Queued,Queue Time,Trained SP,Unallocated SP,Total SP\n" +
 		"Alpha,logistics;pilot,Gunnery V,N/A,3,N/A,10000000,1000000,11000000\n" +
 		"Bravo,,N/A,N/A,,N/A,5000000,0,5000000\n"

--- a/internal/xstrings/xstrings.go
+++ b/internal/xstrings/xstrings.go
@@ -2,6 +2,7 @@
 package xstrings
 
 import (
+	"regexp"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -9,6 +10,43 @@ import (
 )
 
 var folder = cases.Fold(cases.NoLower)
+
+// invalidFilenameChars are characters illegal on Windows / unsafe on Android FAT storage.
+var invalidFilenameChars = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
+
+// reservedFilenames are Windows device names, reserved with or without an extension.
+var reservedFilenames = map[string]bool{
+	"CON": true, "PRN": true, "AUX": true, "NUL": true,
+	"COM1": true, "COM2": true, "COM3": true, "COM4": true, "COM5": true,
+	"COM6": true, "COM7": true, "COM8": true, "COM9": true,
+	"LPT1": true, "LPT2": true, "LPT3": true, "LPT4": true, "LPT5": true,
+	"LPT6": true, "LPT7": true, "LPT8": true, "LPT9": true,
+}
+
+// maxFilenameLength keeps the result within the 255 byte limit most filesystems enforce.
+const maxFilenameLength = 255
+
+// SanitizeFilename returns a copy of s usable as a file name on Windows, Unix,
+// macOS and Android. Returns "_" if nothing usable remains.
+func SanitizeFilename(s string) string {
+	s = invalidFilenameChars.ReplaceAllString(s, "_")
+	s = strings.TrimRight(s, " .")
+	if runes := []rune(s); len(runes) > maxFilenameLength {
+		s = strings.TrimRight(string(runes[:maxFilenameLength]), " .")
+	}
+	if s == "" {
+		return "_"
+	}
+	name, ext, hasExt := strings.Cut(s, ".")
+	if reservedFilenames[strings.ToUpper(name)] {
+		if hasExt {
+			s = name + "_." + ext
+		} else {
+			s = name + "_"
+		}
+	}
+	return s
+}
 
 // CompareIgnoreCase works like [strings.Compare], but is case insensitive.
 func CompareIgnoreCase(a, b string) int {

--- a/internal/xstrings/xstrings_test.go
+++ b/internal/xstrings/xstrings_test.go
@@ -1,6 +1,7 @@
 package xstrings_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,6 +141,39 @@ func TestTruncateWithSuffix(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"unchanged for a normal name", "report_2024.txt", "report_2024.txt"},
+		{"replaces windows-invalid characters", `a<b>c:d"e/f\g|h?i*j`, "a_b_c_d_e_f_g_h_i_j"},
+		{"replaces control characters", "a\x00b\x1fc", "a_b_c"},
+		{"trims trailing dots and spaces", "report.txt  ...", "report.txt"},
+		{"keeps a leading dot for hidden files", ".gitignore", ".gitignore"},
+		{"replaces reserved device name", "CON", "CON_"},
+		{"replaces reserved device name case-insensitively", "com1", "com1_"},
+		{"replaces reserved device name with extension", "NUL.txt", "NUL_.txt"},
+		{"leaves non-reserved name that contains a reserved one", "CONSOLE.txt", "CONSOLE.txt"},
+		{"returns fallback for empty string", "", "_"},
+		{"replaces path separators", "///", "___"},
+		{"returns fallback when only dots and spaces", " . . ", "_"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := xstrings.SanitizeFilename(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+	t.Run("truncates overly long names", func(t *testing.T) {
+		in := strings.Repeat("a", 300)
+		got := xstrings.SanitizeFilename(in)
+		assert.LessOrEqual(t, len([]rune(got)), 255)
+		assert.Equal(t, strings.Repeat("a", 255), got)
+	})
 }
 
 func TestRemoveMultiByte(t *testing.T) {


### PR DESCRIPTION
- Added asset export: 
  - Copy asset in consolidated form to clipboard (e.g. for Janice pricing)
  - Export assets to a CSV file
  - Available for both unified assets and corporation asset search
- Consolidated the shared export/clipboard logic used by assets, skills, and training screens. Also all exports now run in their own go routine, preventing any potential UI freeze.
- Fixed: The export feature for skills was not shown on mobile

Closes #504 