### PR TITLE
test: add missing unit tests across service and storage package

### DIFF
--- a/internal/app/characterservice/assets_internal_test.go
+++ b/internal/app/characterservice/assets_internal_test.go
@@ -291,3 +291,62 @@ func TestUpdateAssetValue(t *testing.T) {
 	})
 
 }
+
+func TestAssetTotalValue(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can return asset total value for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter(storage.CreateCharacterParams{AssetValue: optional.New(123.45)})
+
+		// when
+		got, err := s.AssetTotalValue(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, optional.New(123.45), got)
+	})
+}
+
+func TestListAssets(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can list assets for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		ca := factory.CreateCharacterAsset(storage.CreateCharacterAssetParams{CharacterID: c.ID})
+		factory.CreateCharacterAsset() // asset for another character
+
+		// when
+		got, err := s.ListAssets(t.Context(), c.ID)
+
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, ca.ItemID, got[0].ItemID)
+		}
+	})
+}
+
+func TestListAllAssets(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can list assets across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterAsset()
+		factory.CreateCharacterAsset()
+
+		// when
+		got, err := s.ListAllAssets(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}

--- a/internal/app/characterservice/character_test.go
+++ b/internal/app/characterservice/character_test.go
@@ -465,3 +465,139 @@ func TestDeleteCharacter(t *testing.T) {
 		assert.False(t, got)
 	})
 }
+
+func TestListCharacters(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacterFull()
+		c2 := factory.CreateCharacterFull()
+		// when
+		got, err := cs.ListCharacters(ctx)
+		// then
+		require.NoError(t, err)
+		gotIDs := make([]int64, 0)
+		for _, c := range got {
+			gotIDs = append(gotIDs, c.ID)
+		}
+		assert.ElementsMatch(t, []int64{c1.ID, c2.ID}, gotIDs)
+	})
+}
+
+func TestListCharacterIDs(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list character IDs", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCharacter()
+		c2 := factory.CreateCharacter()
+		// when
+		got, err := cs.ListCharacterIDs(ctx)
+		// then
+		require.NoError(t, err)
+		assert.True(t, got.Contains(c1.ID))
+		assert.True(t, got.Contains(c2.ID))
+	})
+}
+
+func TestListEveCharacters(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list eve characters for existing characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacterFull()
+		// when
+		got, err := cs.ListEveCharacters(ctx)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, c.EveCharacter.ID, got[0].ID)
+		}
+	})
+}
+
+func TestCharacterNames(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return a map of character ID to name", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacterFull()
+		// when
+		got, err := cs.CharacterNames(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, c.EveCharacter.Name, got[c.ID])
+	})
+}
+
+func TestListCharacterCorporationIDs(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return corporation IDs of characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		ec := factory.CreateEveCorporation()
+		x := factory.CreateEveCharacter(storage.CreateEveCharacterParams{CorporationID: ec.ID})
+		factory.CreateCharacterFull(storage.CreateCharacterParams{ID: x.ID})
+		// when
+		got, err := cs.ListCharacterCorporationIDs(ctx)
+		// then
+		require.NoError(t, err)
+		assert.True(t, got.Contains(ec.ID))
+	})
+}
+
+func TestListCharacterCorporations(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return corporations of characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		ec := factory.CreateEveCorporation()
+		factory.CreateCorporation(ec.ID)
+		factory.CreateEveEntityWithCategory(app.EveEntityCorporation, app.EveEntity{ID: ec.ID})
+		x := factory.CreateEveCharacter(storage.CreateEveCharacterParams{CorporationID: ec.ID})
+		factory.CreateCharacterFull(storage.CreateCharacterParams{ID: x.ID})
+		// when
+		got, err := cs.ListCharacterCorporations(ctx)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, ec.ID, got[0].ID)
+		}
+	})
+}
+
+func TestUpdateAllCalculatedValues(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can update calculated values for all characters without error", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterFull()
+		factory.CreateCharacterFull()
+		// when
+		err := cs.UpdateAllCalculatedValues(ctx)
+		// then
+		require.NoError(t, err)
+	})
+}

--- a/internal/app/characterservice/characterservice_internal_test.go
+++ b/internal/app/characterservice/characterservice_internal_test.go
@@ -2,12 +2,15 @@ package characterservice
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"testing"
 	"time"
 
 	"github.com/ErikKalkoken/eveauth"
 	"github.com/ErikKalkoken/go-set"
 	"github.com/fnt-eve/goesi-openapi"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
@@ -103,4 +106,22 @@ func NewFake(args ...Params) *CharacterService {
 	}
 	s := New(arg)
 	return s
+}
+
+func TestDumpData(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can dump requested table as JSON", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		// when
+		got := s.DumpData("characters")
+		// then
+		var world map[string][]map[string]any
+		if assert.NoError(t, json.Unmarshal([]byte(got), &world)) && assert.Len(t, world["characters"], 1) {
+			assert.EqualValues(t, c.ID, world["characters"][0]["id"])
+		}
+	})
 }

--- a/internal/app/characterservice/clones_internal_test.go
+++ b/internal/app/characterservice/clones_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
@@ -193,6 +194,70 @@ func TestCharacterNextAvailableCloneJump(t *testing.T) {
 		x, err := cs.calcNextCloneJump(ctx, c)
 		if assert.NoError(t, err) {
 			assert.True(t, x.IsEmpty())
+		}
+	})
+}
+
+func TestGetJumpClone(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return a jump clone", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		jc := factory.CreateCharacterJumpClone()
+		// when
+		got, err := cs.GetJumpClone(ctx, jc.CharacterID, jc.CloneID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, jc.CloneID, got.CloneID)
+	})
+	t.Run("should return own error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := cs.GetJumpClone(ctx, 1, 1)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListAllJumpClones(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list jump clones across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterJumpClone()
+		factory.CreateCharacterJumpClone()
+		// when
+		got, err := cs.ListAllJumpClones(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}
+
+func TestListJumpClones(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list jump clones for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		jc := factory.CreateCharacterJumpClone(storage.CreateCharacterJumpCloneParams{CharacterID: c.ID})
+		factory.CreateCharacterJumpClone() // clone for another character
+		// when
+		got, err := cs.ListJumpClones(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, jc.CloneID, got[0].CloneID)
 		}
 	})
 }

--- a/internal/app/characterservice/contacts_test.go
+++ b/internal/app/characterservice/contacts_test.go
@@ -264,3 +264,24 @@ func TestUpdateCharacterContactLabelsESI(t *testing.T) {
 		xassert.Equal(t, set.Of[int64](42), ids)
 	})
 }
+
+func TestListContacts(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list contacts for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		contact := factory.CreateCharacterContact(storage.UpdateOrCreateCharacterContactParams{CharacterID: c.ID})
+		factory.CreateCharacterContact() // contact for another character
+		// when
+		got, err := s.ListContacts(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, contact.Contact.ID, got[0].Contact.ID)
+		}
+	})
+}

--- a/internal/app/characterservice/contracts_test.go
+++ b/internal/app/characterservice/contracts_test.go
@@ -329,3 +329,108 @@ func TestListAllCharacterContractSlotsCorporation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetContract(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return a contract", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterContract()
+		// when
+		got, err := s.GetContract(t.Context(), o.CharacterID, o.ContractID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, o.ID, got.ID)
+	})
+	t.Run("should return own error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetContract(t.Context(), 1, 1)
+		// then
+		assert.Error(t, err)
+	})
+}
+
+func TestCountContractBids(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can count bids for a contract", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterContract()
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: o.ID})
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: o.ID})
+		// when
+		got, err := s.CountContractBids(t.Context(), o.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 2, got)
+	})
+}
+
+func TestGetContractTopBid(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return top bid for a contract", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterContract()
+		factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: o.ID, Amount: 100})
+		top := factory.CreateCharacterContractBid(storage.CreateCharacterContractBidParams{ContractID: o.ID, Amount: 500})
+		// when
+		got, err := s.GetContractTopBid(t.Context(), o.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, top.BidID, got.BidID)
+	})
+	t.Run("should return own error when contract has no bids", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterContract()
+		// when
+		_, err := s.GetContractTopBid(t.Context(), o.ID)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListAllContracts(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list contracts across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterContract()
+		factory.CreateCharacterContract()
+		// when
+		got, err := s.ListAllContracts(t.Context())
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}
+
+func TestListContractItems(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list items for a contract", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterContract()
+		item := factory.CreateCharacterContractItem(storage.CreateCharacterContractItemParams{ContractID: o.ID})
+		// when
+		got, err := s.ListContractItems(t.Context(), o.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, item.RecordID, got[0].RecordID)
+		}
+	})
+}

--- a/internal/app/characterservice/implants_internal_test.go
+++ b/internal/app/characterservice/implants_internal_test.go
@@ -105,3 +105,42 @@ func TestUpdateCharacterImplantsESI(t *testing.T) {
 
 	})
 }
+
+func TestListImplants(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list implants for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		ci := factory.CreateCharacterImplant(storage.CreateCharacterImplantParams{CharacterID: c.ID})
+		factory.CreateCharacterImplant() // implant for another character
+		// when
+		got, err := s.ListImplants(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, ci.EveType.ID, got[0].EveType.ID)
+		}
+	})
+}
+
+func TestListAllImplants(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list implants across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterImplant()
+		factory.CreateCharacterImplant()
+		// when
+		got, err := s.ListAllImplants(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}

--- a/internal/app/characterservice/industry_test.go
+++ b/internal/app/characterservice/industry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
@@ -186,5 +187,48 @@ func TestListAllCharactersIndustrySlots(t *testing.T) {
 			}
 			assert.ElementsMatch(t, want, got)
 		}
+	})
+}
+
+func TestGetCharacterIndustryJob(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return an industry job", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterIndustryJob()
+		// when
+		got, err := cs.GetCharacterIndustryJob(ctx, o.CharacterID, o.JobID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, o.JobID, got.JobID)
+	})
+	t.Run("should return own error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := cs.GetCharacterIndustryJob(ctx, 1, 1)
+		// then
+		assert.Error(t, err)
+	})
+}
+
+func TestListAllCharacterIndustryJob(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list industry jobs across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterIndustryJob()
+		factory.CreateCharacterIndustryJob()
+		// when
+		got, err := cs.ListAllCharacterIndustryJob(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
 	})
 }

--- a/internal/app/characterservice/location_internal_test.go
+++ b/internal/app/characterservice/location_internal_test.go
@@ -116,3 +116,77 @@ func TestCharacterService_UpdateLocationESI(t *testing.T) {
 		xassert.EqualOptional(t, structureID, c2.LocationID)
 	})
 }
+
+func TestCharacterService_UpdateOnlineESI(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+
+	t.Run("should update last login from ESI", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/online", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"online":     true,
+				"last_login": "2021-01-01T12:00:00Z",
+			}),
+		)
+		// when
+		changed, err := s.updateOnlineESI(ctx, characterSectionUpdateParams{
+			characterID: c.ID,
+			section:     app.SectionCharacterOnline,
+		})
+		// then
+		require.NoError(t, err)
+		assert.True(t, changed)
+		c2, err := s.GetCharacter(ctx, c.ID)
+		require.NoError(t, err)
+		assert.False(t, c2.LastLoginAt.IsEmpty())
+	})
+}
+
+func TestCharacterService_UpdateShipESI(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+
+	t.Run("should update current ship from ESI", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		ship := factory.CreateEveType()
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/ship", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"ship_item_id": 1000000000001,
+				"ship_name":    "My ship",
+				"ship_type_id": ship.ID,
+			}),
+		)
+		// when
+		changed, err := s.updateShipESI(ctx, characterSectionUpdateParams{
+			characterID: c.ID,
+			section:     app.SectionCharacterShip,
+		})
+		// then
+		require.NoError(t, err)
+		assert.True(t, changed)
+		c2, err := s.GetCharacter(ctx, c.ID)
+		require.NoError(t, err)
+		xassert.EqualOptional(t, ship.ID, c2.ShipTypeID)
+	})
+}

--- a/internal/app/characterservice/loyaltypoints_internal_test.go
+++ b/internal/app/characterservice/loyaltypoints_internal_test.go
@@ -116,3 +116,42 @@ func TestUpdateCharacterLoyaltyPointEntriesESI(t *testing.T) {
 		xassert.Equal(t, set.Of(corporation.ID), ids)
 	})
 }
+
+func TestListLoyaltyPointEntries(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list loyalty point entries for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		e := factory.CreateCharacterLoyaltyPointEntry(storage.UpdateOrCreateCharacterLoyaltyPointEntryParams{CharacterID: c.ID})
+		factory.CreateCharacterLoyaltyPointEntry() // entry for another character
+		// when
+		got, err := s.ListLoyaltyPointEntries(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, e.Corporation.ID, got[0].Corporation.ID)
+		}
+	})
+}
+
+func TestListAllLoyaltyPointEntries(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list loyalty point entries across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterLoyaltyPointEntry()
+		factory.CreateCharacterLoyaltyPointEntry()
+		// when
+		got, err := s.ListAllLoyaltyPointEntries(ctx)
+		// then
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}

