### PR TITLE
fix: prevent notification-parsing panics and a DumpData resource leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ratelimits.md
 .gitconfig
 internal/app/ui/characters/communications.go
 .claude/
+.mcp.json

--- a/internal/app/evenotification/helpers.go
+++ b/internal/app/evenotification/helpers.go
@@ -68,3 +68,27 @@ func makeMarkDownLink(label, url string) string {
 	}
 	return fmt.Sprintf("[%s](%s)", label, url)
 }
+
+// linkDataUint64 returns the uint64 element at idx, or an error if it's missing or the wrong type.
+func linkDataUint64(context string, data []any, idx int) (uint64, error) {
+	if idx < 0 || idx >= len(data) {
+		return 0, fmt.Errorf("evenotification: %s: index %d out of range (len %d)", context, idx, len(data))
+	}
+	v, ok := data[idx].(uint64)
+	if !ok {
+		return 0, fmt.Errorf("evenotification: %s: element %d has type %T, want uint64", context, idx, data[idx])
+	}
+	return v, nil
+}
+
+// linkDataString returns the string element at idx, or an error if it's missing or the wrong type.
+func linkDataString(context string, data []any, idx int) (string, error) {
+	if idx < 0 || idx >= len(data) {
+		return "", fmt.Errorf("evenotification: %s: index %d out of range (len %d)", context, idx, len(data))
+	}
+	v, ok := data[idx].(string)
+	if !ok {
+		return "", fmt.Errorf("evenotification: %s: element %d has type %T, want string", context, idx, data[idx])
+	}
+	return v, nil
+}

--- a/internal/app/evenotification/structure.go
+++ b/internal/app/evenotification/structure.go
@@ -129,12 +129,36 @@ func (n ownershipTransferred) unmarshal(text string) (goesi.OwnershipTransferred
 		if err := yaml.Unmarshal([]byte(text), &data2); err != nil {
 			return data, set.Set[int64]{}, err
 		}
-		data.CharID = int64(data2.CharacterLinkData[2].(uint64))
-		data.NewOwnerCorpID = int64(data2.ToCorporationLinkData[2].(uint64))
-		data.OldOwnerCorpID = int64(data2.FromCorporationLinkData[2].(uint64))
-		data.SolarSystemID = int64(data2.SolarSystemLinkData[2].(uint64))
-		data.StructureID = int64(data2.StructureLinkData[2].(uint64))
-		data.StructureTypeID = int64(data2.StructureLinkData[1].(uint64))
+		charID, err := linkDataUint64("ownershipTransferred.characterLinkData", data2.CharacterLinkData, 2)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		newOwnerCorpID, err := linkDataUint64("ownershipTransferred.toCorporationLinkData", data2.ToCorporationLinkData, 2)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		oldOwnerCorpID, err := linkDataUint64("ownershipTransferred.fromCorporationLinkData", data2.FromCorporationLinkData, 2)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		solarSystemID, err := linkDataUint64("ownershipTransferred.solarSystemLinkData", data2.SolarSystemLinkData, 2)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		structureID, err := linkDataUint64("ownershipTransferred.structureLinkData", data2.StructureLinkData, 2)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		structureTypeID, err := linkDataUint64("ownershipTransferred.structureLinkData", data2.StructureLinkData, 1)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		data.CharID = int64(charID)
+		data.NewOwnerCorpID = int64(newOwnerCorpID)
+		data.OldOwnerCorpID = int64(oldOwnerCorpID)
+		data.SolarSystemID = int64(solarSystemID)
+		data.StructureID = int64(structureID)
+		data.StructureTypeID = int64(structureTypeID)
 		data.StructureName = data2.StructureName
 	}
 	ids := set.Of(data.OldOwnerCorpID, data.NewOwnerCorpID, data.CharID)
@@ -478,8 +502,12 @@ func (n structuresReinforcementChanged) unmarshal(text string) (goesi.Structures
 		return data, set.Set[int64]{}, err
 	}
 	var ids set.Set[int64]
-	for _, r := range data.AllStructureInfo {
-		ids.Add(int64(r[2].(uint64)))
+	for i, r := range data.AllStructureInfo {
+		s, err := parseStructureReinforcementRow(i, r)
+		if err != nil {
+			return data, set.Set[int64]{}, err
+		}
+		ids.Add(s.typeID)
 	}
 	return data, ids, nil
 }
@@ -490,6 +518,28 @@ type structureReinforcementInfo struct {
 	typeID      int64
 }
 
