### PR TITLE
feat: show file dialogs in windows on desktp

### DIFF
--- a/internal/app/ui/charactermanager/charactermanager.go
+++ b/internal/app/ui/charactermanager/charactermanager.go
@@ -31,13 +31,15 @@ type baseUI interface {
 	CurrentCorporation() *app.Corporation
 	ErrorDisplay(err error) string
 	EVEImage() ui.EVEImageService
+	GetOrCreateWindow(id string, titles ...string) (window fyne.Window, created bool)
 	GetOrCreateWindowWithOnClosed(id string, titles ...string) (window fyne.Window, created bool, onClosed func())
-	IsMobile() bool
 	IsDeveloperMode() bool
+	IsMobile() bool
 	IsOffline() bool
 	IsUpdateDisabled() bool
 	LoadCharacter(ctx context.Context, id int64) error
 	LoadCorporation(ctx context.Context, id int64) error
+	MainWindow() fyne.Window
 	SetAnyCharacter(ctx context.Context) error
 	SetAnyCorporation(ctx context.Context) error
 	Signals() *app.Signals

--- a/internal/app/ui/charactermanager/manageTags.go
+++ b/internal/app/ui/charactermanager/manageTags.go
@@ -3,6 +3,7 @@ package charactermanager
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"strings"
 
@@ -19,6 +20,7 @@ import (
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui/filedialog"
 	"github.com/ErikKalkoken/evebuddy/internal/xdesktop"
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
@@ -83,7 +85,7 @@ func (a *manageTags) CreateRenderer() fyne.WidgetRenderer {
 		a.tagList,
 	)
 	actions := kxwidget.NewIconButtonWithMenu(theme.MoreHorizontalIcon(), fyne.NewMenu("",
-		fyne.NewMenuItem("Save tags to file", a.exportTags),
+		fyne.NewMenuItem("Export tags", a.exportTags),
 		fyne.NewMenuItem("Replace tags from file", a.importTags),
 		fyne.NewMenuItem("Delete all tags", a.deleteTags),
 	))
@@ -118,40 +120,16 @@ func (a *manageTags) deleteTags() {
 }
 
 func (a *manageTags) exportTags() {
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if writer == nil {
-			return
-		}
-		m := kmodal.NewProgressInfinite(
-			"Saving tags to file",
-			"Saving...",
-			func() error {
-				defer writer.Close()
-				if err != nil {
-					return err
-				}
-				err := a.cw.u.Character().WriteTags(context.Background(), writer, fyne.CurrentApp().Metadata().Version)
-				if err != nil {
-					return err
-				}
-				slog.Info("Tags exported to file", "uri", writer.URI())
-				a.cw.sb.Show("Tags exported")
-				return nil
-			},
-			a.cw.w,
-		)
-		m.OnError = func(err error) {
-			fyne.Do(func() {
-				ui.ShowErrorAndLog("Failed to export tags", err, a.cw.u.IsDeveloperMode(), a.cw.w)
-			})
-		}
-		m.Start()
-	},
-		a.cw.w,
-	)
-	kxdialog.AddDialogKeyHandler(d, a.cw.w)
-	d.SetTitleText("Save tags to file")
-	d.Show()
+	filedialog.ShowSave(a.cw.u, filedialog.ShowFileSaveWindowParams{
+		CompletionText: "Tags exported",
+		ShowSnackbar:   a.cw.sb.Show,
+		Title:          "Export tags",
+		WindowID:       "tags-export",
+		WriteFunc: func(ctx context.Context, w io.Writer) error {
+			return a.cw.u.Character().WriteTags(ctx, w, fyne.CurrentApp().Metadata().Version)
+		},
+		Window: a.cw.w,
+	})
 }
 
 func (a *manageTags) importTags() {

--- a/internal/app/ui/charactermanager/manageTags.go
+++ b/internal/app/ui/charactermanager/manageTags.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log/slog"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -12,8 +11,6 @@ import (
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
-	kxdialog "github.com/ErikKalkoken/fyne-kx/dialog"
-	kmodal "github.com/ErikKalkoken/fyne-kx/modal"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
 	"github.com/ErikKalkoken/go-set"
 	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
@@ -86,7 +83,7 @@ func (a *manageTags) CreateRenderer() fyne.WidgetRenderer {
 	)
 	actions := kxwidget.NewIconButtonWithMenu(theme.MoreHorizontalIcon(), fyne.NewMenu("",
 		fyne.NewMenuItem("Export tags", a.exportTags),
-		fyne.NewMenuItem("Replace tags from file", a.importTags),
+		fyne.NewMenuItem("Import tags", a.importTags),
 		fyne.NewMenuItem("Delete all tags", a.deleteTags),
 	))
 	ab := xwidget.NewAppBar("Tags", main, actions)
@@ -133,43 +130,23 @@ func (a *manageTags) exportTags() {
 }
 
 func (a *manageTags) importTags() {
-	d := dialog.NewFileOpen(func(reader fyne.URIReadCloser, err error) {
-		m := kmodal.NewProgressInfinite(
-			"Replacing tags from file",
-			"Replacing...",
-			func() error {
-				if reader == nil {
-					return nil
-				}
-				defer reader.Close()
-				if err != nil {
-					return err
-				}
-				ctx := context.Background()
-				err = a.cw.u.Character().ReadAndReplaceTags(ctx, reader, fyne.CurrentApp().Metadata().Version)
-				if err != nil {
-					return err
-				}
-				a.update(ctx)
-				go a.cw.u.Signals().TagsChanged.Emit(ctx, struct{}{})
-				slog.Info("Tags imported from file", "uri", reader.URI())
-				return nil
-			},
-			a.cw.w,
-		)
-		m.OnError = func(err error) {
-			fyne.Do(func() {
-				ui.ShowErrorAndLog("Failed to import tags", err, a.cw.u.IsDeveloperMode(), a.cw.w)
-			})
-		}
-		m.Start()
-	},
-		a.cw.w,
-	)
-	kxdialog.AddDialogKeyHandler(d, a.cw.w)
-	d.SetTitleText("Replace tags from file")
-	d.SetConfirmText("Replace")
-	d.Show()
+	filedialog.ShowOpen(a.cw.u, filedialog.ShowFileOpenWindowParams{
+		CompletionText: "Tags imported",
+		ShowSnackbar:   a.cw.sb.Show,
+		Title:          "Import tags",
+		WindowID:       "tags-import",
+		ReadFunc: func(ctx context.Context, r io.Reader) error {
+			err := a.cw.u.Character().ReadAndReplaceTags(ctx, r, fyne.CurrentApp().Metadata().Version)
+			if err != nil {
+				return err
+			}
+			a.update(ctx)
+			go a.cw.u.Signals().TagsChanged.Emit(ctx, struct{}{})
+			return nil
+		},
+		Window: a.cw.w,
+	})
+
 }
 
 func (a *manageTags) makeManageCharacters() *xwidget.AppBar {

--- a/internal/app/ui/filedialog/filedialog.go
+++ b/internal/app/ui/filedialog/filedialog.go
@@ -38,9 +38,33 @@ func ShowSave(u baseUI, arg ShowFileSaveWindowParams) {
 	}
 
 	w, _ := u.GetOrCreateWindow(arg.WindowID, arg.Title)
-
 	d := createFileSaveDialog(u, arg, w)
+	showDialogInWindow(u, w, d)
+}
 
+type ShowFileOpenWindowParams struct {
+	CompletionText string
+	Extensions     []string
+	ShowSnackbar   func(string)
+	Title          string
+	WindowID       string // optional
+	ReadFunc       func(ctx context.Context, r io.Reader) error
+	Window         fyne.Window // required when running on mobile; used as the native picker's parent
+}
+
+func ShowOpen(u baseUI, arg ShowFileOpenWindowParams) {
+	if u.IsMobile() {
+		d := createFileOpenDialog(u, arg, arg.Window)
+		d.Show()
+		return
+	}
+
+	w, _ := u.GetOrCreateWindow(arg.WindowID, arg.Title)
+	d := createFileOpenDialog(u, arg, w)
+	showDialogInWindow(u, w, d)
+}
+
+func showDialogInWindow(u baseUI, w fyne.Window, d *dialog.FileDialog) {
 	_, s := u.MainWindow().Canvas().InteractiveArea()
 	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
 	d.SetOnClosed(func() {
@@ -78,6 +102,34 @@ func createFileSaveDialog(u baseUI, arg ShowFileSaveWindowParams, w fyne.Window)
 	if arg.Filename != "" {
 		d.SetFileName(arg.Filename)
 	}
+	if len(arg.Extensions) > 0 {
+		d.SetFilter(storage.NewExtensionFileFilter(arg.Extensions))
+	}
+	return d
+}
+
+func createFileOpenDialog(u baseUI, arg ShowFileOpenWindowParams, w fyne.Window) *dialog.FileDialog {
+	d := dialog.NewFileOpen(func(reader fyne.URIReadCloser, err error) {
+		if err != nil {
+			arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+			return
+		}
+		if reader == nil {
+			return
+		}
+		go func() {
+			defer reader.Close()
+			err := arg.ReadFunc(context.Background(), reader)
+			if err != nil {
+				slog.Error(arg.Title, "error", err)
+				fyne.Do(func() {
+					arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+				})
+				return
+			}
+			fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
+		}()
+	}, w)
 	if len(arg.Extensions) > 0 {
 		d.SetFilter(storage.NewExtensionFileFilter(arg.Extensions))
 	}

--- a/internal/app/ui/filedialog/filedialog.go
+++ b/internal/app/ui/filedialog/filedialog.go
@@ -79,25 +79,7 @@ func showDialogInWindow(u baseUI, w fyne.Window, d *dialog.FileDialog) {
 
 func createFileSaveDialog(u baseUI, arg ShowFileSaveWindowParams, w fyne.Window) *dialog.FileDialog {
 	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if err != nil {
-			arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
-			return
-		}
-		if writer == nil {
-			return
-		}
-		go func() {
-			defer writer.Close()
-			err := arg.WriteFunc(context.Background(), writer)
-			if err != nil {
-				slog.Error(arg.Title, "error", err)
-				fyne.Do(func() {
-					arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
-				})
-				return
-			}
-			fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
-		}()
+		handleSaveResult(u, arg, writer, err)
 	}, w)
 	if arg.Filename != "" {
 		d.SetFileName(arg.Filename)
@@ -108,30 +90,56 @@ func createFileSaveDialog(u baseUI, arg ShowFileSaveWindowParams, w fyne.Window)
 	return d
 }
 
+func handleSaveResult(u baseUI, arg ShowFileSaveWindowParams, writer fyne.URIWriteCloser, err error) {
+	if err != nil {
+		arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+		return
+	}
+	if writer == nil {
+		return
+	}
+	go func() {
+		defer writer.Close()
+		err := arg.WriteFunc(context.Background(), writer)
+		if err != nil {
+			slog.Error(arg.Title, "error", err)
+			fyne.Do(func() {
+				arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+			})
+			return
+		}
+		fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
+	}()
+}
+
 func createFileOpenDialog(u baseUI, arg ShowFileOpenWindowParams, w fyne.Window) *dialog.FileDialog {
 	d := dialog.NewFileOpen(func(reader fyne.URIReadCloser, err error) {
-		if err != nil {
-			arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
-			return
-		}
-		if reader == nil {
-			return
-		}
-		go func() {
-			defer reader.Close()
-			err := arg.ReadFunc(context.Background(), reader)
-			if err != nil {
-				slog.Error(arg.Title, "error", err)
-				fyne.Do(func() {
-					arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
-				})
-				return
-			}
-			fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
-		}()
+		handleOpenResult(u, arg, reader, err)
 	}, w)
 	if len(arg.Extensions) > 0 {
 		d.SetFilter(storage.NewExtensionFileFilter(arg.Extensions))
 	}
 	return d
+}
+
+func handleOpenResult(u baseUI, arg ShowFileOpenWindowParams, reader fyne.URIReadCloser, err error) {
+	if err != nil {
+		arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+		return
+	}
+	if reader == nil {
+		return
+	}
+	go func() {
+		defer reader.Close()
+		err := arg.ReadFunc(context.Background(), reader)
+		if err != nil {
+			slog.Error(arg.Title, "error", err)
+			fyne.Do(func() {
+				arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+			})
+			return
+		}
+		fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
+	}()
 }

--- a/internal/app/ui/filedialog/filedialog.go
+++ b/internal/app/ui/filedialog/filedialog.go
@@ -1,0 +1,83 @@
+// Package filedialog shows file dialogs, in a window on desktop and natively on mobile.
+package filedialog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+)
+
+type baseUI interface {
+	ErrorDisplay(err error) string
+	GetOrCreateWindow(id string, titles ...string) (window fyne.Window, created bool)
+	IsDeveloperMode() bool
+	IsMobile() bool
+	MainWindow() fyne.Window
+}
+
+type ShowFileSaveWindowParams struct {
+	CompletionText string
+	Extensions     []string
+	Filename       string
+	ShowSnackbar   func(string)
+	Title          string
+	WindowID       string // optional
+	WriteFunc      func(ctx context.Context, w io.Writer) error
+	Window         fyne.Window // required when running on mobile; used as the native picker's parent
+}
+
+func ShowSave(u baseUI, arg ShowFileSaveWindowParams) {
+	if u.IsMobile() {
+		d := createFileSaveDialog(u, arg, arg.Window)
+		d.Show()
+		return
+	}
+
+	w, _ := u.GetOrCreateWindow(arg.WindowID, arg.Title)
+
+	d := createFileSaveDialog(u, arg, w)
+
+	_, s := u.MainWindow().Canvas().InteractiveArea()
+	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
+	d.SetOnClosed(func() {
+		w.Close()
+	})
+	w.Resize(winSize)
+	d.Show()
+	d.Resize(winSize)
+	w.SetFixedSize(true)
+	w.Show()
+}
+
+func createFileSaveDialog(u baseUI, arg ShowFileSaveWindowParams, w fyne.Window) *dialog.FileDialog {
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		if err != nil {
+			arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+			return
+		}
+		if writer == nil {
+			return
+		}
+		go func() {
+			defer writer.Close()
+			err := arg.WriteFunc(context.Background(), writer)
+			if err != nil {
+				slog.Error(arg.Title, "error", err)
+				fyne.Do(func() {
+					arg.ShowSnackbar("Error: " + u.ErrorDisplay(err))
+				})
+				return
+			}
+			fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
+		}()
+	}, w)
+	d.SetFileName(arg.Filename)
+	if len(arg.Extensions) > 0 {
+		d.SetFilter(storage.NewExtensionFileFilter(arg.Extensions))
+	}
+	return d
+}

--- a/internal/app/ui/filedialog/filedialog.go
+++ b/internal/app/ui/filedialog/filedialog.go
@@ -75,7 +75,9 @@ func createFileSaveDialog(u baseUI, arg ShowFileSaveWindowParams, w fyne.Window)
 			fyne.Do(func() { arg.ShowSnackbar(arg.CompletionText) })
 		}()
 	}, w)