--- a/internal/app/characterservice/mail_test.go
+++ b/internal/app/characterservice/mail_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 	"github.com/ErikKalkoken/evebuddy/internal/xgoesi"
 )
@@ -228,5 +229,239 @@ func TestSendMail(t *testing.T) {
 
 		// then
 		require.Error(t, err)
+	})
+}
+
+func TestDeleteMail(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+
+	t.Run("can delete a mail", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		m := factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID})
+		httpmock.RegisterResponder(
+			"DELETE",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/mail/%d", c.ID, m.MailID),
+			httpmock.NewStringResponder(204, ""))
+		// when
+		err := s.DeleteMail(t.Context(), c.ID, m.MailID)
+		// then
+		require.NoError(t, err)
+		_, err = s.GetMail(t.Context(), c.ID, m.MailID)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestUpdateMailRead(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+
+	t.Run("can mark a mail as read", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		m := factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID, IsRead: optional.New(false)})
+		httpmock.RegisterResponder(
+			"PUT",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/mail/%d", c.ID, m.MailID),
+			httpmock.NewStringResponder(204, ""))
+		// when
+		err := s.UpdateMailRead(t.Context(), c.ID, m.MailID, true)
+		// then
+		require.NoError(t, err)
+		m2, err := s.GetMail(t.Context(), c.ID, m.MailID)
+		require.NoError(t, err)
+		xassert.EqualOptional(t, true, m2.IsRead)
+	})
+}
+
+func TestGetAllMailUnreadCount(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return unread mail count across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID, IsRead: optional.New(false)})
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID, IsRead: optional.New(true)})
+		// when
+		got, err := s.GetAllMailUnreadCount(t.Context())
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 1, got)
+	})
+}
+
+func TestGetMailCounts(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return total and unread mail counts for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID, IsRead: optional.New(false)})
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID, IsRead: optional.New(true)})
+		// when
+		total, unread, err := s.GetMailCounts(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Equal(t, 1, unread)
+	})
+}
+
+func TestGetMailLabelUnreadCounts(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return unread mail counts by label", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		label := factory.CreateCharacterMailLabel(app.CharacterMailLabel{CharacterID: c.ID})
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{
+			CharacterID: c.ID,
+			IsRead:      optional.New(false),
+			LabelIDs:    []int64{label.LabelID},
+		})
+		// when
+		got, err := s.GetMailLabelUnreadCounts(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 1, got[label.LabelID])
+	})
+}
+
+func TestGetMailListUnreadCounts(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can return unread mail counts by list", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		list := factory.CreateCharacterMailList(c.ID)
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{
+			CharacterID:  c.ID,
+			IsRead:       optional.New(false),
+			RecipientIDs: []int64{list.ID},
+		})
+		// when
+		got, err := s.GetMailListUnreadCounts(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 1, got[list.ID])
+	})
+}
+
+func TestListMailLists(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list mail lists for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		list := factory.CreateCharacterMailList(c.ID)
+		// when
+		got, err := s.ListMailLists(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, list.ID, got[0].ID)
+		}
+	})
+}
+
+func TestListMailLabelsOrdered(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list mail labels for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		label := factory.CreateCharacterMailLabel(app.CharacterMailLabel{CharacterID: c.ID})
+		// when
+		got, err := s.ListMailLabelsOrdered(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, label.LabelID, got[0].LabelID)
+		}
+	})
+}
+
+func TestListMailHeadersForLabelOrdered(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list mail headers for a label", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		m := factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID})
+		// when
+		got, err := s.ListMailHeadersForLabelOrdered(t.Context(), c.ID, app.MailLabelAll)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, m.MailID, got[0].MailID)
+		}
+	})
+}
+
+func TestListMailHeadersForListOrdered(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can list mail headers for a mail list", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		list := factory.CreateCharacterMailList(c.ID)
+		m := factory.CreateCharacterMail(storage.CreateCharacterMailParams{
+			CharacterID:  c.ID,
+			RecipientIDs: []int64{list.ID},
+		})
+		// when
+		got, err := s.ListMailHeadersForListOrdered(t.Context(), c.ID, list.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, m.MailID, got[0].MailID)
+		}
+	})
+}
+
+func TestDownloadedBodiesPercentage(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	t.Run("can report total and missing mail body counts", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterMail(storage.CreateCharacterMailParams{CharacterID: c.ID}) // no body
+		// when
+		total, missing, err := s.DownloadedBodiesPercentage(t.Context(), c.ID)
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, 1, missing)
 	})
 }

--- a/internal/app/characterservice/market_internal_test.go
+++ b/internal/app/characterservice/market_internal_test.go
@@ -408,3 +408,22 @@ func TestUpdateOrdersEscrow(t *testing.T) {
 	got := c2.OrdersEscrow
 	assert.Equal(t, optional.New(15.2), got)
 }
+
+func TestListAllMarketOrder(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	t.Run("can list buy orders across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		buy := factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{IsBuyOrder: optional.New(true)})
+		factory.CreateCharacterMarketOrder(storage.UpdateOrCreateCharacterMarketOrderParams{IsBuyOrder: optional.New(false)})
+		// when
+		got, err := s.ListAllMarketOrder(t.Context(), true)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, got, 1) {
+			assert.Equal(t, buy.OrderID, got[0].OrderID)
+		}
+	})
+}

--- a/internal/app/characterservice/notifications_test.go
+++ b/internal/app/characterservice/notifications_test.go
@@ -61,3 +61,68 @@ func TestNotifyCommunications(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNotification(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := characterservice.NewFake(characterservice.Params{Storage: st})
+	t.Run("can return a notification", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		n := factory.CreateCharacterNotification()
+		// when
+		got, err := cs.GetNotification(t.Context(), n.CharacterID, n.NotificationID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, n.NotificationID, got.NotificationID)
+		}
+	})
+	t.Run("should return own error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := cs.GetNotification(t.Context(), 1, 1)
+		// then
+		assert.Error(t, err)
+	})
+}
+
+func TestSetNotificationsAsRead(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := characterservice.NewFake(characterservice.Params{Storage: st})
+	t.Run("can mark notifications as read", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		n1 := factory.CreateCharacterNotification()
+		n2 := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: n1.CharacterID})
+		// when
+		err := cs.SetNotificationsAsRead(t.Context(), set.Of(n1.ID, n2.ID))
+		// then
+		if assert.NoError(t, err) {
+			got, err := st.GetCharacterNotification(t.Context(), n1.CharacterID, n1.NotificationID)
+			if assert.NoError(t, err) {
+				assert.True(t, got.IsRead)
+			}
+		}
+	})
+}
+
+func TestListNotifications(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := characterservice.NewFake(characterservice.Params{Storage: st})
+	t.Run("can list notifications for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{CharacterID: c.ID})
+		factory.CreateCharacterNotification() // notification for another character
+		// when
+		got, err := cs.ListNotifications(t.Context(), c.ID)
+		// then
+		if assert.NoError(t, err) && assert.Len(t, got, 1) {
+			assert.Equal(t, n.NotificationID, got[0].NotificationID)
+		}
+	})
+}

--- a/internal/app/characterservice/planets_internal_test.go
+++ b/internal/app/characterservice/planets_internal_test.go
@@ -321,3 +321,48 @@ func TestUpdateCharacterPlanetsESI(t *testing.T) {
 		}
 	})
 }
+
+func TestGetPlanet(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return a planet", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		p := factory.CreateCharacterPlanet()
+		// when
+		got, err := s.GetPlanet(ctx, p.CharacterID, p.EvePlanet.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, p.EvePlanet.ID, got.EvePlanet.ID)
+		}
+	})
+	t.Run("should return own error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetPlanet(ctx, 1, 1)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListAllPlanets(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list planets across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterPlanet()
+		factory.CreateCharacterPlanet()
+		// when
+		got, err := s.ListAllPlanets(ctx)
+		// then
+		if assert.NoError(t, err) {
+			assert.Len(t, got, 2)
+		}
+	})
+}

--- a/internal/app/characterservice/roles_internal_test.go
+++ b/internal/app/characterservice/roles_internal_test.go
@@ -114,3 +114,45 @@ func TestUpdateCharacterRolesESI(t *testing.T) {
 		xassert.Equal(t, want, got)
 	})
 }
+
+func TestListRoles(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("should return only director role when character is director", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.SetCharacterRoles(c.ID, set.Of(app.RoleDirector, app.RoleAccountant))
+		// when
+		got, err := s.ListRoles(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		want := []app.CharacterRole{
+			{CharacterID: c.ID, Role: app.RoleDirector, Granted: true},
+		}
+		assert.Equal(t, want, got)
+	})
+	t.Run("should return all roles with granted status when not a director", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.SetCharacterRoles(c.ID, set.Of(app.RoleAccountant))
+		// when
+		got, err := s.ListRoles(ctx, c.ID)
+		// then
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+		var found bool
+		for _, r := range got {
+			if r.Role == app.RoleAccountant {
+				found = true
+				assert.True(t, r.Granted)
+			} else {
+				assert.False(t, r.Granted)
+			}
+		}
+		assert.True(t, found)
+	})
+}

--- a/internal/app/characterservice/search_test.go
+++ b/internal/app/characterservice/search_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
@@ -55,5 +56,43 @@ func TestSearchESI(t *testing.T) {
 		}
 		xassert.Equal(t, 1, n)
 		xassert.Equal(t, map[app.SearchCategory][]*app.EveEntity{app.SearchCharacter: {x1}}, got)
+	})
+}
+
+func TestAddEveEntitiesFromSearchESI(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("should add missing entities found via search", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{CharacterID: c.ID})
+		const characterID2 = 3007
+		httpmock.RegisterResponder(
+			"GET",
+			fmt.Sprintf("https://esi.evetech.net/characters/%d/search?categories=corporation&categories=character&categories=alliance&search=abc", c.ID),
+			httpmock.NewJsonResponderOrPanic(200, map[string][]int{
+				"character": {characterID2},
+			}),
+		)
+		httpmock.RegisterResponder(
+			"POST",
+			"https://esi.evetech.net/universe/names",
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{{
+				"id":       characterID2,
+				"name":     "Bruce Wayne",
+				"category": "character",
+			}}),
+		)
+		// when
+		got, err := s.AddEveEntitiesFromSearchESI(ctx, c.ID, "abc")
+		// then
+		require.NoError(t, err)
+		assert.True(t, got.Contains(characterID2))
 	})
 }

--- a/internal/app/characterservice/section_internal_test.go
+++ b/internal/app/characterservice/section_internal_test.go
@@ -3,6 +3,7 @@ package characterservice
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,9 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/ErikKalkoken/go-set"
+
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
@@ -544,5 +548,113 @@ func TestCharacterService_UpdateSectionIfNeeded(t *testing.T) {
 		ids, err := st.ListCharacterAssetIDs(ctx, c.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, 0, ids.Size())
+	})
+}
+
+// settingsWithNotificationTypes wraps the default settings stub but allows
+// overriding which notification types are enabled and the earliest timestamp,
+// which are needed to exercise notifyNewCommunications deterministically.
+type settingsWithNotificationTypes struct {
+	testutil.SettingsStub
+	types set.Set[string]
+}
+
+func (s *settingsWithNotificationTypes) NotificationTypesEnabled() set.Set[string] {
+	return s.types
+}
+
+func (s *settingsWithNotificationTypes) NotifyCommunicationsEarliest() time.Time {
+	return time.Now().Add(-1 * time.Hour)
+}
+
+func TestNotifyNewCommunications(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	t.Run("should notify for an enabled notification type", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		var count int32
+		settings := &settingsWithNotificationTypes{types: set.Of(app.StructureUnderAttack.String())}
+		s := NewFake(Params{
+			Storage:  st,
+			Settings: settings,
+			SendDesktopNotification: func(title, content string) {
+				atomic.AddInt32(&count, 1)
+			},
+		})
+		esiType, _ := storage.EveNotificationTypeToESIString(app.StructureUnderAttack)
+		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+			Type:      esiType,
+			Timestamp: time.Now(),
+			Title:     optional.New("title"),
+			Body:      optional.New("body"),
+		})
+		// when
+		s.notifyNewCommunications(ctx, n.CharacterID)
+		// then
+		xassert.Equal(t, int32(1), atomic.LoadInt32(&count))
+	})
+	t.Run("should not notify when the notification type is not enabled", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		var count int32
+		settings := &settingsWithNotificationTypes{types: set.Of("SomeOtherType")}
+		s := NewFake(Params{
+			Storage:  st,
+			Settings: settings,
+			SendDesktopNotification: func(title, content string) {
+				atomic.AddInt32(&count, 1)
+			},
+		})
+		esiType, _ := storage.EveNotificationTypeToESIString(app.StructureUnderAttack)
+		n := factory.CreateCharacterNotification(storage.CreateCharacterNotificationParams{
+			Type:      esiType,
+			Timestamp: time.Now(),
+		})
+		// when
+		s.notifyNewCommunications(ctx, n.CharacterID)
+		// then
+		xassert.Equal(t, int32(0), atomic.LoadInt32(&count))
+	})
+}
+
+func TestNotifyCharactersIfNeeded(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	t.Run("should notify only watched characters with no active training", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		var count int32
+		s := NewFake(Params{
+			Storage: st,
+			SendDesktopNotification: func(title, content string) {
+				atomic.AddInt32(&count, 1)
+			},
+		})
+		factory.CreateCharacterFull(storage.CreateCharacterParams{IsTrainingWatched: true})
+		factory.CreateCharacterFull(storage.CreateCharacterParams{IsTrainingWatched: false})
+		// when
+		err := s.notifyCharactersIfNeeded(ctx)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, int32(1), atomic.LoadInt32(&count))
+	})
+	t.Run("should do nothing when there are no characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		var count int32
+		s := NewFake(Params{
+			Storage: st,
+			SendDesktopNotification: func(title, content string) {
+				atomic.AddInt32(&count, 1)
+			},
+		})
+		// when
+		err := s.notifyCharactersIfNeeded(ctx)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, int32(0), atomic.LoadInt32(&count))
 	})
 }