+// parseStructureReinforcementRow converts one allStructureInfo row, or returns an error if it's malformed.
+func parseStructureReinforcementRow(idx int, r []any) (structureReinforcementInfo, error) {
+	context := fmt.Sprintf("structuresReinforcementChanged.allStructureInfo[%d]", idx)
+	structureID, err := linkDataUint64(context, r, 0)
+	if err != nil {
+		return structureReinforcementInfo{}, err
+	}
+	name, err := linkDataString(context, r, 1)
+	if err != nil {
+		return structureReinforcementInfo{}, err
+	}
+	typeID, err := linkDataUint64(context, r, 2)
+	if err != nil {
+		return structureReinforcementInfo{}, err
+	}
+	return structureReinforcementInfo{
+		structureID: int64(structureID),
+		name:        name,
+		typeID:      int64(typeID),
+	}, nil
+}
+
 func (n structuresReinforcementChanged) render(ctx context.Context, text string, _ time.Time) (string, string, error) {
 	var title, body string
 	data, typeIDs, err := n.unmarshal(text)
@@ -497,12 +547,10 @@ func (n structuresReinforcementChanged) render(ctx context.Context, text string,
 		return title, body, err
 	}
 	var structures []structureReinforcementInfo
-	for _, r := range data.AllStructureInfo {
-		typeID := int64(r[2].(uint64))
-		s := structureReinforcementInfo{
-			structureID: int64(r[0].(uint64)),
-			name:        r[1].(string),
-			typeID:      typeID,
+	for i, r := range data.AllStructureInfo {
+		s, err := parseStructureReinforcementRow(i, r)
+		if err != nil {
+			return title, body, err
 		}
 		structures = append(structures, s)
 	}

--- a/internal/app/evenotification/structure_test.go
+++ b/internal/app/evenotification/structure_test.go
@@ -1,6 +1,7 @@
 package evenotification_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -218,5 +219,172 @@ func TestStructure_RenderESI(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, title, "Nosodnis - Nara")
 		assert.Contains(t, body, solarSystem.Name)
+	})
+
+	t.Run("OwnershipTransferredLegacyFormat", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		char := f.CreateEveEntityCharacter()
+		oldCorp := f.CreateEveEntityCorporation()
+		newCorp := f.CreateEveEntityCorporation()
+		solarSystem := f.CreateEveSolarSystem()
+		structureType := f.CreateEveType()
+		text := fmt.Sprintf(`
+characterLinkData:
+- showinfo
+- 1380
+- %d
+characterName: %s
+fromCorporationLinkData:
+- showinfo
+- 2
+- %d
+fromCorporationName: Old Corporation
+solarSystemLinkData:
+- showinfo
+- 5
+- %d
+solarSystemName: Amamake
+structureLinkData:
+- showinfo
+- %d
+- 1000000000001
+structureName: Amamake - Alpha
+toCorporationLinkData:
+- showinfo
+- 2
+- %d
+toCorporationName: New Corporation
+`, char.ID, char.Name, oldCorp.ID, solarSystem.ID, structureType.ID, newCorp.ID)
+
+		title, body, err := en.RenderESI(t.Context(), app.OwnershipTransferred, optional.New(text), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "ownership")
+		assert.Contains(t, body, char.Name)
+	})
+
+	t.Run("OwnershipTransferredLegacyFormatWithShortLinkDataReturnsError", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		// structureLinkData is too short; this used to panic instead of returning an error.
+		text := `
+characterLinkData:
+- showinfo
+- 1380
+- 1001
+characterName: John Doe
+fromCorporationLinkData:
+- showinfo
+- 2
+- 2001
+fromCorporationName: Old Corporation
+solarSystemLinkData:
+- showinfo
+- 5
+- 30002537
+solarSystemName: Amamake
+structureLinkData:
+- showinfo
+structureName: Amamake - Alpha
+toCorporationLinkData:
+- showinfo
+- 2
+- 2002
+toCorporationName: New Corporation
+`
+		_, _, err := en.RenderESI(t.Context(), app.OwnershipTransferred, optional.New(text), time.Now())
+		assert.Error(t, err)
+	})
+
+	t.Run("OwnershipTransferredLegacyFormatWithWrongLinkDataTypeReturnsError", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		// structureLinkData's ID is a string; this used to panic instead of returning an error.
+		text := `
+characterLinkData:
+- showinfo
+- 1380
+- 1001
+characterName: John Doe
+fromCorporationLinkData:
+- showinfo
+- 2
+- 2001
+fromCorporationName: Old Corporation
+solarSystemLinkData:
+- showinfo
+- 5
+- 30002537
+solarSystemName: Amamake
+structureLinkData:
+- showinfo
+- 35835
+- not-a-number
+structureName: Amamake - Alpha
+toCorporationLinkData:
+- showinfo
+- 2
+- 2002
+toCorporationName: New Corporation
+`
+		_, _, err := en.RenderESI(t.Context(), app.OwnershipTransferred, optional.New(text), time.Now())
+		assert.Error(t, err)
+	})
+
+	t.Run("StructuresReinforcementChanged", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		structureType := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		text := fmt.Sprintf(`
+allStructureInfo:
+- - 1000000000001
+  - Test Structure
+  - %d
+hour: 19
+numStructures: 1
+timestamp: 132141703753688216
+weekday: 255
+`, structureType.ID)
+
+		title, body, err := en.RenderESI(t.Context(), app.StructuresReinforcementChanged, optional.New(text), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "reinforcement")
+		assert.Contains(t, body, "Test Structure")
+		assert.Contains(t, body, structureType.Name)
+	})
+
+	t.Run("StructuresReinforcementChangedWithShortRowReturnsError", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		// The row is missing its type ID; this used to panic instead of returning an error.
+		text := `
+allStructureInfo:
+- - 1000000000001
+  - Test Structure
+hour: 19
+numStructures: 1
+timestamp: 132141703753688216
+weekday: 255
+`
+		_, _, err := en.RenderESI(t.Context(), app.StructuresReinforcementChanged, optional.New(text), time.Now())
+		assert.Error(t, err)
+	})
+
+	t.Run("StructuresReinforcementChangedWithWrongRowTypeReturnsError", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		// The row's type ID is a string; this used to panic instead of returning an error.
+		text := `
+allStructureInfo:
+- - 1000000000001
+  - Test Structure
+  - not-a-number
+hour: 19
+numStructures: 1
+timestamp: 132141703753688216
+weekday: 255
+`
+		_, _, err := en.RenderESI(t.Context(), app.StructuresReinforcementChanged, optional.New(text), time.Now())
+		assert.Error(t, err)
 	})
 }