-	d.SetFileName(arg.Filename)
+	if arg.Filename != "" {
+		d.SetFileName(arg.Filename)
+	}
 	if len(arg.Extensions) > 0 {
 		d.SetFilter(storage.NewExtensionFileFilter(arg.Extensions))
 	}

--- a/internal/app/ui/filedialog/filedialog_internal_test.go
+++ b/internal/app/ui/filedialog/filedialog_internal_test.go
@@ -1,0 +1,343 @@
+package filedialog
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// UIServiceFake is a minimal baseUI implementation for unit tests.
+type UIServiceFake struct {
+	app        fyne.App
+	mainWindow fyne.Window
+
+	isMobile bool
+
+	getOrCreateWindowCalls int
+	lastWindowID           string
+	lastTitle              string
+	lastCreatedWindow       fyne.Window
+}
+
+func newUIServiceFake(a fyne.App) *UIServiceFake {
+	return &UIServiceFake{app: a, mainWindow: a.NewWindow("Main")}
+}
+
+func (u *UIServiceFake) ErrorDisplay(err error) string { return err.Error() }
+
+func (u *UIServiceFake) GetOrCreateWindow(id string, titles ...string) (fyne.Window, bool) {
+	u.getOrCreateWindowCalls++
+	u.lastWindowID = id
+	u.lastTitle = strings.Join(titles, " - ")
+	u.lastCreatedWindow = u.app.NewWindow(u.lastTitle)
+	return u.lastCreatedWindow, true
+}
+
+func (u *UIServiceFake) IsDeveloperMode() bool   { return false }
+func (u *UIServiceFake) IsMobile() bool          { return u.isMobile }
+func (u *UIServiceFake) MainWindow() fyne.Window { return u.mainWindow }
+
+var _ baseUI = (*UIServiceFake)(nil)
+
+func TestHandleSaveResult(t *testing.T) {
+	t.Run("shows error and skips write func when the dialog reports an error", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		msgs := make(chan string, 1)
+		called := false
+		arg := ShowFileSaveWindowParams{
+			ShowSnackbar: func(s string) { msgs <- s },
+			WriteFunc: func(context.Context, io.Writer) error {
+				called = true
+				return nil
+			},
+		}
+
+		handleSaveResult(u, arg, nil, errors.New("boom"))
+
+		assert.False(t, called)
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "Error: boom", msg)
+		default:
+			t.Fatal("expected a snackbar message")
+		}
+	})
+
+	t.Run("silently ignores a nil writer with no error", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		called := false
+		arg := ShowFileSaveWindowParams{
+			ShowSnackbar: func(s string) { t.Fatalf("unexpected snackbar: %s", s) },
+			WriteFunc: func(context.Context, io.Writer) error {
+				called = true
+				return nil
+			},
+		}
+
+		handleSaveResult(u, arg, nil, nil)
+
+		assert.False(t, called)
+	})
+
+	t.Run("writes the file and shows completion text on success", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		path := filepath.Join(t.TempDir(), "out.txt")
+		writer, err := storage.SaveFileToURI(storage.NewFileURI(path))
+		require.NoError(t, err)
+		msgs := make(chan string, 1)
+		arg := ShowFileSaveWindowParams{
+			CompletionText: "done",
+			ShowSnackbar:   func(s string) { msgs <- s },
+			WriteFunc: func(_ context.Context, w io.Writer) error {
+				_, err := w.Write([]byte("hello"))
+				return err
+			},
+		}
+
+		handleSaveResult(u, arg, writer, nil)
+
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "done", msg)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for snackbar")
+		}
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
+	})
+
+	t.Run("shows error text when write func fails", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		path := filepath.Join(t.TempDir(), "out.txt")
+		writer, err := storage.SaveFileToURI(storage.NewFileURI(path))
+		require.NoError(t, err)
+		msgs := make(chan string, 1)
+		arg := ShowFileSaveWindowParams{
+			ShowSnackbar: func(s string) { msgs <- s },
+			WriteFunc: func(context.Context, io.Writer) error {
+				return errors.New("disk full")
+			},
+		}
+
+		handleSaveResult(u, arg, writer, nil)
+
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "Error: disk full", msg)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for snackbar")
+		}
+	})
+}
+
+func TestHandleOpenResult(t *testing.T) {
+	t.Run("shows error and skips read func when the dialog reports an error", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		msgs := make(chan string, 1)
+		called := false
+		arg := ShowFileOpenWindowParams{
+			ShowSnackbar: func(s string) { msgs <- s },
+			ReadFunc: func(context.Context, io.Reader) error {
+				called = true
+				return nil
+			},
+		}
+
+		handleOpenResult(u, arg, nil, errors.New("boom"))
+
+		assert.False(t, called)
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "Error: boom", msg)
+		default:
+			t.Fatal("expected a snackbar message")
+		}
+	})
+
+	t.Run("silently ignores a nil reader with no error", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		called := false
+		arg := ShowFileOpenWindowParams{
+			ShowSnackbar: func(s string) { t.Fatalf("unexpected snackbar: %s", s) },
+			ReadFunc: func(context.Context, io.Reader) error {
+				called = true
+				return nil
+			},
+		}
+
+		handleOpenResult(u, arg, nil, nil)
+
+		assert.False(t, called)
+	})
+
+	t.Run("reads the file and shows completion text on success", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		path := filepath.Join(t.TempDir(), "in.txt")
+		require.NoError(t, os.WriteFile(path, []byte("hello"), 0o600))
+		reader, err := storage.OpenFileFromURI(storage.NewFileURI(path))
+		require.NoError(t, err)
+		msgs := make(chan string, 1)
+		var got []byte
+		arg := ShowFileOpenWindowParams{
+			CompletionText: "done",
+			ShowSnackbar:   func(s string) { msgs <- s },
+			ReadFunc: func(_ context.Context, r io.Reader) error {
+				var err error
+				got, err = io.ReadAll(r)
+				return err
+			},
+		}
+
+		handleOpenResult(u, arg, reader, nil)
+
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "done", msg)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for snackbar")
+		}
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("shows error text when read func fails", func(t *testing.T) {
+		u := newUIServiceFake(test.NewTempApp(t))
+		path := filepath.Join(t.TempDir(), "in.txt")
+		require.NoError(t, os.WriteFile(path, []byte("hello"), 0o600))
+		reader, err := storage.OpenFileFromURI(storage.NewFileURI(path))
+		require.NoError(t, err)
+		msgs := make(chan string, 1)
+		arg := ShowFileOpenWindowParams{
+			ShowSnackbar: func(s string) { msgs <- s },
+			ReadFunc: func(context.Context, io.Reader) error {
+				return errors.New("corrupt")
+			},
+		}
+
+		handleOpenResult(u, arg, reader, nil)
+
+		select {
+		case msg := <-msgs:
+			assert.Equal(t, "Error: corrupt", msg)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for snackbar")
+		}
+	})
+}
+
+func TestShowSave_Mobile_SkipsWindowCreation(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	u.isMobile = true
+	arg := ShowFileSaveWindowParams{
+		ShowSnackbar: func(string) {},
+		WriteFunc:    func(context.Context, io.Writer) error { return nil },
+		Window:       a.NewWindow("parent"),
+	}
+
+	assert.NotPanics(t, func() { ShowSave(u, arg) })
+	assert.Equal(t, 0, u.getOrCreateWindowCalls)
+}
+
+func TestShowOpen_Mobile_SkipsWindowCreation(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	u.isMobile = true
+	arg := ShowFileOpenWindowParams{
+		ShowSnackbar: func(string) {},
+		ReadFunc:     func(context.Context, io.Reader) error { return nil },
+		Window:       a.NewWindow("parent"),
+	}
+
+	assert.NotPanics(t, func() { ShowOpen(u, arg) })
+	assert.Equal(t, 0, u.getOrCreateWindowCalls)
+}
+
+func TestShowSave_Desktop_UsesWindowIDAndTitle(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	arg := ShowFileSaveWindowParams{
+		WindowID:     "export",
+		Title:        "Export data",
+		ShowSnackbar: func(string) {},
+		WriteFunc:    func(context.Context, io.Writer) error { return nil },
+	}
+
+	ShowSave(u, arg)
+
+	require.Equal(t, 1, u.getOrCreateWindowCalls)
+	assert.Equal(t, "export", u.lastWindowID)
+	assert.Equal(t, "Export data", u.lastTitle)
+}
+
+func TestShowDialogInWindow_ResizesToPercentOfMainWindowAndFixesSize(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	u.mainWindow.Resize(fyne.NewSize(1000, 800))
+	w := a.NewWindow("dialog host")
+	d := dialog.NewFileSave(func(fyne.URIWriteCloser, error) {}, w)
+
+	showDialogInWindow(u, w, d)
+
+	assert.Equal(t, fyne.NewSize(800, 640), w.Canvas().Size())
+	fs, ok := w.(interface{ FixedSize() bool })
+	require.True(t, ok)
+	assert.True(t, fs.FixedSize())
+}
+
+func TestShowDialogInWindow_ClosingDialogClosesWindow(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	w := a.NewWindow("dialog host")
+	d := dialog.NewFileSave(func(fyne.URIWriteCloser, error) {}, w)
+
+	showDialogInWindow(u, w, d)
+	before := len(a.Driver().AllWindows())
+	d.Hide()
+	after := len(a.Driver().AllWindows())
+
+	assert.Less(t, after, before)
+}
+
+func TestCreateFileSaveDialog_AppliesFilenameAndExtensions(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	w := a.NewWindow("host")
+	arg := ShowFileSaveWindowParams{
+		Filename:     "export.json",
+		Extensions:   []string{".json"},
+		ShowSnackbar: func(string) {},
+		WriteFunc:    func(context.Context, io.Writer) error { return nil },
+	}
+
+	var d *dialog.FileDialog
+	assert.NotPanics(t, func() { d = createFileSaveDialog(u, arg, w) })
+	assert.NotNil(t, d)
+}
+
+func TestCreateFileOpenDialog_AppliesExtensions(t *testing.T) {
+	a := test.NewTempApp(t)
+	u := newUIServiceFake(a)
+	w := a.NewWindow("host")
+	arg := ShowFileOpenWindowParams{
+		Extensions:   []string{".json"},
+		ShowSnackbar: func(string) {},
+		ReadFunc:     func(context.Context, io.Reader) error { return nil },
+	}
+
+	var d *dialog.FileDialog
+	assert.NotPanics(t, func() { d = createFileOpenDialog(u, arg, w) })
+	assert.NotNil(t, d)
+}