--- a/internal/app/characterservice/skills_internal_test.go
+++ b/internal/app/characterservice/skills_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ErikKalkoken/go-set"
 	"github.com/jarcoal/httpmock"
@@ -313,4 +314,30 @@ func TestUpdateSkllPointsValue(t *testing.T) {
 		require.NoError(t, err)
 		xassert.EqualOptional(t, 1_000_000, c2.SkillPointsValue)
 	})
+}
+
+func TestIsValidSkillQueueStatus(t *testing.T) {
+	cases := []struct {
+		name        string
+		completedAt time.Time
+		errMsg      string
+		want        bool
+	}{
+		{"valid and recent", time.Now(), "", true},
+		{"never completed", time.Time{}, "", false},
+		{"has error", time.Now(), "boom", false},
+		{"stale", time.Now().Add(-13 * time.Hour), "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &app.CharacterSectionStatus{
+				SectionStatus: app.SectionStatus{
+					CompletedAt:  tc.completedAt,
+					ErrorMessage: tc.errMsg,
+				},
+			}
+			got := isValidSkillQueueStatus(v)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/app/characterservice/skills_test.go
+++ b/internal/app/characterservice/skills_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 	"github.com/ErikKalkoken/evebuddy/internal/xiter"
+	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
 func TestIsTrainingActive(t *testing.T) {
@@ -243,5 +244,173 @@ func TestCharacterService_ListSkills(t *testing.T) {
 
 		o1 := m[es1.ID]
 		assert.False(t, o1.HasPrerequisites)
+	})
+}
+
+func TestListShipsAbilities(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list ship abilities for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		s1 := factory.CreateEveShipSkill()
+		factory.CreateEveShipSkill()
+		c := factory.CreateCharacter()
+		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+			ActiveSkillLevel: 1,
+			CharacterID:      c.ID,
+			TypeID:           s1.SkillTypeID,
+		})
+		// when
+		got, err := cs.ListShipsAbilities(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Len(t, got, 2)
+		}
+	})
+}
+
+func TestListAllSkills(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list skills across all characters", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		et := factory.CreateEveType()
+		c1 := factory.CreateCharacter()
+		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID: c1.ID,
+			TypeID:      et.ID,
+		})
+		c2 := factory.CreateCharacter()
+		factory.CreateCharacterSkill(storage.UpdateOrCreateCharacterSkillParams{
+			CharacterID: c2.ID,
+			TypeID:      et.ID,
+		})
+		// when
+		got, err := cs.ListAllSkills(ctx)
+		// then
+		if assert.NoError(t, err) {
+			ids := xslices.Map(got, func(x *app.CharacterSkill) int64 { return x.CharacterID })
+			assert.ElementsMatch(t, []int64{c1.ID, c2.ID}, ids)
+		}
+	})
+}
+
+func TestTotalTrainingTime(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("should return a duration when section status is valid and up to date", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterSectionStatus(testutil.CharacterSectionStatusParams{
+			CharacterID: c.ID,
+			Section:     app.SectionCharacterSkillqueue,
+		})
+		now := time.Now()
+		factory.CreateCharacterSkillqueueItem(storage.SkillqueueItemParams{
+			CharacterID: c.ID,
+			StartDate:   optional.New(now),
+			FinishDate:  optional.New(now.Add(2 * time.Hour)),
+		})
+		// when
+		got, err := cs.TotalTrainingTime(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			v, ok := got.Value()
+			if assert.True(t, ok) {
+				assert.Greater(t, v, time.Duration(0))
+			}
+		}
+	})
+	t.Run("should return empty when no section status exists yet", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		// when
+		got, err := cs.TotalTrainingTime(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			_, ok := got.Value()
+			assert.False(t, ok)
+		}
+	})
+	t.Run("should return empty when section status is stale", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterSectionStatus(testutil.CharacterSectionStatusParams{
+			CharacterID: c.ID,
+			Section:     app.SectionCharacterSkillqueue,
+			CompletedAt: time.Now().Add(-24 * time.Hour),
+		})
+		// when
+		got, err := cs.TotalTrainingTime(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			_, ok := got.Value()
+			assert.False(t, ok)
+		}
+	})
+	t.Run("should return empty when section status has an error", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		factory.CreateCharacterSectionStatus(testutil.CharacterSectionStatusParams{
+			CharacterID:  c.ID,
+			Section:      app.SectionCharacterSkillqueue,
+			ErrorMessage: "error",
+		})
+		// when
+		got, err := cs.TotalTrainingTime(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			_, ok := got.Value()
+			assert.False(t, ok)
+		}
+	})
+}
+
+func TestUpdateIsTrainingWatched(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	cs := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can update the watched flag", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacterFull()
+		// when
+		err := cs.UpdateIsTrainingWatched(ctx, c.ID, true)
+		// then
+		if assert.NoError(t, err) {
+			got, err := st.GetCharacter(ctx, c.ID)
+			if assert.NoError(t, err) {
+				assert.True(t, got.IsTrainingWatched)
+			}
+		}
+	})
+	t.Run("clears the training-notified cache so a new notification can be sent", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacterFull(storage.CreateCharacterParams{IsTrainingWatched: true})
+		var sendCount int
+		notify := func(title, content string) { sendCount++ }
+		require.NoError(t, cs.NotifyExpiredTrainingForWatched(ctx, c.ID, notify))
+		require.NoError(t, cs.NotifyExpiredTrainingForWatched(ctx, c.ID, notify))
+		require.Equal(t, 1, sendCount) // second call suppressed by cache
+		// when
+		err := cs.UpdateIsTrainingWatched(ctx, c.ID, true)
+		// then
+		require.NoError(t, err)
+		require.NoError(t, cs.NotifyExpiredTrainingForWatched(ctx, c.ID, notify))
+		assert.Equal(t, 2, sendCount) // cache was cleared, so notification is sent again
 	})
 }

--- a/internal/app/characterservice/tag_test.go
+++ b/internal/app/characterservice/tag_test.go
@@ -131,3 +131,194 @@ func TestImportTags(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestCreateTag(t *testing.T) {
+	db, st, _ := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can create a new tag", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		got, err := s.CreateTag(ctx, "Alpha")
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, "Alpha", got.Name)
+			tags, err := st.ListTagsByName(ctx)
+			if assert.NoError(t, err) && assert.Len(t, tags, 1) {
+				assert.Equal(t, "Alpha", tags[0].Name)
+			}
+		}
+	})
+}
+
+func TestDeleteTag(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can delete a tag", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		tag := factory.CreateCharacterTag()
+		// when
+		err := s.DeleteTag(ctx, tag.ID)
+		// then
+		if assert.NoError(t, err) {
+			tags, err := st.ListTagsByName(ctx)
+			if assert.NoError(t, err) {
+				assert.Empty(t, tags)
+			}
+		}
+	})
+}
+
+func TestDeleteAllTags(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can delete all tags", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterTag()
+		factory.CreateCharacterTag()
+		// when
+		err := s.DeleteAllTags(ctx)
+		// then
+		if assert.NoError(t, err) {
+			tags, err := st.ListTagsByName(ctx)
+			if assert.NoError(t, err) {
+				assert.Empty(t, tags)
+			}
+		}
+	})
+}
+
+func TestListTagsByName(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list tags sorted by name", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterTag("Zulu")
+		factory.CreateCharacterTag("Alpha")
+		// when
+		got, err := s.ListTagsByName(ctx)
+		// then
+		if assert.NoError(t, err) && assert.Len(t, got, 2) {
+			assert.Equal(t, "Alpha", got[0].Name)
+			assert.Equal(t, "Zulu", got[1].Name)
+		}
+	})
+}
+
+func TestRenameTag(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can rename a tag", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		tag := factory.CreateCharacterTag("Old")
+		// when
+		err := s.RenameTag(ctx, tag.ID, "New")
+		// then
+		if assert.NoError(t, err) {
+			tags, err := st.ListTagsByName(ctx)
+			if assert.NoError(t, err) && assert.Len(t, tags, 1) {
+				assert.Equal(t, "New", tags[0].Name)
+			}
+		}
+	})
+}
+
+func TestAddAndRemoveTagFromCharacter(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can add and remove a tag from a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		tag := factory.CreateCharacterTag()
+		c := factory.CreateCharacter()
+		// when
+		err := s.AddTagToCharacter(ctx, c.ID, tag.ID)
+		// then
+		if assert.NoError(t, err) {
+			cc, err := st.ListCharacterTagsForCharacter(ctx, c.ID)
+			if assert.NoError(t, err) {
+				assert.Len(t, cc, 1)
+			}
+		}
+		// when
+		err = s.RemoveTagFromCharacter(ctx, c.ID, tag.ID)
+		// then
+		if assert.NoError(t, err) {
+			cc, err := st.ListCharacterTagsForCharacter(ctx, c.ID)
+			if assert.NoError(t, err) {
+				assert.Empty(t, cc)
+			}
+		}
+	})
+}
+
+func TestListCharactersForTag(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can split characters into tagged and others", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		tag := factory.CreateCharacterTag()
+		c1 := factory.CreateCharacter()
+		factory.AddCharacterToTag(tag, c1)
+		c2 := factory.CreateCharacter()
+		// when
+		tagged, others, err := s.ListCharactersForTag(ctx, tag.ID)
+		// then
+		if assert.NoError(t, err) {
+			taggedIDs := xslices.Map(tagged, func(x *app.EntityShort) int64 { return x.ID })
+			otherIDs := xslices.Map(others, func(x *app.EntityShort) int64 { return x.ID })
+			assert.ElementsMatch(t, []int64{c1.ID}, taggedIDs)
+			assert.ElementsMatch(t, []int64{c2.ID}, otherIDs)
+		}
+	})
+}
+
+func TestListTagsForCharacter(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list tag names for a character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		tag := factory.CreateCharacterTag("Alpha")
+		c := factory.CreateCharacter()
+		factory.AddCharacterToTag(tag, c)
+		// when
+		got, err := s.ListTagsForCharacter(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.True(t, got.Contains("Alpha"))
+		}
+	})
+	t.Run("returns empty set when character has no tags", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCharacter()
+		// when
+		got, err := s.ListTagsForCharacter(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, 0, got.Size())
+		}
+	})
+}

--- a/internal/app/characterservice/token_test.go
+++ b/internal/app/characterservice/token_test.go
@@ -68,6 +68,48 @@ func TestHasTokenWithScopes(t *testing.T) {
 	})
 }
 