--- a/internal/app/storage/storage.go
+++ b/internal/app/storage/storage.go
@@ -74,33 +74,35 @@ func (st *Storage) DumpData(tables ...string) string {
 	slices.Sort(tables)
 	world := make(map[string]any)
 	for _, table := range tables {
-		sql := fmt.Sprintf("SELECT * FROM %s;", table)
-		rows, err := st.dbRO.Query(sql)
-		if err != nil {
-			panic(err)
-		}
-		defer rows.Close()
-		cols, err := rows.Columns()
-		if err != nil {
-			panic(err)
-		}
-		var data []any
-		for rows.Next() {
-			items := make([]any, len(cols))
-			for i := range items {
-				items[i] = new(any)
-			}
-			if err := rows.Scan(items...); err != nil {
+		world[table] = func() []any {
+			sql := fmt.Sprintf("SELECT * FROM %s;", table)
+			rows, err := st.dbRO.Query(sql)
+			if err != nil {
 				panic(err)
 			}
-			row := make(map[string]any)
-			for i, v := range items {
-				vv := v.(*any)
-				row[cols[i]] = *vv
+			defer rows.Close()
+			cols, err := rows.Columns()
+			if err != nil {
+				panic(err)
 			}
-			data = append(data, row)
-		}
-		world[table] = data
+			var data []any
+			for rows.Next() {
+				items := make([]any, len(cols))
+				for i := range items {
+					items[i] = new(any)
+				}
+				if err := rows.Scan(items...); err != nil {
+					panic(err)
+				}
+				row := make(map[string]any)
+				for i, v := range items {
+					vv := v.(*any)
+					row[cols[i]] = *vv
+				}
+				data = append(data, row)
+			}
+			return data
+		}()
 	}
 	b, err := json.MarshalIndent(world, "", "    ")
 	if err != nil {


### PR DESCRIPTION
- Fixed unchecked type assertions in ESI structure-notification parsing (ownershipTransferred, structuresReinforcementChanged) that could crash the app on malformed/unexpected notification data — now returns an error instead of panicking.
- Fixed a resource leak in Storage.DumpData where result sets for each dumped table stayed open until the whole function returned instead of closing per table.