--- a/internal/app/ui/screens/helper.go
+++ b/internal/app/ui/screens/helper.go
@@ -1,15 +1,15 @@
 package screens
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"slices"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/storage"
 
-	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui/filedialog"
 )
 
 // copyRowsToClipboard copies rows from a data table to clipboard.
@@ -36,38 +36,17 @@ func copyRowsToClipboard[T any](u baseUI, topic string, rows []T, transform func
 // The function can be called in the main thread.
 func exportRowsAsCSV[T any](u baseUI, topic string, filename string, rows []T, writeRows func(io.Writer, []T) error) {
 	w := u.MainWindow()
-	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-		if writer == nil {
-			return
-		}
-		showError := func(err error) {
-			ui.ShowErrorAndLog("Failed to export "+topic, err, u.IsDeveloperMode(), w)
-		}
-		if err != nil {
-			writer.Close()
-			showError(err)
-			return
-		}
-		rows2 := slices.Clone(rows)
-		go func() {
-			defer writer.Close()
-			err := writeRows(writer, rows2)
-			if err != nil {
-				fyne.Do(func() {
-					showError(err)
-				})
-				return
-			}
-			u.ShowSnackbar("Exported " + topic + " to CSV")
-		}()
-	}, w)
-
-	d.SetFileName(filename)
-	d.SetFilter(storage.NewExtensionFileFilter([]string{".csv"}))
-	d.SetTitleText("Export " + topic + " as CSV")
-	d.Show()
-
-	_, s := w.Canvas().InteractiveArea()
-	winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
-	d.Resize(winSize)
+	rows2 := slices.Clone(rows)
+	filedialog.ShowSave(u, filedialog.ShowFileSaveWindowParams{
+		CompletionText: "Exported " + topic + " to CSV",
+		Extensions:     []string{".csv"},
+		Filename:       filename,
+		ShowSnackbar:   u.ShowSnackbar,
+		Title:          "Export " + topic + " as CSV",
+		WindowID:       fmt.Sprintf("export-%s-%s", topic, filename),
+		WriteFunc: func(_ context.Context, w io.Writer) error {
+			return writeRows(w, rows2)
+		},
+		Window: w,
+	})
 }