+func TestCharactersWithMissingScopes(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("should list characters missing scopes and exclude complete ones", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		complete := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{
+			CharacterID: complete.ID,
+			Scopes:      app.Scopes(),
+		})
+		incomplete := factory.CreateCharacter()
+		factory.CreateCharacterToken(storage.UpdateOrCreateCharacterTokenParams{
+			CharacterID: incomplete.ID,
+			Scopes:      set.Of("alpha"),
+		})
+		noToken := factory.CreateCharacter()
+		// when
+		got, err := s.CharactersWithMissingScopes(ctx)
+		// then
+		if assert.NoError(t, err) {
+			ids := make([]int64, len(got))
+			for i, c := range got {
+				ids[i] = c.ID
+			}
+			assert.ElementsMatch(t, []int64{incomplete.ID, noToken.ID}, ids)
+		}
+	})
+	t.Run("should return empty when no characters exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		got, err := s.CharactersWithMissingScopes(ctx)
+		// then
+		if assert.NoError(t, err) {
+			assert.Empty(t, got)
+		}
+	})
+}
+
 func TestMissingScopes(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()

--- a/internal/app/characterservice/wallet_test.go
+++ b/internal/app/characterservice/wallet_test.go
@@ -1,0 +1,64 @@
+package characterservice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app/characterservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
+)
+
+func TestGetWalletJournalEntry(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return a wallet journal entry", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterWalletJournalEntry()
+		// when
+		got, err := s.GetWalletJournalEntry(ctx, o.CharacterID, o.RefID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, o.RefID, got.RefID)
+		}
+	})
+	t.Run("should return error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetWalletJournalEntry(ctx, 1, 1)
+		// then
+		assert.Error(t, err)
+	})
+}
+
+func TestGetWalletTransactions(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewCharacterServiceFake(characterservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return a wallet transaction", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCharacterWalletTransaction()
+		// when
+		got, err := s.GetWalletTransactions(ctx, o.CharacterID, o.TransactionID)
+		// then
+		if assert.NoError(t, err) {
+			assert.Equal(t, o.TransactionID, got.TransactionID)
+		}
+	})
+	t.Run("should return error when not found", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetWalletTransactions(ctx, 1, 1)
+		// then
+		assert.Error(t, err)
+	})
+}

--- a/internal/app/corporationservice/assets_internal_test.go
+++ b/internal/app/corporationservice/assets_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 func TestUpdateCorporationAssetsESI(t *testing.T) {
@@ -260,6 +261,44 @@ func TestUpdateCorporationAssetsESI(t *testing.T) {
 		x, err = st.GetCorporationAsset(ctx, c.ID, 1000000016836)
 		require.NoError(t, err)
 		xassert.Equal(t, "", x.Name)
+	})
+}
+
+func TestListAssets(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list assets and filter out alliance assets", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		et := factory.CreateEveType(storage.CreateEveTypeParams{ID: app.EveTypeAlliance})
+		a1 := factory.CreateCorporationAsset(storage.CreateCorporationAssetParams{CorporationID: c.ID})
+		factory.CreateCorporationAsset(storage.CreateCorporationAssetParams{CorporationID: c.ID, EveTypeID: et.ID})
+		got, err := s.ListAssets(ctx, c.ID)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.CorporationAsset) int64 { return x.ItemID }))
+			xassert.Equal(t, set.Of(a1.ItemID), ids)
+		}
+	})
+}
+
+func TestListAllAssets(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list assets from all corporations", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		a1 := factory.CreateCorporationAsset(storage.CreateCorporationAssetParams{CorporationID: c1.ID})
+		a2 := factory.CreateCorporationAsset(storage.CreateCorporationAssetParams{CorporationID: c2.ID})
+		got, err := s.ListAllAssets(ctx)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.CorporationAsset) int64 { return x.ItemID }))
+			xassert.Equal(t, set.Of(a1.ItemID, a2.ItemID), ids)
+		}
 	})
 }
 

--- a/internal/app/corporationservice/contracts_internal_test.go
+++ b/internal/app/corporationservice/contracts_internal_test.go
@@ -16,7 +16,116 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
+
+func TestGetContract(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return existing contract", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		o := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		got, err := s.GetContract(ctx, c.ID, o.ContractID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, o.ID, got.ID)
+		}
+	})
+	t.Run("should return error when contract not found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetContract(ctx, c.ID, 42)
+		assert.Error(t, err)
+	})
+}
+
+func TestCountContractBids(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can count bids for a contract", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCorporationContract()
+		factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: o.ID})
+		factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: o.ID})
+		got, err := s.CountContractBids(ctx, o.ID)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, got)
+		}
+	})
+	t.Run("returns zero when contract has no bids", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCorporationContract()
+		got, err := s.CountContractBids(ctx, o.ID)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 0, got)
+		}
+	})
+}
+
+func TestGetContractTopBid(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("returns the bid with the highest amount", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCorporationContract()
+		factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: o.ID, Amount: 100})
+		top := factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: o.ID, Amount: 500})
+		factory.CreateCorporationContractBid(storage.CreateCorporationContractBidParams{ContractID: o.ID, Amount: 200})
+		got, err := s.GetContractTopBid(ctx, o.ID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, top.BidID, got.BidID)
+		}
+	})
+	t.Run("should return error when contract has no bids", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCorporationContract()
+		_, err := s.GetContractTopBid(ctx, o.ID)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListCorporationContracts(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list contracts for a corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		o1 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		o2 := factory.CreateCorporationContract(storage.CreateCorporationContractParams{CorporationID: c.ID})
+		factory.CreateCorporationContract()
+		got, err := s.ListCorporationContracts(ctx, c.ID)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.CorporationContract) int64 { return x.ID }))
+			xassert.Equal(t, set.Of(o1.ID, o2.ID), ids)
+		}
+	})
+}
+
+func TestListContractItems(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list items for a contract", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		o := factory.CreateCorporationContract()
+		i1 := factory.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: o.ID})
+		i2 := factory.CreateCorporationContractItem(storage.CreateCorporationContractItemParams{ContractID: o.ID})
+		got, err := s.ListContractItems(ctx, o.ID)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.CorporationContractItem) int64 { return x.RecordID }))
+			xassert.Equal(t, set.Of(i1.RecordID, i2.RecordID), ids)
+		}
+	})
+}
 
 func TestUpdateContractESI(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)

--- a/internal/app/corporationservice/corporation_test.go
+++ b/internal/app/corporationservice/corporation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+	"github.com/ErikKalkoken/evebuddy/internal/xiter"
 )
 
 func TestCorporation_UpdateCorporations(t *testing.T) {
@@ -110,5 +111,128 @@ func TestCorporation_UpdateCorporations(t *testing.T) {
 			t.Fatal()
 		}
 		xassert.Equal(t, 0, got.Size())
+	})
+}
+
+func TestCorporation_GetCorporation(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("can return existing corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		got, err := s.GetCorporation(ctx, c.ID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, c.ID, got.ID)
+		}
+	})
+	t.Run("should return error when corporation not found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		_, err := s.GetCorporation(ctx, 42)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestCorporation_GetAnyCorporation(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("can return a corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		got, err := s.GetAnyCorporation(ctx)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, c.ID, got.ID)
+		}
+	})
+	t.Run("should return error when no corporation found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		_, err := s.GetAnyCorporation(ctx)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestCorporation_HasCorporation(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("reports true when corporation exists", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		got, err := s.HasCorporation(ctx, c.ID)
+		if assert.NoError(t, err) {
+			assert.True(t, got)
+		}
+	})
+	t.Run("reports false when corporation does not exist", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		got, err := s.HasCorporation(ctx, 42)
+		if assert.NoError(t, err) {
+			assert.False(t, got)
+		}
+	})
+	t.Run("reports false when id is zero", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		got, err := s.HasCorporation(ctx, 0)
+		if assert.NoError(t, err) {
+			assert.False(t, got)
+		}
+	})
+}
+
+func TestCorporation_ListCorporationsShort(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("can list corporations in short form", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		got, err := s.ListCorporationsShort(ctx)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.EntityShort) int64 { return x.ID }))
+			xassert.Equal(t, set.Of(c1.ID, c2.ID), ids)
+		}
+	})
+}
+
+func TestCorporation_CorporationNames(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("returns a map of corporation names", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		got, err := s.CorporationNames(ctx)
+		if assert.NoError(t, err) {
+			ec, err := st.GetEveCorporation(ctx, c.ID)
+			if assert.NoError(t, err) {
+				assert.Equal(t, ec.Name, got[c.ID])
+			}
+		}
+	})
+}
+
+func TestCorporation_ListPrivilegedCorporations(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	s := testdouble.NewCorporationServiceFake(corporationservice.Params{Storage: st})
+	t.Run("can list corporations with privileged access", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		character := factory.CreateCharacter()
+		corp1 := factory.CreateCorporation(character.EveCharacter.Corporation.ID)
+		factory.SetCharacterRoles(character.ID, app.CorporationSectionWalletJournal(app.Division1).Roles())
+		factory.CreateCorporation()
+		got, err := s.ListPrivilegedCorporations(ctx)
+		if assert.NoError(t, err) {
+			ids := set.Collect(xiter.MapSlice(got, func(x *app.EntityShort) int64 { return x.ID }))
+			xassert.Equal(t, set.Of(corp1.ID), ids)
+		}
 	})
 }

--- a/internal/app/corporationservice/industry_internal_test.go
+++ b/internal/app/corporationservice/industry_internal_test.go
@@ -20,6 +20,66 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
+func TestGetCorporationIndustryJob(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return existing job", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		j := factory.CreateCorporationIndustryJob(storage.UpdateOrCreateCorporationIndustryJobParams{CorporationID: c.ID})
+		got, err := s.GetCorporationIndustryJob(ctx, c.ID, j.JobID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, j.JobID, got.JobID)
+		}
+	})
+	t.Run("should return error when job not found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetCorporationIndustryJob(ctx, c.ID, 42)
+		assert.Error(t, err)
+	})
+}
+
+func TestListAllCorporationIndustryJobs(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list jobs from all corporations", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		j1 := factory.CreateCorporationIndustryJob(storage.UpdateOrCreateCorporationIndustryJobParams{CorporationID: c1.ID})
+		j2 := factory.CreateCorporationIndustryJob(storage.UpdateOrCreateCorporationIndustryJobParams{CorporationID: c2.ID})
+		got, err := s.ListAllCorporationIndustryJobs(ctx)
+		if assert.NoError(t, err) {
+			ids := set.Of(xslices.Map(got, func(x *app.CorporationIndustryJob) int64 { return x.JobID })...)
+			xassert.Equal(t, set.Of(j1.JobID, j2.JobID), ids)
+		}
+	})
+}
+
+func TestListCorporationIndustryJobs(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list jobs for a corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		j1 := factory.CreateCorporationIndustryJob(storage.UpdateOrCreateCorporationIndustryJobParams{CorporationID: c1.ID})
+		factory.CreateCorporationIndustryJob(storage.UpdateOrCreateCorporationIndustryJobParams{CorporationID: c2.ID})
+		got, err := s.ListCorporationIndustryJobs(ctx, c1.ID)
+		if assert.NoError(t, err) {
+			ids := set.Of(xslices.Map(got, func(x *app.CorporationIndustryJob) int64 { return x.JobID })...)
+			xassert.Equal(t, set.Of(j1.JobID), ids)
+		}
+	})
+}
+
 func TestUpdateIndustryJobsESI(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()

--- a/internal/app/corporationservice/members_internal_test.go
+++ b/internal/app/corporationservice/members_internal_test.go
@@ -16,6 +16,25 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
+func TestListMembers(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list members of a corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		m1 := factory.CreateCorporationMember(storage.CorporationMemberParams{CorporationID: c1.ID})
+		factory.CreateCorporationMember(storage.CorporationMemberParams{CorporationID: c2.ID})
+		got, err := s.ListMembers(ctx, c1.ID)
+		if assert.NoError(t, err) {
+			require.Len(t, got, 1)
+			xassert.Equal(t, m1.Character.ID, got[0].Character.ID)
+		}
+	})
+}
+
 func TestUpdateCorporationMembersESI(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()

--- a/internal/app/corporationservice/structures_internal_test.go
+++ b/internal/app/corporationservice/structures_internal_test.go
@@ -9,12 +9,54 @@ import (
 	"github.com/ErikKalkoken/go-set"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/storage"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
+
+func TestGetStructure(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return existing structure", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		o := factory.CreateCorporationStructure(storage.UpdateOrCreateCorporationStructureParams{CorporationID: c.ID})
+		got, err := s.GetStructure(ctx, c.ID, o.StructureID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, o.StructureID, got.StructureID)
+		}
+	})
+	t.Run("should return error when structure not found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetStructure(ctx, c.ID, 42)
+		assert.Error(t, err)
+	})
+}
+
+func TestListStructures(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can list structures for a corporation", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c1 := factory.CreateCorporation()
+		c2 := factory.CreateCorporation()
+		o1 := factory.CreateCorporationStructure(storage.UpdateOrCreateCorporationStructureParams{CorporationID: c1.ID})
+		factory.CreateCorporationStructure(storage.UpdateOrCreateCorporationStructureParams{CorporationID: c2.ID})
+		got, err := s.ListStructures(ctx, c1.ID)
+		if assert.NoError(t, err) {
+			require.Len(t, got, 1)
+			xassert.Equal(t, o1.StructureID, got[0].StructureID)
+		}
+	})
+}
 
 func TestUpdateCorporationStructuresESI(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)

