### PR TITLE
feat: add notification fixture export

### DIFF
--- a/internal/app/characterservice/notificationfixture.go
+++ b/internal/app/characterservice/notificationfixture.go
@@ -1,0 +1,191 @@
+package characterservice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"maps"
+	"math/rand/v2"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/icrowley/fake"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+)
+
+// idKeyPattern matches ESI notification YAML field names holding entity IDs, e.g. charID, corpID, listOfCharIDs.
+var idKeyPattern = regexp.MustCompile(`ID\d*s?$`)
+
+// nameLinkPattern matches an embedded HTML entity link, e.g. `<a href="showinfo:1376//1001">Bruce Wayne</a>`.
+var nameLinkPattern = regexp.MustCompile(`^(<a href="showinfo:(\d+)(?://\d+)?">).*(</a>)$`)
+
+// ESI "showinfo" category codes used in name links.
+const (
+	linkTypeCharacter   = "1376"
+	linkTypeCorporation = "2"
+	linkTypeAlliance    = "16159"
+)
+
+type notificationFixture struct {
+	NotificationID int64     `json:"notification_id"`
+	Type           string    `json:"type"`
+	SenderID       int64     `json:"sender_id"`
+	SenderType     string    `json:"sender_type"`
+	Timestamp      time.Time `json:"timestamp"`
+	Text           string    `json:"text"`
+	IsRead         bool      `json:"is_read"`
+}
+
+// WriteNotificationTypeFixtures writes the newest notification per distinct type found in
+// storage as JSON, in the evenotification package's testdata shape, with IDs and names anonymized.
+func (s *CharacterService) WriteNotificationTypeFixtures(ctx context.Context, writer io.Writer) error {
+	notifications, err := s.ListAllNotifications(ctx)
+	if err != nil {
+		return err
+	}
+	seen := make(map[app.EveNotificationType]*app.CharacterNotification)
+	for _, n := range notifications {
+		if n.Type == app.UnknownNotification {
+			continue
+		}
+		if cur, ok := seen[n.Type]; !ok || n.Timestamp.After(cur.Timestamp) {
+			seen[n.Type] = n
+		}
+	}
+	types := slices.Collect(maps.Keys(seen))
+	slices.SortFunc(types, func(a, b app.EveNotificationType) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	fixtures := make([]notificationFixture, 0, len(types))
+	for _, t := range types {
+		n := seen[t]
+		ids := make(map[int64]int64) // reset per entry so substitutions stay consistent within it
+
+		text, _ := n.Text.Value()
+		anonymizedText := text
+		if text != "" {
+			var data any
+			if err := yaml.Unmarshal([]byte(text), &data); err != nil {
+				return err
+			}
+			data = anonymize(data, ids)
+			b, err := yaml.Marshal(data)
+			if err != nil {
+				return err
+			}
+			anonymizedText = string(b)
+		}
+
+		fixtures = append(fixtures, notificationFixture{
+			NotificationID: n.NotificationID,
+			Type:           n.Type.String(),
+			SenderID:       anonymizeID(n.Sender.ID, ids),
+			SenderType:     n.Sender.Category.String(),
+			Timestamp:      n.Timestamp,
+			Text:           anonymizedText,
+			IsRead:         n.IsRead,
+		})
+	}
+	b, err := json.MarshalIndent(fixtures, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(b)
+	return err
+}
+
+// anonymize recursively anonymizes a decoded YAML value: IDs under keys matching idKeyPattern
+// via ids, and every other string via [anonymizeString].
+func anonymize(v any, ids map[int64]int64) any {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, val := range x {
+			if idKeyPattern.MatchString(k) {
+				x[k] = anonymizeIDValue(val, ids)
+			} else {
+				x[k] = anonymize(val, ids)
+			}
+		}
+		return x
+	case []any:
+		for i, val := range x {
+			x[i] = anonymize(val, ids)
+		}
+		return x
+	case string:
+		return anonymizeString(x)
+	default:
+		return v
+	}
+}
+
+// anonymizeIDValue anonymizes a value under an ID-like key: an integer ID (or numeric ID string), or a list of those.
+func anonymizeIDValue(v any, ids map[int64]int64) any {
+	switch x := v.(type) {
+	case string:
+		if id, err := strconv.ParseInt(x, 10, 64); err == nil {
+			return strconv.FormatInt(anonymizeID(id, ids), 10)
+		}
+		return anonymizeString(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = anonymizeIDValue(item, ids)
+		}
+		return out
+	default:
+		if id, ok := toInt64(x); ok {
+			return anonymizeID(id, ids)
+		}
+		return x
+	}
+}
+
+// anonymizeString replaces a free-form YAML string with random placeholder content, preserving
+// empty strings, the "showinfo" literal, and the href structure of embedded name links (only their
+// display name is replaced), since those are required by evenotification's parsing/branching logic.
+func anonymizeString(s string) string {
+	if s == "" || s == "showinfo" {
+		return s
+	}
+	if m := nameLinkPattern.FindStringSubmatch(s); m != nil {
+		prefix, code, suffix := m[1], m[2], m[3]
+		switch code {
+		case linkTypeCharacter:
+			return prefix + fake.FullName() + suffix
+		case linkTypeCorporation, linkTypeAlliance:
+			return prefix + fake.Company() + suffix
+		default:
+			return s
+		}
+	}
+	n := min(max(len(strings.Fields(s)), 1), 10)
+	return fake.WordsN(n)
+}
+
+// toInt64 converts the integer types produced by the YAML decoder (int64 or uint64) into an int64.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case uint64:
+		return int64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// anonymizeID returns a random placeholder for orig, reusing prior placeholders from ids.
+func anonymizeID(orig int64, ids map[int64]int64) int64 {
+	if v, ok := ids[orig]; ok {
+		return v
+	}
+	v := rand.Int64N(900_000_000) + 100_000_000
+	ids[orig] = v
+	return v
+}

--- a/internal/app/characterservice/notificationfixture_test.go
+++ b/internal/app/characterservice/notificationfixture_test.go
@@ -1,0 +1,167 @@
+package characterservice_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+)
+
+func TestWriteNotificationTypeFixtures(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := characterservice.NewFake(characterservice.Params{Storage: st})
+	now := time.Now().UTC()
+
+	sender := factory.CreateEveEntityCharacter()
+	factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+		Type:      "CorpAppNewMsg",
+		SenderID:  sender.ID,
+		Timestamp: now.Add(-time.Hour), // older, should be replaced by the newer one below
+		Text:      optional.New("applicationText: example\ncharID: 1011\ncorpID: 2001\n"),
+		IsRead:    false,
+	})
+	newest := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+		Type:      "CorpAppNewMsg",
+		SenderID:  sender.ID,
+		Timestamp: now,
+		Text:      optional.New("applicationText: example\ncharID: 1011\nallyCharID: 1011\ncorpID: 2001\n"),
+		IsRead:    true,
+	})
+	factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+		Type:      "CharAppAcceptMsg",
+		SenderID:  factory.CreateEveEntityCorporation().ID,
+		Timestamp: now,
+		Text:      optional.New("charID: 1011\ncorpID: 2001\n"),
+	})
+	factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+		Type:      "NotAKnownESIType",
+		Timestamp: now,
+	})
+
+	var buf bytes.Buffer
+	err := cs.WriteNotificationTypeFixtures(t.Context(), &buf)
+	require.NoError(t, err)
+
+	var got []struct {
+		NotificationID int64     `json:"notification_id"`
+		Type           string    `json:"type"`
+		SenderID       int64     `json:"sender_id"`
+		SenderType     string    `json:"sender_type"`
+		Timestamp      time.Time `json:"timestamp"`
+		Text           string    `json:"text"`
+		IsRead         bool      `json:"is_read"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+	// one fixture per known type, unknown type excluded
+	require.Len(t, got, 2)
+	types := []string{got[0].Type, got[1].Type}
+	assert.ElementsMatch(t, []string{"CorpAppNewMsg", "CharAppAcceptMsg"}, types)
+
+	var corpAppNewMsg struct {
+		NotificationID int64
+		Type           string
+		SenderID       int64
+		SenderType     string
+		Timestamp      time.Time
+		Text           string
+		IsRead         bool
+	}
+	for _, x := range got {
+		if x.Type == "CorpAppNewMsg" {
+			corpAppNewMsg.NotificationID = x.NotificationID
+			corpAppNewMsg.SenderID = x.SenderID
+			corpAppNewMsg.SenderType = x.SenderType
+			corpAppNewMsg.Text = x.Text
+			corpAppNewMsg.IsRead = x.IsRead
+		}
+	}
+
+	// the newest notification for the type was picked, not the older one
+	assert.Equal(t, newest.NotificationID, corpAppNewMsg.NotificationID)
+	assert.True(t, corpAppNewMsg.IsRead)
+	assert.Equal(t, "character", corpAppNewMsg.SenderType)
+
+	// sender ID and IDs in text are anonymized
+	assert.NotEqual(t, sender.ID, corpAppNewMsg.SenderID)
+	assert.NotContains(t, corpAppNewMsg.Text, "1011")
+	assert.NotContains(t, corpAppNewMsg.Text, "2001")
+
+	// the same original ID (charID and allyCharID both 1011) maps to the same placeholder
+	var data map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(corpAppNewMsg.Text), &data))
+	charID, ok := data["charID"]
+	require.True(t, ok)
+	allyCharID, ok := data["allyCharID"]
+	require.True(t, ok)
+	assert.Equal(t, charID, allyCharID)
+	assert.NotEqual(t, int64(1011), charID)
+}
+
+func TestWriteNotificationTypeFixtures_AnonymizesStrings(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := characterservice.NewFake(characterservice.Params{Storage: st})
+
+	text := "" +
+		"corpName: Wayne Enterprises\n" +
+		"corpLink: <a href=\"showinfo:2//2001\">Wayne Enterprises</a>\n" +
+		"corpLinkData:\n" +
+		"- showinfo\n" +
+		"- 2\n" +
+		"- 2001\n" +
+		"firedByLink: <a href=\"showinfo:1376//1001\">Bruce Wayne</a>\n" +
+		"applicationText: please let me join your corporation\n"
+	factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+		Type: "CorpAppNewMsg",
+		Text: optional.New(text),
+	})
+
+	var buf bytes.Buffer
+	err := cs.WriteNotificationTypeFixtures(t.Context(), &buf)
+	require.NoError(t, err)
+
+	var got []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	anonymized := got[0].Text
+
+	var data map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(anonymized), &data))
+
+	// the "showinfo" literal marker in *LinkData arrays must be preserved
+	linkData, ok := data["corpLinkData"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, "showinfo", linkData[0])
+
+	// name links keep their href structure but get a new display name
+	corpLink, ok := data["corpLink"].(string)
+	require.True(t, ok)
+	assert.Regexp(t, `^<a href="showinfo:2//2001">.+</a>$`, corpLink)
+	assert.NotContains(t, corpLink, "Wayne Enterprises")
+
+	firedByLink, ok := data["firedByLink"].(string)
+	require.True(t, ok)
+	assert.Regexp(t, `^<a href="showinfo:1376//1001">.+</a>$`, firedByLink)
+	assert.NotContains(t, firedByLink, "Bruce Wayne")
+
+	// generic free text fields are replaced too
+	corpName, ok := data["corpName"].(string)
+	require.True(t, ok)
+	assert.NotEqual(t, "Wayne Enterprises", corpName)
+	applicationText, ok := data["applicationText"].(string)
+	require.True(t, ok)
+	assert.NotEqual(t, "please let me join your corporation", applicationText)
+}

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -40,6 +40,7 @@ type baseUI interface {
 	IsDeveloperMode() bool
 	IsMobile() bool
 	IsOffline() bool
+	MainWindow() fyne.Window
 	Signals() *app.Signals
 	StatusCache() *statuscache.StatusCache
 }
@@ -182,8 +183,10 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 	if a.u.IsDeveloperMode() {
 		items = append(items,
 			fyne.NewMenuItemSeparator(),
-			fyne.NewMenuItem("Export notification type fixtures", func() {
+			fyne.NewMenuItem("Export notification fixtures...", func() {
+				w2, _, _ := a.u.GetOrCreateWindowWithOnClosed("", "Export notification fixtures")
 				d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+					defer w2.Close()
 					if writer == nil {
 						return
 					}
@@ -199,13 +202,19 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 							fyne.Do(func() { a.sb.Show("Error: " + a.u.ErrorDisplay(err)) })
 							return
 						}
-						fyne.Do(func() { a.sb.Show("Notification type fixtures exported") })
+						fyne.Do(func() { a.sb.Show("Notification fixtures exported") })
 					}()
-				}, w)
+				}, w2)
 				d.SetFileName("notification_fixtures.json")
 				d.SetFilter(storage.NewExtensionFileFilter([]string{".json"}))
-				d.SetTitleText("Export notification type fixtures")
+
+				_, s := u.MainWindow().Canvas().InteractiveArea()
+				winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
+				w2.Resize(winSize)
 				d.Show()
+				d.Resize(winSize)
+				w2.SetFixedSize(true)
+				w2.Show()
 			}),
 		)
 	}

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -10,7 +10,9 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -35,6 +37,7 @@ type baseUI interface {
 	EVEImage() ui.EVEImageService
 	EVEUniverse() *eveuniverseservice.EVEUniverseService
 	GetOrCreateWindowWithOnClosed(id string, titles ...string) (window fyne.Window, created bool, onClosed func())
+	IsDeveloperMode() bool
 	IsMobile() bool
 	IsOffline() bool
 	Signals() *app.Signals
@@ -126,7 +129,7 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 	a.entityMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreHorizontalIcon(), fyne.NewMenu(""))
 	a.sectionMoreButton = kxwidget.NewIconButtonWithMenu(theme.MoreHorizontalIcon(), fyne.NewMenu(""))
 
-	menu := fyne.NewMenu("",
+	items := []*fyne.MenuItem{
 		fyne.NewMenuItem("Reload all characters", func() {
 			go func() {
 				err := a.u.Character().UpdateCharactersIfNeeded(context.Background(), true)
@@ -175,7 +178,38 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 			}()
 			a.sb.Show("Started reloading notifications")
 		}),
-	)
+	}
+	if a.u.IsDeveloperMode() {
+		items = append(items,
+			fyne.NewMenuItemSeparator(),
+			fyne.NewMenuItem("Export notification type fixtures", func() {
+				d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+					if writer == nil {
+						return
+					}
+					if err != nil {
+						a.sb.Show("Error: " + a.u.ErrorDisplay(err))
+						return
+					}
+					go func() {
+						defer writer.Close()
+						err := a.u.Character().WriteNotificationTypeFixtures(context.Background(), writer)
+						if err != nil {
+							slog.Error("update status", "error", err)
+							fyne.Do(func() { a.sb.Show("Error: " + a.u.ErrorDisplay(err)) })
+							return
+						}
+						fyne.Do(func() { a.sb.Show("Notification type fixtures exported") })
+					}()
+				}, w)
+				d.SetFileName("notification_fixtures.json")
+				d.SetFilter(storage.NewExtensionFileFilter([]string{".json"}))
+				d.SetTitleText("Export notification type fixtures")
+				d.Show()
+			}),
+		)
+	}
+	menu := fyne.NewMenu("", items...)
 	moreButton := kxwidget.NewIconButtonWithMenu(theme.MoreHorizontalIcon(), menu)
 	if a.u.IsOffline() {
 		moreButton.Disable()


### PR DESCRIPTION
Added the ability to export samples of character notifications as fixtures. This feature is available on the update status window (more button) and shown in developer mode only. Only one sample per notification type will be exported. All IDs and names are anonymized.

The purpose of this new feature is to provide users an easy way to share notification fixtures with us. This will enable us to add support for currently missing notification types.