--- a/internal/app/ui/settings/settings.go
+++ b/internal/app/ui/settings/settings.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"image/color"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	asettings "github.com/ErikKalkoken/evebuddy/internal/app/settings"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui/filedialog"
 	"github.com/ErikKalkoken/evebuddy/internal/xdesktop"
 	"github.com/ErikKalkoken/evebuddy/internal/xmaps"
 	"github.com/ErikKalkoken/evebuddy/internal/xstrings"
@@ -35,6 +37,7 @@ type baseUI interface {
 	ClearAllCaches()
 	DataPaths() xmaps.OrderedMap[string, string]
 	ErrorDisplay(err error) string
+	GetOrCreateWindow(id string, titles ...string) (window fyne.Window, created bool)
 	GetOrCreateWindowWithOnClosed(id string, titles ...string) (window fyne.Window, created bool, onClosed func())
 	IsDeveloperMode() bool
 	IsMobile() bool
@@ -353,13 +356,13 @@ func (a *settings) makeGeneralPage() (fyne.CanvasObject, *kxwidget.IconButton) {
 	exportAppLog := settingAction{
 		Label: "Export application log",
 		Action: func() {
-			a.showExportFileDialog(a.u.DataPaths()["log"])
+			a.showExportFileDialog("application log", a.u.DataPaths()["log"])
 		},
 	}
 	exportCrashLog := settingAction{
 		Label: "Export crash log",
 		Action: func() {
-			a.showExportFileDialog(a.u.DataPaths()["crashfile"])
+			a.showExportFileDialog("crash log", a.u.DataPaths()["crashfile"])
 		},
 	}
 	deleteAppLog := settingAction{
@@ -429,7 +432,7 @@ func (a *settings) showDeleteFileDialog(name, path string) {
 		}, a.w)
 }
 
-func (a *settings) showExportFileDialog(path string) {
+func (a *settings) showExportFileDialog(topic, path string) {
 	filename := filepath.Base(path)
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -439,35 +442,20 @@ func (a *settings) showExportFileDialog(path string) {
 		ui.ShowErrorAndLog("Failed to open "+filename, err, a.u.IsDeveloperMode(), a.w)
 		return
 	}
-	d := dialog.NewFileSave(
-		func(writer fyne.URIWriteCloser, err error) {
-			err2 := func() error {
-				if err != nil {
-					return err
-				}
-				if writer == nil {
-					return nil
-				}
-				defer func() {
-					err := writer.Close()
-					if err != nil {
-						slog.Error("Tag export", "error", err)
-					}
-				}()
-				if _, err := writer.Write(data); err != nil {
-					return err
-				}
-				a.sb.Show("File " + filename + " exported")
-				return nil
-			}()
-			if err2 != nil {
-				ui.ShowErrorAndLog("Failed to export "+filename, err, a.u.IsDeveloperMode(), a.w)
-			}
-		}, a.w,
-	)
-	d.SetFileName(filename)
-	xdesktop.DisableShortcutsForDialog(d, a.w)
-	d.Show()
+
+	filedialog.ShowSave(a.u, filedialog.ShowFileSaveWindowParams{
+		CompletionText: xstrings.Title(topic) + " exported",
+		Filename:       filename,
+		ShowSnackbar:   a.sb.Show,
+		Title:          "Export " + topic,
+		WindowID:       "export-log",
+		WriteFunc: func(_ context.Context, w io.Writer) error {
+			_, err := w.Write(data)
+			return err
+
+		},
+		Window: a.w,
+	})
 }
 
 func (a *settings) makeNotificationPage() (fyne.CanvasObject, *kxwidget.IconButton) {

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -192,6 +192,7 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 					Title:          "Export notification fixtures",
 					WriteFunc:      a.u.Character().WriteNotificationTypeFixtures,
 					Window:         w,
+					WindowID:       "export-notification-fixtures",
 				})
 			}),
 		)