--- a/internal/app/corporationservice/wallet_internal_test.go
+++ b/internal/app/corporationservice/wallet_internal_test.go
@@ -21,6 +21,139 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
+func TestGetWalletName(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("can return existing wallet name", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		w := factory.CreateCorporationWalletName(storage.UpdateOrCreateCorporationWalletNameParams{CorporationID: c.ID, DivisionID: 1})
+		got, err := s.GetWalletName(ctx, c.ID, app.Division1)
+		if assert.NoError(t, err) {
+			assert.Equal(t, w.Name, got)
+		}
+	})
+	t.Run("should return error when not found", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetWalletName(ctx, c.ID, app.Division1)
+		assert.Error(t, err)
+	})
+}
+
+func TestListWalletNames(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st})
+	ctx := context.Background()
+	t.Run("returns stored names merged with defaults", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		factory.CreateCorporationWalletName(storage.UpdateOrCreateCorporationWalletNameParams{
+			CorporationID: c.ID,
+			DivisionID:    1,
+			Name:          "Awesome Wallet",
+		})
+		got := s.ListWalletNames(ctx, c.ID)
+		assert.Equal(t, "Awesome Wallet", got[app.Division1])
+		assert.Equal(t, "2nd Wallet Division", got[app.Division2])
+	})
+	t.Run("returns defaults when corporation unknown", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		got := s.ListWalletNames(ctx, 42)
+		assert.Equal(t, "Master Wallet", got[app.Division1])
+	})
+}
+
+func TestListWalletBalances(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st, CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+	ctx := context.Background()
+	t.Run("can list balances with names", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		factory.CreateCorporationTokenForSection(c.ID, app.SectionCorporationWalletBalances)
+		factory.CreateCorporationWalletBalance(storage.UpdateOrCreateCorporationWalletBalanceParams{
+			CorporationID: c.ID,
+			DivisionID:    1,
+			Balance:       123.45,
+		})
+		got, err := s.ListWalletBalances(ctx, c.ID)
+		if assert.NoError(t, err) {
+			m := make(map[int64]app.CorporationWalletBalanceWithName)
+			for _, x := range got {
+				m[x.DivisionID] = x
+			}
+			require.Contains(t, m, int64(1))
+			assert.Equal(t, 123.45, m[1].Balance)
+			assert.Equal(t, "Master Wallet", m[1].Name)
+		}
+	})
+	t.Run("returns empty when section not enabled", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		got, err := s.ListWalletBalances(ctx, c.ID)
+		if assert.NoError(t, err) {
+			assert.Empty(t, got)
+		}
+	})
+}
+
+func TestGetWalletJournalEntry(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st, CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+	ctx := context.Background()
+	t.Run("can return existing entry", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		factory.CreateCorporationTokenForSection(c.ID, app.CorporationSectionWalletJournal(app.Division1))
+		e := factory.CreateCorporationWalletJournalEntry(storage.CreateCorporationWalletJournalEntryParams{
+			CorporationID: c.ID,
+			DivisionID:    1,
+		})
+		got, err := s.GetWalletJournalEntry(ctx, c.ID, app.Division1, e.RefID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, e.RefID, got.RefID)
+		}
+	})
+	t.Run("should return error when section not enabled", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetWalletJournalEntry(ctx, c.ID, app.Division1, 42)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestGetWalletTransaction(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	s := NewFake(Params{Storage: st, CharacterService: &CharacterServiceFake{Token: &app.CharacterToken{AccessToken: "accessToken"}}})
+	ctx := context.Background()
+	t.Run("can return existing transaction", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		factory.CreateCorporationTokenForSection(c.ID, app.CorporationSectionWalletTransactions(app.Division1))
+		x := factory.CreateCorporationWalletTransaction(storage.CreateCorporationWalletTransactionParams{
+			CorporationID: c.ID,
+			DivisionID:    1,
+		})
+		got, err := s.GetWalletTransaction(ctx, c.ID, app.Division1, x.TransactionID)
+		if assert.NoError(t, err) {
+			xassert.Equal(t, x.TransactionID, got.TransactionID)
+		}
+	})
+	t.Run("should return error when section not enabled", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		_, err := s.GetWalletTransaction(ctx, c.ID, app.Division1, 42)
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
 func TestUpdateWalletBalancesESI(t *testing.T) {
 	db, st, factory := testutil.NewDBOnDisk(t)
 	defer db.Close()

--- a/internal/app/eveimageservice/eveimageservice_test.go
+++ b/internal/app/eveimageservice/eveimageservice_test.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/app/eveimageservice"
@@ -25,9 +26,7 @@ func TestImageFetchingAsync(t *testing.T) {
 		test.NewTempApp(t)
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/character.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -50,9 +49,7 @@ func TestImageFetchingAsync(t *testing.T) {
 		test.NewTempApp(t)
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/character.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -74,6 +71,187 @@ func TestImageFetchingAsync(t *testing.T) {
 		})
 		assert.Equal(t, dat, result2.Content())
 		assert.Equal(t, 0, httpmock.GetTotalCallCount())
+	})
+	t.Run("can fetch an alliance logo async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/alliance.png")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/alliances/99/logo?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.AllianceLogoAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a corporation logo async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/corporation.png")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/corporations/99/logo?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.CorporationLogoAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a faction logo async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/faction.png")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/corporations/99/logo?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.FactionLogoAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a type render async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/type.jpeg")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/types/99/render?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.InventoryTypeRenderAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a type icon async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/type.jpeg")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/types/99/icon?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.InventoryTypeIconAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a type BPO async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/type.jpeg")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/types/99/bp?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.InventoryTypeBPOAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+	t.Run("can fetch a type BPC async from the image server", func(t *testing.T) {
+		// given
+		test.NewTempApp(t)
+		c := testutil.NewCacheFake()
+		dat, err := os.ReadFile("testdata/type.jpeg")
+		require.NoError(t, err)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			"https://images.evetech.net/types/99/bpc?size=64",
+			httpmock.NewBytesResponder(200, dat),
+		)
+		//when
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		result := make(chan fyne.Resource, 2)
+		s.InventoryTypeBPCAsync(99, 64, func(r fyne.Resource) {
+			result <- r
+		})
+		<-result
+		second := <-result
+		assert.Equal(t, dat, second.Content())
+	})
+}
+
+func TestInventoryTypeSKINAsync(t *testing.T) {
+	t.Run("returns the SKIN icon for the expected size", func(t *testing.T) {
+		// given
+		c := testutil.NewCacheFake()
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		// when
+		var result fyne.Resource
+		s.InventoryTypeSKINAsync(99, 64, func(r fyne.Resource) {
+			result = r
+		})
+		// then
+		assert.Equal(t, "skin_icon_64px.png", result.Name())
+	})
+	t.Run("returns a broken image placeholder for an unsupported size", func(t *testing.T) {
+		// given
+		c := testutil.NewCacheFake()
+		s := eveimageservice.New(c, http.DefaultClient, false)
+		// when
+		var result fyne.Resource
+		s.InventoryTypeSKINAsync(99, 32, func(r fyne.Resource) {
+			result = r
+		})
+		// then
+		assert.Contains(t, result.Name(), "broken")
 	})
 }
 
@@ -117,9 +295,7 @@ func TestImageFetching(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/alliance.png")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -129,17 +305,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.AllianceLogo(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a character portrait from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/character.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -150,17 +323,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.CharacterPortrait(93330670, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a corporation logo from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/corporation.png")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -171,17 +341,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.CorporationLogo(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a faction logo from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/faction.png")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -192,17 +359,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.FactionLogo(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a type icon from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/type.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -213,17 +377,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.InventoryTypeIcon(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a type render from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/type.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -234,17 +395,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.InventoryTypeRender(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a type BPO from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/type.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -255,17 +413,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.InventoryTypeBPO(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("can fetch a type BPC from the image server", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/type.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -276,17 +431,14 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, false)
 		r, err := m.InventoryTypeBPC(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, dat, r.Content())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, dat, r.Content())
 	})
 	t.Run("should convert images size errors", func(t *testing.T) {
 		// given
 		c := testutil.NewCacheFake()
 		dat, err := os.ReadFile("testdata/character.jpeg")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		httpmock.Reset()
 		httpmock.RegisterResponder(
 			"GET",
@@ -311,10 +463,9 @@ func TestImageFetching(t *testing.T) {
 		m := eveimageservice.New(c, http.DefaultClient, true)
 		r, err := m.AllianceLogo(99, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Contains(t, r.Name(), "broken")
-			assert.Equal(t, 0, httpmock.GetTotalCallCount())
-		}
+		require.NoError(t, err)
+		assert.Contains(t, r.Name(), "broken")
+		assert.Equal(t, 0, httpmock.GetTotalCallCount())
 	})
 }
 
@@ -328,9 +479,8 @@ func TestOffline(t *testing.T) {
 	c := testutil.NewCacheFake()
 	s := eveimageservice.New(c, http.DefaultClient, true)
 	x, err := s.CharacterPortrait(123, 64)
-	if assert.NoError(t, err) {
-		assert.NotEmpty(t, x.Content())
-	}
+	require.NoError(t, err)
+	assert.NotEmpty(t, x.Content())
 }
 
 func TestEveEntityLogo(t *testing.T) {
@@ -358,10 +508,9 @@ func TestEveEntityLogo(t *testing.T) {
 				// when
 				got, err := m.EveEntityLogo(o, 64)
 				// then
-				if assert.NoError(t, err) {
-					assert.Equal(t, tc.want, got)
-					assert.Equal(t, 0, httpmock.GetTotalCallCount())
-				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+				assert.Equal(t, 0, httpmock.GetTotalCallCount())
 			})
 		}
 	})
@@ -393,9 +542,8 @@ func TestEveEntityLogo(t *testing.T) {
 				// when
 				got, err := m.EveEntityLogo(o, 64)
 				// then
-				if assert.NoError(t, err) {
-					assert.Equal(t, dat, got.Content())
-				}
+				require.NoError(t, err)
+				assert.Equal(t, dat, got.Content())
 			})
 		}
 	})
@@ -408,10 +556,9 @@ func TestEveEntityLogo(t *testing.T) {
 		// when
 		got, err := m.EveEntityLogo(o, 64)
 		// then
-		if assert.NoError(t, err) {
-			assert.Equal(t, theme.BrokenImageIcon(), got)
-			assert.Equal(t, 0, httpmock.GetTotalCallCount())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, theme.BrokenImageIcon(), got)
+		assert.Equal(t, 0, httpmock.GetTotalCallCount())
 	})
 }
 

--- a/internal/app/evenotification/helpers_internal_test.go
+++ b/internal/app/evenotification/helpers_internal_test.go
@@ -1,0 +1,107 @@
+package evenotification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+)
+
+func TestMakeInfoLink2(t *testing.T) {
+	cases := []struct {
+		name     string
+		label    string
+		linkData []any
+		want     string
+	}{
+		{"2 elements", "Jita IV", []any{"showinfo", uint64(60003760)}, "[Jita IV](showinfo:60003760)"},
+		{"3 elements", "Jita IV", []any{"showinfo", uint64(3802), uint64(60003760)}, "[Jita IV](showinfo:3802//60003760)"},
+		{"wrong length 1", "Jita IV", []any{"showinfo"}, "Jita IV"},
+		{"wrong length 4", "Jita IV", []any{"showinfo", 1, 2, 3}, "Jita IV"},
+		{"not showinfo", "Jita IV", []any{"other", uint64(60003760)}, "Jita IV"},
+		{"empty", "Jita IV", []any{}, "Jita IV"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := makeInfoLink2(tc.label, tc.linkData)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMakeInfoLink(t *testing.T) {
+	t.Run("returns ? when entity is nil", func(t *testing.T) {
+		var e *app.EveEntity
+		got := makeInfoLink(e)
+		assert.Equal(t, "?", got)
+	})
+	t.Run("returns name when link can not be constructed and name is set", func(t *testing.T) {
+		e := &app.EveEntity{ID: 42, Name: "Unknown Thing", Category: app.EveEntityUndefined}
+		got := makeInfoLink(e)
+		assert.Equal(t, "Unknown Thing", got)
+	})
+	t.Run("returns ? when link can not be constructed and name is empty", func(t *testing.T) {
+		e := &app.EveEntity{ID: 42, Category: app.EveEntityUndefined}
+		got := makeInfoLink(e)
+		assert.Equal(t, "?", got)
+	})
+	t.Run("returns markdown link for a resolvable entity", func(t *testing.T) {
+		e := &app.EveEntity{ID: 42, Name: "Bob", Category: app.EveEntityCharacter}
+		got := makeInfoLink(e)
+		assert.Equal(t, "[Bob](showinfo:1373//42)", got)
+	})
+}
+
+func TestMakeMarkDownLink(t *testing.T) {
+	t.Run("returns label when url is empty", func(t *testing.T) {
+		got := makeMarkDownLink("Bob", "")
+		assert.Equal(t, "Bob", got)
+	})
+	t.Run("returns markdown link when url is set", func(t *testing.T) {
+		got := makeMarkDownLink("Bob", "showinfo:1377//42")
+		assert.Equal(t, "[Bob](showinfo:1377//42)", got)
+	})
+}
+
+func TestLinkDataUint64(t *testing.T) {
+	t.Run("returns value for valid index and type", func(t *testing.T) {
+		got, err := linkDataUint64("ctx", []any{"x", uint64(123)}, 1)
+		if assert.NoError(t, err) {
+			assert.Equal(t, uint64(123), got)
+		}
+	})
+	t.Run("returns error when index out of range", func(t *testing.T) {
+		_, err := linkDataUint64("ctx", []any{"x"}, 5)
+		assert.Error(t, err)
+	})
+	t.Run("returns error when index negative", func(t *testing.T) {
+		_, err := linkDataUint64("ctx", []any{"x"}, -1)
+		assert.Error(t, err)
+	})
+	t.Run("returns error when wrong type", func(t *testing.T) {
+		_, err := linkDataUint64("ctx", []any{"x", "not a uint64"}, 1)
+		assert.Error(t, err)
+	})
+}
+
+func TestLinkDataString(t *testing.T) {
+	t.Run("returns value for valid index and type", func(t *testing.T) {
+		got, err := linkDataString("ctx", []any{"x", "hello"}, 1)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "hello", got)
+		}
+	})
+	t.Run("returns error when index out of range", func(t *testing.T) {
+		_, err := linkDataString("ctx", []any{"x"}, 5)
+		assert.Error(t, err)
+	})
+	t.Run("returns error when index negative", func(t *testing.T) {
+		_, err := linkDataString("ctx", []any{"x"}, -1)
+		assert.Error(t, err)
+	})
+	t.Run("returns error when wrong type", func(t *testing.T) {
+		_, err := linkDataString("ctx", []any{"x", uint64(123)}, 1)
+		assert.Error(t, err)
+	})
+}

--- a/internal/app/evenotification/moonmining_test.go
+++ b/internal/app/evenotification/moonmining_test.go
@@ -1,0 +1,179 @@
+package evenotification_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/evenotification"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+)
+
+func TestMoonmining_RenderESI(t *testing.T) {
+	db, st, f := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	eus := evenotification.NewEveUniverseService(st)
+	en := evenotification.New(eus)
+
+	t.Run("MoonminingAutomaticFracture", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		ore := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		text, err := yaml.Marshal(map[string]any{
+			"moonID":          moon.ID,
+			"oreVolumeByType": map[int64]float64{ore.ID: 1234.5},
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingAutomaticFracture, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, ore.Name)
+	})
+
+	t.Run("MoonminingExtractionStarted", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		ore := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		text, err := yaml.Marshal(map[string]any{
+			"autoTime":        132202238630000000,
+			"moonID":          moon.ID,
+			"oreVolumeByType": map[int64]float64{ore.ID: 500},
+			"readyTime":       132202237630000000,
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingExtractionStarted, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, ore.Name)
+	})
+
+	t.Run("MoonminingExtractionFinished", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		ore := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		text, err := yaml.Marshal(map[string]any{
+			"autoTime":        132202238630000000,
+			"moonID":          moon.ID,
+			"oreVolumeByType": map[int64]float64{ore.ID: 500},
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingExtractionFinished, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, ore.Name)
+	})
+
+	t.Run("MoonminingExtractionCancelled with canceller", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		canceller := f.CreateEveEntityCharacter()
+		text, err := yaml.Marshal(map[string]any{
+			"cancelledBy":     canceller.ID,
+			"moonID":          moon.ID,
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingExtractionCancelled, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, canceller.Name)
+	})
+
+	t.Run("MoonminingExtractionCancelled without canceller", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		text, err := yaml.Marshal(map[string]any{
+			"cancelledBy":     0,
+			"moonID":          moon.ID,
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingExtractionCancelled, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.NotContains(t, body, " by ")
+	})
+
+	t.Run("MoonminingLaserFired with firer", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		ore := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		firer := f.CreateEveEntityCharacter()
+		text, err := yaml.Marshal(map[string]any{
+			"firedBy":         firer.ID,
+			"moonID":          moon.ID,
+			"oreVolumeByType": map[int64]float64{ore.ID: 500},
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingLaserFired, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, ore.Name)
+		assert.Contains(t, body, firer.Name)
+	})
+
+	t.Run("MoonminingLaserFired without firer", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		moon := f.CreateEveMoon()
+		ore := f.CreateEveEntityWithCategory(app.EveEntityInventoryType)
+		text, err := yaml.Marshal(map[string]any{
+			"firedBy":         0,
+			"moonID":          moon.ID,
+			"oreVolumeByType": map[int64]float64{ore.ID: 500},
+			"structureID":     1000000000001,
+			"structureName":   "Munin - Mining Outpost",
+			"structureTypeID": 35835,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.MoonminingLaserFired, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "Munin - Mining Outpost")
+		assert.Contains(t, body, moon.Name)
+		assert.Contains(t, body, ore.Name)
+	})
+}

--- a/internal/app/evenotification/orbital_test.go
+++ b/internal/app/evenotification/orbital_test.go
@@ -1,0 +1,140 @@
+package evenotification_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/evenotification"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/optional"
+)
+
+func TestOrbital_RenderESI(t *testing.T) {
+	db, st, f := testutil.NewDBInMemory()
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	eus := evenotification.NewEveUniverseService(st)
+	en := evenotification.New(eus)
+
+	t.Run("OrbitalAttacked full data", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		aggressor := f.CreateEveEntityCharacter()
+		aggressorCorp := f.CreateEveEntityCorporation()
+		aggressorAlliance := f.CreateEveEntityAlliance()
+		planet := f.CreateEvePlanet()
+		structureType := f.CreateEveType()
+		text, err := yaml.Marshal(map[string]any{
+			"aggressorAllianceID": aggressorAlliance.ID,
+			"aggressorCorpID":     aggressorCorp.ID,
+			"aggressorID":         aggressor.ID,
+			"planetID":            planet.ID,
+			"planetTypeID":        11,
+			"shieldLevel":         0.5,
+			"solarSystemID":       30000142,
+			"typeID":              structureType.ID,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.OrbitalAttacked, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "is under attack")
+		assert.Contains(t, title, structureType.Name)
+		assert.Contains(t, title, planet.Name)
+		assert.Contains(t, body, aggressor.Name)
+		assert.Contains(t, body, aggressorCorp.Name)
+		assert.Contains(t, body, aggressorAlliance.Name)
+	})
+
+	t.Run("OrbitalAttacked without alliance", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		aggressor := f.CreateEveEntityCharacter()
+		aggressorCorp := f.CreateEveEntityCorporation()
+		planet := f.CreateEvePlanet()
+		structureType := f.CreateEveType()
+		text, err := yaml.Marshal(map[string]any{
+			"aggressorAllianceID": 0,
+			"aggressorCorpID":     aggressorCorp.ID,
+			"aggressorID":         aggressor.ID,
+			"planetID":            planet.ID,
+			"planetTypeID":        11,
+			"shieldLevel":         0.5,
+			"solarSystemID":       30000142,
+			"typeID":              structureType.ID,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.OrbitalAttacked, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "is under attack")
+		assert.Contains(t, body, aggressor.Name)
+		assert.Contains(t, body, aggressorCorp.Name)
+		assert.NotContains(t, body, "Alliance:")
+	})
+
+	t.Run("OrbitalReinforced full data", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		aggressor := f.CreateEveEntityCharacter()
+		aggressorCorp := f.CreateEveEntityCorporation()
+		aggressorAlliance := f.CreateEveEntityAlliance()
+		planet := f.CreateEvePlanet()
+		structureType := f.CreateEveType()
+		text, err := yaml.Marshal(map[string]any{
+			"aggressorAllianceID": aggressorAlliance.ID,
+			"aggressorCorpID":     aggressorCorp.ID,
+			"aggressorID":         aggressor.ID,
+			"planetID":            planet.ID,
+			"planetTypeID":        11,
+			"reinforceExitTime":   132202238630000000,
+			"solarSystemID":       30000142,
+			"typeID":              structureType.ID,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.OrbitalReinforced, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "has been reinforced")
+		assert.Contains(t, title, structureType.Name)
+		assert.Contains(t, title, planet.Name)
+		assert.Contains(t, body, aggressor.Name)
+		assert.Contains(t, body, aggressorCorp.Name)
+		assert.Contains(t, body, aggressorAlliance.Name)
+	})
+
+	t.Run("OrbitalReinforced without alliance", func(t *testing.T) {
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		aggressor := f.CreateEveEntityCharacter()
+		aggressorCorp := f.CreateEveEntityCorporation()
+		planet := f.CreateEvePlanet()
+		structureType := f.CreateEveType()
+		text, err := yaml.Marshal(map[string]any{
+			"aggressorAllianceID": 0,
+			"aggressorCorpID":     aggressorCorp.ID,
+			"aggressorID":         aggressor.ID,
+			"planetID":            planet.ID,
+			"planetTypeID":        11,
+			"reinforceExitTime":   132202238630000000,
+			"solarSystemID":       30000142,
+			"typeID":              structureType.ID,
+		})
+		require.NoError(t, err)
+
+		title, body, err := en.RenderESI(t.Context(), app.OrbitalReinforced, optional.New(string(text)), time.Now())
+		require.NoError(t, err)
+		assert.Contains(t, title, "has been reinforced")
+		assert.Contains(t, body, aggressor.Name)
+		assert.Contains(t, body, aggressorCorp.Name)
+		assert.NotContains(t, body, "Alliance:")
+	})
+}

--- a/internal/app/eveuniverseservice/character_test.go
+++ b/internal/app/eveuniverseservice/character_test.go
@@ -19,6 +19,30 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
+func TestGetCharacterESI(t *testing.T) {
+	db, st, f := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return existing character", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := f.CreateEveCharacter()
+		// when
+		c2, err := s.GetCharacterESI(t.Context(), c1.ID)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, c1, c2)
+	})
+	t.Run("should return error when character does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetCharacterESI(t.Context(), 666)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
 func TestGetOrCreateEveCharacterESI(t *testing.T) {
 	db, st, f := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/eveuniverseservice/entity_internal_test.go
+++ b/internal/app/eveuniverseservice/entity_internal_test.go
@@ -1,0 +1,46 @@
+package eveuniverseservice
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+)
+
+func TestUpdateEntityNameIfExists(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := &EVEUniverseService{st: st}
+	t.Run("should update name when entity exists", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		e := factory.CreateEveEntity()
+		// when
+		err := s.updateEntityNameIfExists(t.Context(), e.ID, "New Name")
+		// then
+		if err != nil {
+			t.Fatal(err)
+		}
+		o, err := st.GetEveEntity(t.Context(), e.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		xassert.Equal(t, "New Name", o.Name)
+	})
+	t.Run("should do nothing when entity does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		err := s.updateEntityNameIfExists(t.Context(), 666, "New Name")
+		// then
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = st.GetEveEntity(t.Context(), 666)
+		if !errors.Is(err, app.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+}

--- a/internal/app/eveuniverseservice/entity_test.go
+++ b/internal/app/eveuniverseservice/entity_test.go
@@ -19,6 +19,43 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
+func TestListEntitiesByPartialName(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return entities matching partial name", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		e1 := factory.CreateEveEntity(app.EveEntity{Name: "Erik Kalkoken"})
+		factory.CreateEveEntity(app.EveEntity{Name: "Someone Else"})
+		// when
+		oo, err := s.ListEntitiesByPartialName(t.Context(), "Kalkoken")
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, oo, 1) {
+			xassert.Equal(t, e1.ID, oo[0].ID)
+		}
+	})
+}
+
+func TestListEntitiesForIDs(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return entities for given IDs", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		e1 := factory.CreateEveEntity()
+		e2 := factory.CreateEveEntity()
+		factory.CreateEveEntity()
+		// when
+		oo, err := s.ListEntitiesForIDs(t.Context(), []int64{e1.ID, e2.ID})
+		// then
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*app.EveEntity{e1, e2}, oo)
+	})
+}
+
 func TestAddMissingEveEntities(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/eveuniverseservice/eveuniverseservice_test.go
+++ b/internal/app/eveuniverseservice/eveuniverseservice_test.go
@@ -1,0 +1,66 @@
+package eveuniverseservice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ErikKalkoken/go-set"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/eveuniverseservice"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
+	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+)
+
+func TestAddMissingEveEntitiesAndLocations(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	ctx := context.Background()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should resolve missing entities", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"POST",
+			"https://esi.evetech.net/universe/names",
+			httpmock.NewJsonResponderOrPanic(200, []map[string]any{
+				{"id": 47, "name": "Erik", "category": "character"},
+			}),
+		)
+		// when
+		err := s.AddMissingEveEntitiesAndLocations(ctx, set.Of[int64](47), set.Of[int64]())
+		// then
+		require.NoError(t, err)
+		o, err := st.GetEveEntity(ctx, 47)
+		require.NoError(t, err)
+		xassert.Equal(t, "Erik", o.Name)
+		xassert.Equal(t, app.EveEntityCharacter, o.Category)
+	})
+	t.Run("should do nothing when both sets are empty", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		// when
+		err := s.AddMissingEveEntitiesAndLocations(ctx, set.Of[int64](), set.Of[int64]())
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, 0, httpmock.GetTotalCallCount())
+	})
+	t.Run("should do nothing when locations already exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		loc := factory.CreateEveLocationStation()
+		// when
+		err := s.AddMissingEveEntitiesAndLocations(ctx, set.Of[int64](), set.Of(loc.ID))
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, 0, httpmock.GetTotalCallCount())
+	})
+}