--- a/internal/app/ui/updatestatus/updatestatus.go
+++ b/internal/app/ui/updatestatus/updatestatus.go
@@ -10,9 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	kxwidget "github.com/ErikKalkoken/fyne-kx/widget"
@@ -24,6 +22,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
 	"github.com/ErikKalkoken/evebuddy/internal/app/statuscache"
 	"github.com/ErikKalkoken/evebuddy/internal/app/ui"
+	"github.com/ErikKalkoken/evebuddy/internal/app/ui/filedialog"
 	"github.com/ErikKalkoken/evebuddy/internal/eveicon"
 	ihumanize "github.com/ErikKalkoken/evebuddy/internal/humanize"
 	"github.com/ErikKalkoken/evebuddy/internal/icons"
@@ -36,6 +35,7 @@ type baseUI interface {
 	ErrorDisplay(err error) string
 	EVEImage() ui.EVEImageService
 	EVEUniverse() *eveuniverseservice.EVEUniverseService
+	GetOrCreateWindow(id string, titles ...string) (window fyne.Window, created bool)
 	GetOrCreateWindowWithOnClosed(id string, titles ...string) (window fyne.Window, created bool, onClosed func())
 	IsDeveloperMode() bool
 	IsMobile() bool
@@ -184,37 +184,15 @@ func newUpdateStatus(u baseUI, w fyne.Window) *updateStatus {
 		items = append(items,
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Export notification fixtures...", func() {
-				w2, _, _ := a.u.GetOrCreateWindowWithOnClosed("", "Export notification fixtures")
-				d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-					defer w2.Close()
-					if writer == nil {
-						return
-					}
-					if err != nil {
-						a.sb.Show("Error: " + a.u.ErrorDisplay(err))
-						return
-					}
-					go func() {
-						defer writer.Close()
-						err := a.u.Character().WriteNotificationTypeFixtures(context.Background(), writer)
-						if err != nil {
-							slog.Error("update status", "error", err)
-							fyne.Do(func() { a.sb.Show("Error: " + a.u.ErrorDisplay(err)) })
-							return
-						}
-						fyne.Do(func() { a.sb.Show("Notification fixtures exported") })
-					}()
-				}, w2)
-				d.SetFileName("notification_fixtures.json")
-				d.SetFilter(storage.NewExtensionFileFilter([]string{".json"}))
-
-				_, s := u.MainWindow().Canvas().InteractiveArea()
-				winSize := fyne.NewSize(s.Width*0.8, s.Height*0.8)
-				w2.Resize(winSize)
-				d.Show()
-				d.Resize(winSize)
-				w2.SetFixedSize(true)
-				w2.Show()
+				filedialog.ShowSave(u, filedialog.ShowFileSaveWindowParams{
+					CompletionText: "Notification fixtures exported",
+					Extensions:     []string{".json"},
+					Filename:       "notification_fixtures.json",
+					ShowSnackbar:   a.sb.Show,
+					Title:          "Export notification fixtures",
+					WriteFunc:      a.u.Character().WriteNotificationTypeFixtures,
+					Window:         w,
+				})
 			}),
 		)
 	}


### PR DESCRIPTION
- Added a new package filedialog that provides the ability to show a file save or file open dialog in a dedicated window on desktop and a native window on mobile.
- Refactored existing file dialog usages to now use the new filefialog feature
- This also fixes a bug where evebuddy would panic when a file dialog closes on mobile