--- a/internal/app/eveuniverseservice/location_test.go
+++ b/internal/app/eveuniverseservice/location_test.go
@@ -18,12 +18,55 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
+	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
 const (
 	stationID   = 60000277
 	structureID = 1_000_000_000_009
 )
+
+func TestGetLocation(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return existing location", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		loc := factory.CreateEveLocationStation()
+		// when
+		got, err := s.GetLocation(context.Background(), loc.ID)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, loc.ID, got.ID)
+	})
+	t.Run("should return error when location does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetLocation(context.Background(), 666)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListLocations(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return all locations", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		l1 := factory.CreateEveLocationStation()
+		l2 := factory.CreateEveLocationStructure()
+		// when
+		oo, err := s.ListLocations(context.Background())
+		// then
+		require.NoError(t, err)
+		got := xslices.Map(oo, func(x *app.EveLocation) int64 { return x.ID })
+		assert.ElementsMatch(t, []int64{l1.ID, l2.ID}, got)
+	})
+}
 
 func TestGetOrCreateLocationESI_AnyExceptStrutures(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()

--- a/internal/app/eveuniverseservice/map_test.go
+++ b/internal/app/eveuniverseservice/map_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ErikKalkoken/go-set"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 
@@ -17,6 +18,49 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
+
+func TestAddMissingRegions(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("do nothing when all regions already exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		r := factory.CreateEveRegion()
+		// when
+		err := s.AddMissingRegions(ctx, set.Of(r.ID, 0))
+		// then
+		if assert.NoError(t, err) {
+			xassert.Equal(t, 0, httpmock.GetTotalCallCount())
+		}
+	})
+	t.Run("can fetch missing regions from ESI", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi.evetech.net/universe/regions/\d+`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"constellations": []int{20000302, 20000303},
+				"description":    "It has long been an established fact of civilization...",
+				"name":           "Metropolis",
+				"region_id":      10000042,
+			}),
+		)
+		// when
+		err := s.AddMissingRegions(ctx, set.Of[int64](10000042))
+		// then
+		if assert.NoError(t, err) {
+			_, err := st.GetEveRegion(ctx, 10000042)
+			assert.NoError(t, err)
+		}
+	})
+}
 
 func TestGetOrCreateEveRegionESI(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
@@ -115,6 +159,57 @@ func TestGetOrCreateEveConstellationESI(t *testing.T) {
 			if assert.NoError(t, err) {
 				xassert.Equal(t, x1, x2)
 			}
+		}
+	})
+}
+
+func TestAddMissingSolarSystems(t *testing.T) {
+	db, st, factory := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("do nothing when all solar systems already exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		x := factory.CreateEveSolarSystem()
+		// when
+		err := s.AddMissingSolarSystems(ctx, set.Of(x.ID, 0))
+		// then
+		if assert.NoError(t, err) {
+			xassert.Equal(t, 0, httpmock.GetTotalCallCount())
+		}
+	})
+	t.Run("can fetch missing solar systems from ESI", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		factory.CreateEveConstellation(storage.CreateEveConstellationParams{ID: 20000001})
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi.evetech.net/universe/systems/\d+`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"constellation_id": 20000001,
+				"name":             "Akpivem",
+				"position": map[string]any{
+					"x": -91174141133075340,
+					"y": 43938227486247170,
+					"z": -56482824383339900,
+				},
+				"security_class":  "B",
+				"security_status": 0.8462923765182495,
+				"star_id":         40000040,
+				"system_id":       30000003,
+			}),
+		)
+		// when
+		err := s.AddMissingSolarSystems(ctx, set.Of[int64](30000003))
+		// then
+		if assert.NoError(t, err) {
+			_, err := st.GetEveSolarSystem(ctx, 30000003)
+			assert.NoError(t, err)
 		}
 	})
 }

--- a/internal/app/eveuniverseservice/organization_test.go
+++ b/internal/app/eveuniverseservice/organization_test.go
@@ -20,6 +20,58 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xslices"
 )
 
+func TestRandomizeAllAllianceNames(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should randomize names of all alliances only", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		alliance := factory.CreateEveEntityAlliance(app.EveEntity{Name: "Original Alliance"})
+		corporation := factory.CreateEveEntityCorporation(app.EveEntity{Name: "Original Corp"})
+		// when
+		err := s.RandomizeAllAllianceNames(t.Context())
+		// then
+		require.NoError(t, err)
+		o1, err := st.GetEveEntity(t.Context(), alliance.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, "Original Alliance", o1.Name)
+		o2, err := st.GetEveEntity(t.Context(), corporation.ID)
+		require.NoError(t, err)
+		xassert.Equal(t, "Original Corp", o2.Name)
+	})
+}
+
+func TestRandomizeAllCorporationNames(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should randomize names of all corporations", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		corporation := factory.CreateEveCorporation(storage.UpdateOrCreateEveCorporationParams{Name: "Original Corp"})
+		factory.CreateEveEntityCorporation(app.EveEntity{ID: corporation.ID, Name: "Original Corp"})
+		// when
+		err := s.RandomizeAllCorporationNames(t.Context())
+		// then
+		require.NoError(t, err)
+		o1, err := st.GetEveCorporation(t.Context(), corporation.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, "Original Corp", o1.Name)
+		o2, err := st.GetEveEntity(t.Context(), corporation.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, "Original Corp", o2.Name)
+	})
+	t.Run("should do nothing when there are no corporations", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		err := s.RandomizeAllCorporationNames(t.Context())
+		// then
+		require.NoError(t, err)
+	})
+}
+
 func TestFetchAlliance(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/eveuniverseservice/skill_test.go
+++ b/internal/app/eveuniverseservice/skill_test.go
@@ -13,6 +13,68 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/app/testutil/testdouble"
 )
 
+func TestListSkillGroups(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return skill groups only", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		skillCategory := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategorySkill, IsPublished: true})
+		skillGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: skillCategory.ID, IsPublished: true})
+		factory.CreateEveType(storage.CreateEveTypeParams{GroupID: skillGroup.ID, IsPublished: true})
+		otherGroup := factory.CreateEveGroup(storage.CreateEveGroupParams{IsPublished: true})
+		factory.CreateEveType(storage.CreateEveTypeParams{GroupID: otherGroup.ID, IsPublished: true})
+		// when
+		oo, err := s.ListSkillGroups(t.Context())
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, oo, 1) {
+			assert.Equal(t, skillGroup.ID, oo[0].ID)
+		}
+	})
+}
+
+func TestUpdateShipSkills(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should update ship skills", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		category := factory.CreateEveCategory(storage.CreateEveCategoryParams{ID: app.EveCategoryShip})
+		group := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID})
+		ship := factory.CreateEveType(storage.CreateEveTypeParams{GroupID: group.ID, IsPublished: true})
+		skill := factory.CreateEveType()
+		primarySkillID := factory.CreateEveDogmaAttribute(storage.CreateEveDogmaAttributeParams{
+			ID: app.EveDogmaAttributePrimarySkillID,
+		})
+		primarySkillLevel := factory.CreateEveDogmaAttribute(storage.CreateEveDogmaAttributeParams{
+			ID: app.EveDogmaAttributePrimarySkillLevel,
+		})
+		factory.CreateEveTypeDogmaAttribute(storage.CreateEveTypeDogmaAttributeParams{
+			EveTypeID:        ship.ID,
+			DogmaAttributeID: primarySkillID.ID,
+			Value:            float64(skill.ID),
+		})
+		factory.CreateEveTypeDogmaAttribute(storage.CreateEveTypeDogmaAttributeParams{
+			EveTypeID:        ship.ID,
+			DogmaAttributeID: primarySkillLevel.ID,
+			Value:            float64(3),
+		})
+		// when
+		err := s.UpdateShipSkills(t.Context())
+		// then
+		require.NoError(t, err)
+		xx, err := st.ListEveShipSkills(t.Context(), ship.ID)
+		require.NoError(t, err)
+		if assert.Len(t, xx, 1) {
+			assert.Equal(t, skill.ID, xx[0].SkillTypeID)
+			assert.Equal(t, uint(3), xx[0].SkillLevel)
+		}
+	})
+}
+
 func TestEveUniverseService_ListSkills(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/eveuniverseservice/type_internal_test.go
+++ b/internal/app/eveuniverseservice/type_internal_test.go
@@ -2,12 +2,104 @@ package eveuniverseservice
 
 import (
 	"context"
+	"net/http"
+	"regexp"
+	"strconv"
 	"testing"
 
+	"github.com/fnt-eve/goesi-openapi"
+	"github.com/jarcoal/httpmock"
+
 	"github.com/ErikKalkoken/evebuddy/internal/app"
+	"github.com/ErikKalkoken/evebuddy/internal/app/testutil"
 	"github.com/ErikKalkoken/evebuddy/internal/optional"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
+
+func TestUpdateTypes(t *testing.T) {
+	db, st, _ := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	esiClient := goesi.NewESIClientWithOptions(http.DefaultClient, goesi.ClientOptions{
+		UserAgent: "EveBuddy/1.0 (test@kalkoken.net)",
+	})
+	s := &EVEUniverseService{st: st, esiClient: esiClient, concurrencyLimit: -1}
+	ctx := context.Background()
+
+	categoryIDRx := regexp.MustCompile(`/categories/(\d+)`)
+	groups := map[int64][]int{
+		25: {587},
+		26: {588},
+	}
+	categoryGroups := map[int64][]int{
+		app.EveCategoryShip:  {25},
+		app.EveCategorySkill: {26},
+	}
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://esi.evetech.net/universe/categories/\d+`,
+		func(req *http.Request) (*http.Response, error) {
+			m := categoryIDRx.FindStringSubmatch(req.URL.Path)
+			id, _ := strconv.ParseInt(m[1], 10, 64)
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"category_id": id,
+				"groups":      categoryGroups[id],
+				"name":        "Category",
+				"published":   true,
+			})
+		},
+	)
+	groupIDRx := regexp.MustCompile(`/groups/(\d+)`)
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://esi.evetech.net/universe/groups/\d+`,
+		func(req *http.Request) (*http.Response, error) {
+			m := groupIDRx.FindStringSubmatch(req.URL.Path)
+			id, _ := strconv.ParseInt(m[1], 10, 64)
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"category_id": 6,
+				"group_id":    id,
+				"name":        "Group",
+				"published":   true,
+				"types":       groups[id],
+			})
+		},
+	)
+	typeIDRx := regexp.MustCompile(`/types/(\d+)`)
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://esi.evetech.net/universe/types/\d+`,
+		func(req *http.Request) (*http.Response, error) {
+			m := typeIDRx.FindStringSubmatch(req.URL.Path)
+			id, _ := strconv.ParseInt(m[1], 10, 64)
+			groupID := int64(25)
+			if id == 588 {
+				groupID = 26
+			}
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"description": "A type",
+				"group_id":    groupID,
+				"name":        "Type",
+				"published":   true,
+				"type_id":     id,
+			})
+		},
+	)
+
+	t.Run("should update ship and skill types and report added ones", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		added, err := s.updateTypes(ctx)
+		// then
+		if err != nil {
+			t.Fatal(err)
+		}
+		xassert.Equal(t, true, added.Contains(587))
+		xassert.Equal(t, true, added.Contains(588))
+	})
+}
 
 func TestFormatDogmaValue(t *testing.T) {
 	cases := []struct {

--- a/internal/app/eveuniverseservice/type_test.go
+++ b/internal/app/eveuniverseservice/type_test.go
@@ -18,6 +18,166 @@ import (
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
 )
 
+func TestGetType(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return existing type", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		et := factory.CreateEveType()
+		// when
+		got, err := s.GetType(context.Background(), et.ID)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, et, got)
+	})
+	t.Run("should return error when type does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetType(context.Background(), 666)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestListGroupsForCategory(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return groups for a category", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		category := factory.CreateEveCategory()
+		g1 := factory.CreateEveGroup(storage.CreateEveGroupParams{CategoryID: category.ID})
+		factory.CreateEveGroup() // other category
+		// when
+		oo, err := s.ListGroupsForCategory(context.Background(), category.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, oo, 1) {
+			xassert.Equal(t, g1.ID, oo[0].ID)
+		}
+	})
+}
+
+func TestGetDogmaAttribute(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return existing dogma attribute", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		da := factory.CreateEveDogmaAttribute()
+		// when
+		got, err := s.GetDogmaAttribute(context.Background(), da.ID)
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, da, got)
+	})
+	t.Run("should return error when dogma attribute does not exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := s.GetDogmaAttribute(context.Background(), 666)
+		// then
+		assert.ErrorIs(t, err, app.ErrNotFound)
+	})
+}
+
+func TestFormatDogmaValueWrapper(t *testing.T) {
+	db, st, _ := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should format a simple dogma value", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		text, iconID := s.FormatDogmaValue(context.Background(), 0.04, app.EveUnitAbsolutePercent)
+		// then
+		xassert.Equal(t, "4%", text)
+		xassert.Equal(t, int64(0), iconID)
+	})
+}
+
+func TestListTypeDogmaAttributesForType(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	t.Run("should return dogma attributes for a type", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		et := factory.CreateEveType()
+		da := factory.CreateEveDogmaAttribute()
+		factory.CreateEveTypeDogmaAttribute(storage.CreateEveTypeDogmaAttributeParams{
+			EveTypeID:        et.ID,
+			DogmaAttributeID: da.ID,
+			Value:            42,
+		})
+		// when
+		oo, err := s.ListTypeDogmaAttributesForType(context.Background(), et.ID)
+		// then
+		require.NoError(t, err)
+		if assert.Len(t, oo, 1) {
+			xassert.Equal(t, da.ID, oo[0].DogmaAttribute.ID)
+			xassert.Equal(t, 42.0, oo[0].Value)
+		}
+	})
+}
+
+func TestUpdateCategoryWithChildrenESI(t *testing.T) {
+	db, st, _ := testutil.NewDBOnDisk(t)
+	defer db.Close()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	s := testdouble.NewEVEUniverseServiceFake(eveuniverseservice.Params{Storage: st})
+	ctx := context.Background()
+	t.Run("should fetch category with its groups and types from ESI", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		httpmock.Reset()
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi.evetech.net/universe/categories/\d+`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"category_id": 6,
+				"groups":      []int{25},
+				"name":        "Ship",
+				"published":   true,
+			}),
+		)
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi.evetech.net/universe/groups/\d+`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"category_id": 6,
+				"group_id":    25,
+				"name":        "Frigate",
+				"published":   true,
+				"types":       []int{587},
+			}),
+		)
+		httpmock.RegisterResponder(
+			"GET",
+			`=~^https://esi.evetech.net/universe/types/\d+`,
+			httpmock.NewJsonResponderOrPanic(200, map[string]any{
+				"description": "The Rifter is a...",
+				"group_id":    25,
+				"name":        "Rifter",
+				"published":   true,
+				"type_id":     587,
+			}),
+		)
+		// when
+		err := s.UpdateCategoryWithChildrenESI(ctx, 6)
+		// then
+		require.NoError(t, err)
+		_, err = st.GetEveType(ctx, 587)
+		assert.NoError(t, err)
+	})
+}
+
 func TestGetOrCreateEveCategoryESI(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/storage/charactertag_test.go
+++ b/internal/app/storage/charactertag_test.go
@@ -92,6 +92,21 @@ func TestTag(t *testing.T) {
 			assert.Error(t, err, app.ErrNotFound)
 		}
 	})
+	t.Run("can delete all tags", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateCharacterTag()
+		factory.CreateCharacterTag()
+		// when
+		err := st.DeleteAllTags(ctx)
+		// then
+		if assert.NoError(t, err) {
+			tags, err := st.ListTagsByName(ctx)
+			if assert.NoError(t, err) {
+				assert.Empty(t, tags)
+			}
+		}
+	})
 }
 
 func TestReplaceTags(t *testing.T) {

--- a/internal/app/storage/corporation_test.go
+++ b/internal/app/storage/corporation_test.go
@@ -74,6 +74,18 @@ func TestCorporation(t *testing.T) {
 			xassert.Equal(t, c2, c1)
 		}
 	})
+	t.Run("can delete", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		// when
+		err := st.DeleteCorporation(ctx, c.ID)
+		// then
+		if assert.NoError(t, err) {
+			_, err := st.GetCorporation(ctx, c.ID)
+			assert.ErrorIs(t, err, app.ErrNotFound)
+		}
+	})
 }
 
 func TestListCorporations(t *testing.T) {

--- a/internal/app/storage/corporationmember_test.go
+++ b/internal/app/storage/corporationmember_test.go
@@ -92,14 +92,52 @@ func TestCorporationMember(t *testing.T) {
 			CorporationID: c.ID,
 		})
 		// when
-		oo, err := st.ListCorporationMembers(ctx, c.ID)
+		err := st.DeleteCorporationMembers(ctx, c.ID, set.Of(e1.Character.ID, e2.Character.ID))
 		// then
 		if assert.NoError(t, err) {
-			got := set.Of(xslices.Map(oo, func(x *app.CorporationMember) int64 {
-				return x.Character.ID
-			})...)
-			want := set.Of(e1.Character.ID, e2.Character.ID)
-			xassert.Equal(t, want, got)
+			got, err := st.ListCorporationMemberIDs(ctx, c.ID)
+			if assert.NoError(t, err) {
+				assert.Empty(t, got)
+			}
+		}
+	})
+	t.Run("can delete specific members", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		e1 := factory.CreateCorporationMember(storage.CorporationMemberParams{
+			CorporationID: c.ID,
+		})
+		e2 := factory.CreateCorporationMember(storage.CorporationMemberParams{
+			CorporationID: c.ID,
+		})
+		// when
+		err := st.DeleteCorporationMembers(ctx, c.ID, set.Of(e1.Character.ID))
+		// then
+		if assert.NoError(t, err) {
+			got, err := st.ListCorporationMemberIDs(ctx, c.ID)
+			if assert.NoError(t, err) {
+				want := set.Of(e2.Character.ID)
+				xassert.Equal(t, want, got)
+			}
+		}
+	})
+	t.Run("does nothing when no member IDs given", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c := factory.CreateCorporation()
+		e1 := factory.CreateCorporationMember(storage.CorporationMemberParams{
+			CorporationID: c.ID,
+		})
+		// when
+		err := st.DeleteCorporationMembers(ctx, c.ID, set.Set[int64]{})
+		// then
+		if assert.NoError(t, err) {
+			got, err := st.ListCorporationMemberIDs(ctx, c.ID)
+			if assert.NoError(t, err) {
+				want := set.Of(e1.Character.ID)
+				xassert.Equal(t, want, got)
+			}
 		}
 	})
 }

--- a/internal/app/storage/evecharacter_test.go
+++ b/internal/app/storage/evecharacter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ErikKalkoken/go-set"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -254,6 +255,27 @@ func TestEveCharacter(t *testing.T) {
 		c2, err := st.GetEveCharacter(t.Context(), c1.ID)
 		require.NoError(t, err)
 		xassert.Equal(t, "Erik", c2.Name)
+	})
+	t.Run("can list character IDs", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		c1 := f.CreateEveCharacter()
+		c2 := f.CreateEveCharacter()
+		// when
+		got, err := st.ListEveCharacterIDs(t.Context())
+		// then
+		require.NoError(t, err)
+		want := set.Of(c1.ID, c2.ID)
+		xassert.Equal(t, want, got)
+	})
+	t.Run("should return empty set when no characters exist", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		got, err := st.ListEveCharacterIDs(t.Context())
+		// then
+		require.NoError(t, err)
+		xassert.Equal(t, 0, got.Size())
 	})
 }
 

--- a/internal/app/storage/eveentity_test.go
+++ b/internal/app/storage/eveentity_test.go
@@ -171,6 +171,45 @@ func TestEveEntity(t *testing.T) {
 	})
 }
 
+func TestListEveEntityByNameAndCategory(t *testing.T) {
+	db, st, factory := testutil.NewDBInMemory()
+	defer db.Close()
+	ctx := context.Background()
+	t.Run("should return objs with matching name and category", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		factory.CreateEveEntityCharacter(app.EveEntity{Name: "Erik"})
+		factory.CreateEveEntityAlliance(app.EveEntity{Name: "Erik"})
+		factory.CreateEveEntityCharacter(app.EveEntity{Name: "Other"})
+		// when
+		ee, err := st.ListEveEntityByNameAndCategory(ctx, "Erik", app.EveEntityCharacter)
+		// then
+		if assert.NoError(t, err) {
+			got := xslices.Map(ee, func(e *app.EveEntity) string {
+				return e.Name
+			})
+			want := []string{"Erik"}
+			xassert.Equal(t, want, got)
+		}
+	})
+	t.Run("should return error for empty name", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := st.ListEveEntityByNameAndCategory(ctx, "", app.EveEntityCharacter)
+		// then
+		assert.Error(t, err)
+	})
+	t.Run("should return error for undefined category", func(t *testing.T) {
+		// given
+		testutil.MustTruncateTables(db)
+		// when
+		_, err := st.ListEveEntityByNameAndCategory(ctx, "Erik", app.EveEntityUndefined)
+		// then
+		assert.Error(t, err)
+	})
+}
+
 func TestListEveEntitiesForIDs(t *testing.T) {
 	db, st, factory := testutil.NewDBInMemory()
 	defer db.Close()

--- a/internal/app/storage/storage_internal_test.go
+++ b/internal/app/storage/storage_internal_test.go
@@ -2,8 +2,13 @@ package storage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
@@ -18,5 +23,41 @@ func TestConvertNoRowsError(t *testing.T) {
 		err := errors.New("random error")
 		got := convertGetError(err)
 		xassert.Equal(t, err, got)
+	})
+}
+
+func TestDumpData(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, ApplyMigrations(db))
+	st := New(db, db)
+	t.Run("can dump all tables", func(t *testing.T) {
+		// given
+		_, err := st.CreateTag(t.Context(), "Alpha")
+		require.NoError(t, err)
+		// when
+		got := st.DumpData()
+		// then
+		var world map[string]any
+		require.NoError(t, json.Unmarshal([]byte(got), &world))
+		assert.Contains(t, world, "character_tags")
+	})
+	t.Run("can dump specific tables only", func(t *testing.T) {
+		// given
+		_, err := st.CreateTag(t.Context(), "Bravo")
+		require.NoError(t, err)
+		// when
+		got := st.DumpData("character_tags")
+		// then
+		var world map[string]any
+		require.NoError(t, json.Unmarshal([]byte(got), &world))
+		assert.Contains(t, world, "character_tags")
+		assert.Len(t, world, 1)
+	})
+	t.Run("panics for unknown table", func(t *testing.T) {
+		assert.Panics(t, func() {
+			st.DumpData("does_not_exist")
+		})
 	})
 }


### PR DESCRIPTION
- characterservice: added tests for previously untested CRUD/tag/wallet/section-update functions (68.0% → 81.1% coverage)
- corporationservice: added tests for zero-coverage functions across assets, contracts, corporation, industry, members, structures, wallet (63.9% → 73.0%, section.go excluded)
- evenotification: added dedicated test files for moonmining.go, orbital.go, and untested helper functions (81.4% → 81.6%)
- eveuniverseservice: added tests for zero-coverage functions across character, entity, location, map, organization, skill, type (67.2% → 76.8%, section.go excluded)
- storage: added tests for zero-coverage functions (DeleteAllTags, DeleteCorporation, DeleteCorporationMembers, ListEveCharacterIDs, ListEveEntityByNameAndCategory, DumpData); fixed a pre-existing test that never actually called the function it claimed to test (74.3% → 76.2%, generated queries subpackage excluded)
- eveimageservice: added tests for the 8 untested async image-loading methods (76.9% → 83.3%)