### PR TITLE
test: add missing unit tests for xwidget and settings packages

### DIFF
--- a/internal/app/settings/settings_internal_test.go
+++ b/internal/app/settings/settings_internal_test.go
@@ -68,6 +68,18 @@ func (p myPreferences) SetStringList(k string, v []string) {
 	setAny(p, k, v)
 }
 
+func (p myPreferences) Float(key string) float64 {
+	return getAny[float64](p, key)
+}
+
+func (p myPreferences) FloatWithFallback(key string, fallback float64) float64 {
+	return getAnyWithFallback(p, key, fallback)
+}
+
+func (p myPreferences) SetFloat(k string, v float64) {
+	setAny(p, k, v)
+}
+
 func (p myPreferences) FloatList(key string) []float64 {
 	return getAny[[]float64](p, key)
 }

--- a/internal/app/settings/settings_test.go
+++ b/internal/app/settings/settings_test.go
@@ -3,9 +3,11 @@ package settings_test
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"github.com/ErikKalkoken/go-set"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ErikKalkoken/evebuddy/internal/app/settings"
 	"github.com/ErikKalkoken/evebuddy/internal/xassert"
@@ -69,5 +71,369 @@ func TestColorTheme(t *testing.T) {
 		s.SetColorTheme(settings.Dark)
 		x1 := s.ColorTheme()
 	xassert.Equal(t, settings.Dark, x1)
+	})
+	t.Run("Can reset theme", func(t *testing.T) {
+		s := settings.New(settings.NewMyPref())
+		s.SetColorTheme(settings.Dark)
+		s.ResetColorTheme()
+		assert.Equal(t, settings.Auto, s.ColorTheme())
+	})
+	t.Run("ColorThemeDefault reports the default theme", func(t *testing.T) {
+		s := settings.New(settings.NewMyPref())
+		assert.Equal(t, settings.Auto, s.ColorThemeDefault())
+	})
+}
+
+func TestDeveloperMode(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.False(t, s.DeveloperMode())
+	s.SetDeveloperMode(true)
+	assert.True(t, s.DeveloperMode())
+}
+
+func TestLogLevelNames(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	want := []string{"debug", "info", "warning", "error"}
+	assert.Equal(t, want, s.LogLevelNames())
+}
+
+func TestLogLevelDefaultAndReset(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.Equal(t, "info", s.LogLevelDefault())
+	assert.Equal(t, s.LogLevelDefault(), s.LogLevel())
+	s.SetLogLevel("debug")
+	assert.Equal(t, "debug", s.LogLevel())
+	s.ResetLogLevel()
+	assert.Equal(t, s.LogLevelDefault(), s.LogLevel())
+}
+
+func TestApprovedContactCost(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	minimum, maximum, def := s.ApprovedContactCostPresets()
+	assert.Equal(t, 0, minimum)
+	assert.Equal(t, 1_000_000, maximum)
+	assert.Equal(t, 0, def)
+	assert.Equal(t, def, s.ApprovedContactCost())
+	s.SetApprovedContactCost(500)
+	assert.Equal(t, 500, s.ApprovedContactCost())
+}
+
+func TestMaxMails(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	minimum, maximum, def := s.MaxMailsPresets()
+	assert.Equal(t, 0, minimum)
+	assert.Equal(t, 10_000, maximum)
+	assert.Equal(t, 250, def)
+	assert.Equal(t, def, s.MaxMails())
+	s.SetMaxMails(500)
+	assert.Equal(t, 500, s.MaxMails())
+}
+
+func TestMarketOrderRetentionDays(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	minimum, maximum, def := s.MarketOrderRetentionDaysPresets()
+	assert.Equal(t, 30, minimum)
+	assert.Equal(t, 360, maximum)
+	assert.Equal(t, 90, def)
+	assert.Equal(t, def, s.MarketOrderRetentionDays())
+	s.SetMarketOrdersRetentionDay(120)
+	assert.Equal(t, 120, s.MarketOrderRetentionDays())
+}
+
+func TestSysTrayEnabled(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.True(t, s.SysTrayEnabledDefault())
+	assert.Equal(t, s.SysTrayEnabledDefault(), s.SysTrayEnabled())
+	s.SetSysTrayEnabled(false)
+	assert.False(t, s.SysTrayEnabled())
+}
+
+func TestWindowSizeDefaultAndReset(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	want := fyne.NewSize(1000, 600)
+	xassert.Equal(t, want, s.WindowSize())
+	s.SetWindowSize(fyne.NewSize(200, 300))
+	xassert.Equal(t, fyne.NewSize(200, 300), s.WindowSize())
+	s.ResetWindowSize()
+	xassert.Equal(t, want, s.WindowSize())
+}
+
+func TestTabsMainID(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.Equal(t, -1, s.TabsMainID())
+	s.SetTabsMainID(3)
+	assert.Equal(t, 3, s.TabsMainID())
+	s.ResetTabsMainID()
+	assert.Equal(t, -1, s.TabsMainID())
+}
+
+func TestLastCharacterIDReset(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	s.SetLastCharacterID(123)
+	assert.Equal(t, int64(123), s.LastCharacterID())
+	s.ResetLastCharacterID()
+	assert.Equal(t, int64(0), s.LastCharacterID())
+}
+
+func TestLastCorporationIDReset(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	s.SetLastCorporationID(123)
+	assert.Equal(t, int64(123), s.LastCorporationID())
+	s.ResetLastCorporationID()
+	assert.Equal(t, int64(0), s.LastCorporationID())
+}
+
+func TestMaxWalletTransactions(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	minimum, maximum, def := s.MaxWalletTransactionsPresets()
+	assert.Equal(t, 0, minimum)
+	assert.Equal(t, 10_000, maximum)
+	assert.Equal(t, 1_000, def)
+	assert.Equal(t, def, s.MaxWalletTransactions())
+	s.SetMaxWalletTransactions(500)
+	assert.Equal(t, 500, s.MaxWalletTransactions())
+	s.ResetMaxWalletTransactions()
+	assert.Equal(t, def, s.MaxWalletTransactions())
+}
+
+func TestNotifyTimeoutHours(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	minimum, maximum, def := s.NotifyTimeoutHoursPresets()
+	assert.Equal(t, 1, minimum)
+	assert.Equal(t, 90*24, maximum)
+	assert.Equal(t, 30*24, def)
+	assert.Equal(t, def, s.NotifyTimeoutHours())
+	s.SetNotifyTimeoutHours(48)
+	assert.Equal(t, 48, s.NotifyTimeoutHours())
+	s.ResetNotifyTimeoutHours()
+	assert.Equal(t, def, s.NotifyTimeoutHours())
+}
+
+func TestNotificationTypesEnabledReset(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	s.SetNotificationTypesEnabled(set.Of("alpha", "bravo"))
+	assert.Equal(t, 2, s.NotificationTypesEnabled().Size())
+	s.ResetNotificationTypesEnabled()
+	assert.Equal(t, 0, s.NotificationTypesEnabled().Size())
+}
+
+func TestNotifyEarliestGettersAndSetters(t *testing.T) {
+	cases := []struct {
+		name string
+		get  func(*settings.Settings) time.Time
+		set  func(*settings.Settings, time.Time)
+	}{
+		{"Communications", (*settings.Settings).NotifyCommunicationsEarliest, (*settings.Settings).SetNotifyCommunicationsEarliest},
+		{"Contracts", (*settings.Settings).NotifyContractsEarliest, (*settings.Settings).SetNotifyContractsEarliest},
+		{"Mails", (*settings.Settings).NotifyMailsEarliest, (*settings.Settings).SetNotifyMailsEarliest},
+		{"PI", (*settings.Settings).NotifyPIEarliest, (*settings.Settings).SetNotifyPIEarliest},
+		{"Training", (*settings.Settings).NotifyTrainingEarliest, (*settings.Settings).SetNotifyTrainingEarliest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := settings.New(settings.NewMyPref())
+			want := time.Now().UTC().Add(-time.Hour)
+			tc.set(s, want)
+			got := tc.get(s)
+			assert.WithinDuration(t, want, got, time.Second)
+		})
+	}
+}
+
+func TestNotifyEnabledFlags(t *testing.T) {
+	cases := []struct {
+		name       string
+		get        func(*settings.Settings) bool
+		getDefault func(*settings.Settings) bool
+		set        func(*settings.Settings, bool)
+	}{
+		{"Communications", (*settings.Settings).NotifyCommunicationsEnabled, (*settings.Settings).NotifyCommunicationsEnabledDefault, (*settings.Settings).SetNotifyCommunicationsEnabled},
+		{"Contracts", (*settings.Settings).NotifyContractsEnabled, (*settings.Settings).NotifyContractsEnabledDefault, (*settings.Settings).SetNotifyContractsEnabled},
+		{"Mails", (*settings.Settings).NotifyMailsEnabled, (*settings.Settings).NotifyMailsEnabledDefault, (*settings.Settings).SetNotifyMailsEnabled},
+		{"PI", (*settings.Settings).NotifyPIEnabled, (*settings.Settings).NotifyPIEnabledDefault, (*settings.Settings).SetNotifyPIEnabled},
+		{"Training", (*settings.Settings).NotifyTrainingEnabled, (*settings.Settings).NotifyTrainingEnabledDefault, (*settings.Settings).SetNotifyTrainingEnabled},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := settings.New(settings.NewMyPref())
+			assert.False(t, tc.getDefault(s))
+			assert.Equal(t, tc.getDefault(s), tc.get(s))
+			tc.set(s, true)
+			assert.True(t, tc.get(s))
+		})
+	}
+}
+
+func TestPreferMarketTab(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.False(t, s.PreferMarketTab())
+	s.SetPreferMarketTab(true)
+	assert.True(t, s.PreferMarketTab())
+	s.ResetPreferMarketTab()
+	assert.False(t, s.PreferMarketTab())
+}
+
+func TestHideLimitedCorporations(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.False(t, s.HideLimitedCorporationsDefault())
+	assert.Equal(t, s.HideLimitedCorporationsDefault(), s.HideLimitedCorporations())
+	s.SetHideLimitedCorporations(true)
+	assert.True(t, s.HideLimitedCorporations())
+}
+
+func TestFyneScale(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.Equal(t, 1.0, s.FyneScaleDefault())
+	assert.Equal(t, s.FyneScaleDefault(), s.FyneScale())
+	s.SetFyneScale(1.5)
+	assert.Equal(t, 1.5, s.FyneScale())
+	s.ResetFyneScale()
+	assert.Equal(t, 1.0, s.FyneScale())
+}
+
+func TestDisableDPIDetection(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	assert.False(t, s.DisableDPIDetection())
+	s.SetDisableDPIDetection(true)
+	assert.True(t, s.DisableDPIDetection())
+	s.ResetDisableDPIDetection()
+	assert.False(t, s.DisableDPIDetection())
+}
+
+func TestResetUI(t *testing.T) {
+	s := settings.New(settings.NewMyPref())
+	s.SetTabsMainID(5)
+	s.SetWindowSize(fyne.NewSize(200, 300))
+	s.SetColorTheme(settings.Dark)
+	s.SetFyneScale(2.0)
+	s.SetDisableDPIDetection(true)
+
+	s.ResetUI()
+
+	assert.Equal(t, -1, s.TabsMainID())
+	xassert.Equal(t, fyne.NewSize(1000, 600), s.WindowSize())
+	assert.Equal(t, settings.Auto, s.ColorTheme())
+	assert.Equal(t, 1.0, s.FyneScale())
+	assert.False(t, s.DisableDPIDetection())
+}
+
+func TestKeys(t *testing.T) {
+	got := settings.Keys()
+	assert.NotEmpty(t, got)
+	seen := set.Of(got...)
+	assert.Equal(t, len(got), seen.Size(), "Keys() should not contain duplicate entries")
+}
+
+func TestSettingsNilReceiverIsSafe(t *testing.T) {
+	var s *settings.Settings
+
+	assert.NotPanics(t, func() {
+		assert.False(t, s.DeveloperMode())
+		s.SetDeveloperMode(true)
+
+		assert.Nil(t, s.LogLevelNames())
+		assert.Equal(t, slog.Level(0), s.LogLevelSlog())
+		assert.Equal(t, "", s.LogLevel())
+		assert.Equal(t, "", s.LogLevelDefault())
+		s.ResetLogLevel()
+		s.SetLogLevel("debug")
+
+		assert.Equal(t, 0, s.ApprovedContactCost())
+		s.SetApprovedContactCost(1)
+
+		assert.Equal(t, 0, s.MaxMails())
+		s.SetMaxMails(1)
+
+		assert.Equal(t, 0, s.MarketOrderRetentionDays())
+		s.SetMarketOrdersRetentionDay(1)
+
+		assert.False(t, s.SysTrayEnabled())
+		assert.True(t, s.SysTrayEnabledDefault())
+		s.SetSysTrayEnabled(true)
+
+		assert.Equal(t, fyne.Size{}, s.WindowSize())
+		s.ResetWindowSize()
+		s.SetWindowSize(fyne.NewSize(1, 1))
+
+		s.ResetTabsMainID()
+		s.SetTabsMainID(1)
+		assert.Equal(t, 0, s.TabsMainID())
+
+		assert.Equal(t, int64(0), s.LastCharacterID())
+		s.ResetLastCharacterID()
+		s.SetLastCharacterID(1)
+
+		assert.Equal(t, int64(0), s.LastCorporationID())
+		s.ResetLastCorporationID()
+		s.SetLastCorporationID(1)
+
+		assert.Equal(t, 0, s.MaxWalletTransactions())
+		s.ResetMaxWalletTransactions()
+		s.SetMaxWalletTransactions(1)
+
+		assert.Equal(t, 0, s.NotifyTimeoutHours())
+		s.ResetNotifyTimeoutHours()
+		s.SetNotifyTimeoutHours(1)
+
+		assert.Equal(t, 0, s.NotificationTypesEnabled().Size())
+		s.ResetNotificationTypesEnabled()
+		s.SetNotificationTypesEnabled(set.Of("x"))
+
+		for _, get := range []func() time.Time{
+			s.NotifyCommunicationsEarliest,
+			s.NotifyContractsEarliest,
+			s.NotifyMailsEarliest,
+			s.NotifyPIEarliest,
+			s.NotifyTrainingEarliest,
+		} {
+			assert.True(t, get().IsZero())
+		}
+		s.SetNotifyCommunicationsEarliest(time.Now())
+		s.SetNotifyContractsEarliest(time.Now())
+		s.SetNotifyMailsEarliest(time.Now())
+		s.SetNotifyPIEarliest(time.Now())
+		s.SetNotifyTrainingEarliest(time.Now())
+
+		for _, get := range []func() bool{
+			s.NotifyCommunicationsEnabled, s.NotifyCommunicationsEnabledDefault,
+			s.NotifyContractsEnabled, s.NotifyContractsEnabledDefault,
+			s.NotifyMailsEnabled, s.NotifyMailsEnabledDefault,
+			s.NotifyPIEnabled, s.NotifyPIEnabledDefault,
+			s.NotifyTrainingEnabled, s.NotifyTrainingEnabledDefault,
+		} {
+			assert.False(t, get())
+		}
+		s.SetNotifyCommunicationsEnabled(true)
+		s.SetNotifyContractsEnabled(true)
+		s.SetNotifyMailsEnabled(true)
+		s.SetNotifyPIEnabled(true)
+		s.SetNotifyTrainingEnabled(true)
+
+		assert.Nil(t, s.RecentSearches())
+		s.SetRecentSearches([]int64{1})
+
+		assert.False(t, s.PreferMarketTab())
+		s.ResetPreferMarketTab()
+		s.SetPreferMarketTab(true)
+
+		assert.False(t, s.HideLimitedCorporations())
+		assert.False(t, s.HideLimitedCorporationsDefault())
+		s.SetHideLimitedCorporations(true)
+
+		assert.Equal(t, settings.ColorTheme(""), s.ColorTheme())
+		assert.Equal(t, settings.ColorTheme(""), s.ColorThemeDefault())
+		s.ResetColorTheme()
+		s.SetColorTheme(settings.Dark)
+
+		assert.Equal(t, float64(0), s.FyneScale())
+		assert.Equal(t, float64(0), s.FyneScaleDefault())
+		s.ResetFyneScale()
+		s.SetFyneScale(1)
+
+		assert.False(t, s.DisableDPIDetection())
+		s.ResetDisableDPIDetection()
+		s.SetDisableDPIDetection(true)
+
+		s.ResetUI()
 	})
 }

--- a/internal/xwidget/activity_test.go
+++ b/internal/xwidget/activity_test.go
@@ -1,0 +1,34 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestActivity_CanCreate(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	a := xwidget.NewActivity()
+	w := test.NewWindow(a)
+	defer w.Close()
+
+	assert.NotPanics(t, a.Start)
+	assert.NotPanics(t, a.Stop)
+}
+
+func TestActivity_SupportsToolTip(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	a := xwidget.NewActivity()
+	w := test.NewWindow(a)
+	defer w.Close()
+
+	a.SetToolTip("Loading")
+	assert.Equal(t, "Loading", a.ToolTip())
+}

--- a/internal/xwidget/appbar_test.go
+++ b/internal/xwidget/appbar_test.go
@@ -1,0 +1,68 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestAppBar_CanCreateAndSetTitle(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	body := widget.NewLabel("Body")
+	ab := xwidget.NewAppBar("Title", body)
+	w := test.NewWindow(ab)
+	defer w.Close()
+
+	assert.Equal(t, "Title", ab.Title())
+
+	ab.SetTitle("New Title")
+	assert.Equal(t, "New Title", ab.Title())
+}
+
+func TestAppBar_CanCreateWithTrailingItems(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	body := widget.NewLabel("Body")
+	trailing := widget.NewButton("Action", nil)
+	ab := xwidget.NewAppBar("Title", body, trailing)
+	w := test.NewWindow(ab)
+	defer w.Close()
+
+	assert.NotPanics(t, ab.Refresh)
+}
+
+func TestAppBar_CanCreateWithHiddenBackground(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	ab := xwidget.NewAppBar("Title", widget.NewLabel("Body"))
+	ab.HideBackground = true
+	w := test.NewWindow(ab)
+	defer w.Close()
+
+	assert.NotPanics(t, ab.Refresh)
+}
+
+func TestAppBar_WhenPushedItGetsANavigator(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	second := xwidget.NewAppBar("Second", widget.NewLabel("Second"))
+	nav.Push(second)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	assert.Equal(t, nav, second.Navigator)
+	assert.NotPanics(t, func() {
+		second.Navigator.Pop()
+	})
+}

--- a/internal/xwidget/contextmenu_internal_test.go
+++ b/internal/xwidget/contextmenu_internal_test.go
@@ -1,0 +1,21 @@
+package xwidget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextMenuButton_SetMenuItems(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	b := NewContextMenuButton("Test", fyne.NewMenu("", fyne.NewMenuItem("Old", nil)))
+	newItems := []*fyne.MenuItem{fyne.NewMenuItem("New", nil)}
+
+	b.SetMenuItems(newItems)
+
+	assert.Equal(t, newItems, b.menu.Items)
+}

--- a/internal/xwidget/contextmenu_test.go
+++ b/internal/xwidget/contextmenu_test.go
@@ -1,0 +1,51 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestContextMenuButton_CanCreate(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	b := xwidget.NewContextMenuButton("Test", menu)
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	assert.Equal(t, "Test", b.Text)
+}
+
+func TestContextMenuButton_CanCreateWithIcon(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	b := xwidget.NewContextMenuButtonWithIcon("Test", theme.HomeIcon(), menu)
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	assert.Equal(t, "Test", b.Text)
+	assert.Equal(t, theme.HomeIcon(), b.Icon)
+}
+
+func TestContextMenuButton_TapShowsMenuWithoutPanic(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	b := xwidget.NewContextMenuButton("Test", menu)
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	assert.NotPanics(t, func() {
+		test.Tap(b)
+	})
+}

--- a/internal/xwidget/helper_test.go
+++ b/internal/xwidget/helper_test.go
@@ -1,0 +1,66 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestShowPopUpMenuBelowLeading_NilMenuIsNoop(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	lbl := widget.NewLabel("x")
+	w := test.NewWindow(lbl)
+	defer w.Close()
+
+	assert.NotPanics(t, func() {
+		xwidget.ShowPopUpMenuBelowLeading(lbl, nil)
+	})
+}
+
+func TestShowPopUpMenuBelowLeading_ShowsMenu(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	lbl := widget.NewLabel("x")
+	w := test.NewWindow(lbl)
+	defer w.Close()
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	assert.NotPanics(t, func() {
+		xwidget.ShowPopUpMenuBelowLeading(lbl, menu)
+	})
+}
+
+func TestShowPopUpMenuBelowTrailing_NilMenuIsNoop(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	lbl := widget.NewLabel("x")
+	w := test.NewWindow(lbl)
+	defer w.Close()
+
+	assert.NotPanics(t, func() {
+		xwidget.ShowPopUpMenuBelowTrailing(lbl, nil)
+	})
+}
+
+func TestShowPopUpMenuBelowTrailing_ShowsMenu(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	lbl := widget.NewLabel("x")
+	w := test.NewWindow(lbl)
+	defer w.Close()
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	assert.NotPanics(t, func() {
+		xwidget.ShowPopUpMenuBelowTrailing(lbl, menu)
+	})
+}

--- a/internal/xwidget/hyperlink_test.go
+++ b/internal/xwidget/hyperlink_test.go
@@ -1,0 +1,34 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNewCustomHyperlink_CanCreate(t *testing.T) {
+	h := xwidget.NewCustomHyperlink("Test", nil)
+	assert.Equal(t, "Test", h.Text)
+}
+
+func TestNewCustomHyperlink_CanTap(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var tapped bool
+	h := xwidget.NewCustomHyperlink("Test", func() {
+		tapped = true
+	})
+	w := test.NewWindow(h)
+	defer w.Close()
+
+	// Simulate what widget.Hyperlink.Tapped does when the tap lands on the
+	// text, without depending on its internal hit-testing geometry.
+	require.NotNil(t, h.OnTapped)
+	h.OnTapped()
+	assert.True(t, tapped)
+}

--- a/internal/xwidget/iconbutton_test.go
+++ b/internal/xwidget/iconbutton_test.go
@@ -1,0 +1,54 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestIconButton_CanCreateAndTap(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var tapped bool
+	b := xwidget.NewIconButton(theme.HomeIcon(), func() {
+		tapped = true
+	})
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	test.Tap(b.Icon)
+	assert.True(t, tapped)
+}
+
+func TestIconButton_CanCreateWithMenu(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	b := xwidget.NewIconButtonWithMenu(theme.HomeIcon(), menu)
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	assert.NotNil(t, b.Icon)
+	assert.NotPanics(t, func() {
+		test.Tap(b.Icon)
+	})
+}
+
+func TestIconButton_SetToolTip(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	b := xwidget.NewIconButton(theme.HomeIcon(), nil)
+	w := test.NewWindow(b)
+	defer w.Close()
+
+	b.SetToolTip("Hello")
+	assert.Equal(t, "Hello", b.Icon.ToolTip())
+}

--- a/internal/xwidget/image_test.go
+++ b/internal/xwidget/image_test.go
@@ -1,0 +1,117 @@
+package xwidget_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNewImageFromResource(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	img := xwidget.NewImageFromResource(theme.HomeIcon(), fyne.NewSize(50, 60))
+
+	assert.Equal(t, canvas.ImageFillContain, img.FillMode)
+	assert.Equal(t, fyne.NewSize(50, 60), img.MinSize())
+	assert.Equal(t, theme.HomeIcon(), img.Resource)
+}
+
+func TestLoadResourceAsyncWithCache_CacheHit(t *testing.T) {
+	test.NewTempApp(t)
+
+	cached := theme.HomeIcon()
+	var got fyne.Resource
+
+	xwidget.LoadResourceAsyncWithCache(
+		theme.CancelIcon(),
+		func() (fyne.Resource, bool) { return cached, true },
+		func(r fyne.Resource) { got = r },
+		func() (fyne.Resource, error) {
+			t.Fatal("loader should not be called on cache hit")
+			return nil, nil
+		},
+		func(fyne.Resource) {
+			t.Fatal("setter should not be called on cache hit")
+		},
+	)
+
+	assert.Equal(t, cached, got)
+}
+
+func TestLoadResourceAsyncWithCache_CacheMissLoadsAsync(t *testing.T) {
+	test.NewTempApp(t)
+
+	initial := theme.CancelIcon()
+	loaded := theme.HomeIcon()
+
+	var mu sync.Mutex
+	var updates []fyne.Resource
+	var setResource fyne.Resource
+	done := make(chan struct{})
+
+	xwidget.LoadResourceAsyncWithCache(
+		initial,
+		func() (fyne.Resource, bool) { return nil, false },
+		func(r fyne.Resource) {
+			mu.Lock()
+			updates = append(updates, r)
+			n := len(updates)
+			mu.Unlock()
+			if n == 2 {
+				close(done)
+			}
+		},
+		func() (fyne.Resource, error) { return loaded, nil },
+		func(r fyne.Resource) { setResource = r },
+	)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async load to complete")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []fyne.Resource{initial, loaded}, updates)
+	assert.Equal(t, loaded, setResource)
+}
+
+func TestLoadResourceAsyncWithCache_LoaderErrorFallsBackToBrokenImage(t *testing.T) {
+	test.NewTempApp(t)
+
+	initial := theme.CancelIcon()
+	done := make(chan struct{})
+	var final fyne.Resource
+
+	xwidget.LoadResourceAsyncWithCache(
+		initial,
+		func() (fyne.Resource, bool) { return nil, false },
+		func(r fyne.Resource) {
+			final = r
+			if r != initial {
+				close(done)
+			}
+		},
+		func() (fyne.Resource, error) { return nil, errors.New("boom") },
+		func(fyne.Resource) {},
+	)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async load to complete")
+	}
+
+	assert.Equal(t, theme.BrokenImageIcon(), final)
+}

--- a/internal/xwidget/label_test.go
+++ b/internal/xwidget/label_test.go
@@ -1,0 +1,15 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNewLabelWithSelection(t *testing.T) {
+	l := xwidget.NewLabelWithSelection("Test")
+	assert.Equal(t, "Test", l.Text)
+	assert.True(t, l.Selectable)
+}

--- a/internal/xwidget/navbar_test.go
+++ b/internal/xwidget/navbar_test.go
@@ -1,0 +1,133 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNavBar_PanicsWithoutDestinations(t *testing.T) {
+	assert.Panics(t, func() {
+		xwidget.NewNavBar()
+	})
+}
+
+func TestNavBar_SelectsFirstDestinationOnCreation(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var selectedA int
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	dA.OnSelected = func() { selectedA++ }
+	dB := xwidget.NewDestinationDef("B", theme.HomeIcon(), widget.NewLabel("B"))
+
+	nb := xwidget.NewNavBar(dA, dB)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	id, ok := nb.Selected()
+	assert.True(t, ok)
+	assert.Equal(t, 0, id)
+	assert.Equal(t, 1, selectedA)
+}
+
+func TestNavBar_SelectSwitchesDestinationAndFiresCallback(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var selectedB int
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	dB := xwidget.NewDestinationDef("B", theme.HomeIcon(), widget.NewLabel("B"))
+	dB.OnSelected = func() { selectedB++ }
+
+	nb := xwidget.NewNavBar(dA, dB)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	nb.Select(1)
+	id, ok := nb.Selected()
+	assert.True(t, ok)
+	assert.Equal(t, 1, id)
+	assert.Equal(t, 1, selectedB)
+}
+
+func TestNavBar_SelectingCurrentDestinationAgainFiresOnSelectedAgain(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var selectedAgain int
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	dA.OnSelectedAgain = func() { selectedAgain++ }
+
+	nb := xwidget.NewNavBar(dA)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	nb.Select(0)
+	assert.Equal(t, 1, selectedAgain)
+}
+
+func TestNavBar_EnableAndDisableDestination(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	dB := xwidget.NewDestinationDef("B", theme.HomeIcon(), widget.NewLabel("B"))
+	nb := xwidget.NewNavBar(dA, dB)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	assert.True(t, nb.Enabled(1))
+
+	nb.Disable(1)
+	assert.False(t, nb.Enabled(1))
+
+	nb.Select(1) // disabled destination must not be selectable
+	id, _ := nb.Selected()
+	assert.Equal(t, 0, id)
+
+	nb.Enable(1)
+	assert.True(t, nb.Enabled(1))
+
+	nb.Select(1)
+	id, _ = nb.Selected()
+	assert.Equal(t, 1, id)
+}
+
+func TestNavBar_OutOfBoundsCallsAreNoop(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	nb := xwidget.NewNavBar(dA)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	assert.False(t, nb.Enabled(5))
+	assert.False(t, nb.Enabled(-1))
+	assert.NotPanics(t, func() { nb.Enable(5) })
+	assert.NotPanics(t, func() { nb.Disable(-1) })
+	assert.NotPanics(t, func() { nb.Select(99) })
+	assert.NotPanics(t, func() { nb.ShowBadge(99, widget.HighImportance) })
+	assert.NotPanics(t, func() { nb.HideBadge(99) })
+}
+
+func TestNavBar_ShowAndHideBadgeAndBar(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	dA := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	nb := xwidget.NewNavBar(dA)
+	w := test.NewWindow(nb)
+	defer w.Close()
+
+	assert.NotPanics(t, func() { nb.ShowBadge(0, widget.DangerImportance) })
+	assert.NotPanics(t, func() { nb.HideBadge(0) })
+	assert.NotPanics(t, nb.HideBar)
+	assert.NotPanics(t, nb.ShowBar)
+}

--- a/internal/xwidget/navigator_test.go
+++ b/internal/xwidget/navigator_test.go
@@ -1,0 +1,112 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNavigator_PanicsWithoutRootAppBar(t *testing.T) {
+	assert.Panics(t, func() {
+		xwidget.NewNavigator(nil)
+	})
+}
+
+func TestNavigator_PushAndPop(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	assert.True(t, nav.IsRoot())
+	assert.False(t, nav.IsEmpty())
+	assert.Equal(t, fyne.CanvasObject(root), nav.Current())
+
+	second := xwidget.NewAppBar("Second", widget.NewLabel("Second"))
+	nav.Push(second)
+
+	assert.False(t, nav.IsRoot())
+	assert.Equal(t, fyne.CanvasObject(second), nav.Current())
+
+	popped := nav.Pop()
+	assert.Equal(t, fyne.CanvasObject(second), popped)
+	assert.True(t, nav.IsRoot())
+}
+
+func TestNavigator_PopOnRootPageReturnsNil(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	assert.Nil(t, nav.Pop())
+	assert.True(t, nav.IsRoot())
+}
+
+func TestNavigator_PopAllRemovesEveryNonRootPage(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	nav.Push(xwidget.NewAppBar("Second", widget.NewLabel("Second")))
+	nav.Push(xwidget.NewAppBar("Third", widget.NewLabel("Third")))
+
+	nav.PopAll()
+
+	assert.True(t, nav.IsRoot())
+	assert.Equal(t, fyne.CanvasObject(root), nav.Current())
+}
+
+func TestNavigator_SetReplacesRootAndClearsStack(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	nav.Push(xwidget.NewAppBar("Second", widget.NewLabel("Second")))
+
+	newRoot := xwidget.NewAppBar("New Root", widget.NewLabel("New Root"))
+	nav.Set(newRoot)
+
+	assert.True(t, nav.IsRoot())
+	assert.Equal(t, fyne.CanvasObject(newRoot), nav.Current())
+}
+
+func TestNavigator_PushAndHideNavBarThenPopShowsBarAgain(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	root := xwidget.NewAppBar("Root", widget.NewLabel("Root"))
+	nav := xwidget.NewNavigator(root)
+	dest := xwidget.NewDestinationDef("A", theme.HomeIcon(), widget.NewLabel("A"))
+	nav.NavBar = xwidget.NewNavBar(dest)
+	w := test.NewWindow(nav)
+	defer w.Close()
+
+	second := xwidget.NewAppBar("Second", widget.NewLabel("Second"))
+	assert.NotPanics(t, func() {
+		nav.PushAndHideNavBar(second)
+	})
+	assert.NotPanics(t, func() {
+		nav.Pop()
+	})
+}

--- a/internal/xwidget/navlist_test.go
+++ b/internal/xwidget/navlist_test.go
@@ -1,0 +1,72 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNavList_CanCreate(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	it1 := xwidget.NewNavListItem("Alpha", theme.HomeIcon(), nil)
+	it2 := xwidget.NewNavListItem("Bravo", theme.HomeIcon(), nil)
+	list := xwidget.NewNavList(it1, it2)
+	w := test.NewWindow(list)
+	defer w.Close()
+
+	assert.NotNil(t, list)
+}
+
+func TestNavListItem_TapRunsAction(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var tapped bool
+	it := xwidget.NewNavListItem("Headline", theme.HomeIcon(), func() {
+		tapped = true
+	})
+	w := test.NewWindow(it)
+	defer w.Close()
+
+	test.Tap(it)
+	assert.True(t, tapped)
+}
+
+func TestNavListItem_TapWhileDisabledDoesNothing(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var tapped bool
+	it := xwidget.NewNavListItem("Headline", theme.HomeIcon(), func() {
+		tapped = true
+	})
+	it.IsDisabled = true
+	w := test.NewWindow(it)
+	defer w.Close()
+
+	test.Tap(it)
+	assert.False(t, tapped)
+}
+
+func TestNavListItem_RefreshAfterFieldChanges(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	it := xwidget.NewNavListItem("Headline", theme.HomeIcon(), nil)
+	w := test.NewWindow(it)
+	defer w.Close()
+
+	it.Headline = "New Headline"
+	it.Supporting = "Supporting text"
+	it.Leading = theme.CancelIcon()
+	it.Trailing = theme.CancelIcon()
+	it.IsDisabled = true
+
+	assert.NotPanics(t, it.Refresh)
+}

--- a/internal/xwidget/progressbutton_internal_test.go
+++ b/internal/xwidget/progressbutton_internal_test.go
@@ -1,0 +1,169 @@
+package xwidget
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressButton_InitialState(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), nil)
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	assert.False(t, pb.progress.Visible())
+	assert.False(t, pb.button.locked)
+}
+
+func TestProgressButton_TapRunsActionAndRestoresState(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	var ran atomic.Bool
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), func() {
+		ran.Store(true)
+		close(started)
+		<-proceed
+	})
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	test.Tap(pb.button)
+	<-started
+
+	assert.True(t, pb.button.locked)
+	assert.Equal(t, "", pb.button.Text)
+	assert.True(t, pb.progress.Visible())
+
+	close(proceed)
+
+	assert.Eventually(t, func() bool {
+		return !pb.button.locked
+	}, time.Second, 5*time.Millisecond)
+	assert.True(t, ran.Load())
+	assert.False(t, pb.progress.Visible())
+	assert.Equal(t, "Click", pb.button.Text)
+}
+
+func TestProgressButton_TapIgnoredWhenNoAction(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), nil)
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	assert.NotPanics(t, func() { test.Tap(pb.button) })
+	assert.False(t, pb.button.locked)
+}
+
+func TestProgressButton_SecondTapWhileRunningIsIgnored(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	var runCount atomic.Int32
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), func() {
+		runCount.Add(1)
+		close(started)
+		<-proceed
+	})
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	test.Tap(pb.button)
+	<-started
+	test.Tap(pb.button) // no-op: button is locked while running
+
+	close(proceed)
+	assert.Eventually(t, func() bool { return !pb.button.locked }, time.Second, 5*time.Millisecond)
+	assert.EqualValues(t, 1, runCount.Load())
+}
+
+func TestProgressButton_SetTextIconImportanceWhileIdle(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), nil)
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	pb.SetText("New")
+	assert.Equal(t, "New", pb.button.Text)
+
+	pb.SetIcon(theme.CancelIcon())
+	assert.Equal(t, theme.CancelIcon(), pb.button.Icon)
+
+	pb.SetImportance(widget.HighImportance)
+	assert.Equal(t, widget.HighImportance, pb.button.Importance)
+}
+
+func TestProgressButton_SetTextIconWhileRunningIsDeferredUntilCompletion(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), func() {
+		close(started)
+		<-proceed
+	})
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	test.Tap(pb.button)
+	<-started
+
+	pb.SetText("Later")
+	pb.SetIcon(theme.CancelIcon())
+	assert.NotEqual(t, "Later", pb.button.Text) // button is cleared while running
+	assert.Equal(t, "Later", pb.label)          // pending value stored for restoration
+
+	close(proceed)
+
+	assert.Eventually(t, func() bool { return !pb.button.locked }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, "Later", pb.button.Text)
+	assert.Equal(t, theme.CancelIcon(), pb.button.Icon)
+}
+
+func TestProgressButton_DisableWhileRunningAppliesAfterCompletion(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+
+	pb := NewProgressButton("Click", theme.HomeIcon(), func() {
+		close(started)
+		<-proceed
+	})
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	test.Tap(pb.button)
+	<-started
+
+	pb.Disable()
+	assert.True(t, pb.Disabled())
+	assert.False(t, pb.button.Disabled()) // underlying button not disabled yet
+
+	close(proceed)
+
+	assert.Eventually(t, func() bool { return !pb.button.locked }, time.Second, 5*time.Millisecond)
+	assert.True(t, pb.button.Disabled())
+	assert.True(t, pb.Disabled())
+}

--- a/internal/xwidget/progressbutton_test.go
+++ b/internal/xwidget/progressbutton_test.go
@@ -1,0 +1,37 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestProgressButton_CanCreate(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	pb := xwidget.NewProgressButton("Click", theme.HomeIcon(), nil)
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	assert.False(t, pb.Disabled())
+}
+
+func TestProgressButton_EnableDisable(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	pb := xwidget.NewProgressButton("Click", theme.HomeIcon(), nil)
+	w := test.NewWindow(pb)
+	defer w.Close()
+
+	pb.Disable()
+	assert.True(t, pb.Disabled())
+
+	pb.Enable()
+	assert.False(t, pb.Disabled())
+}

--- a/internal/xwidget/searchentry_internal_test.go
+++ b/internal/xwidget/searchentry_internal_test.go
@@ -1,0 +1,43 @@
+package xwidget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchEntry_ClearButtonTogglesWithText(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	se := NewSearchEntry("Search...", nil)
+	w := test.NewWindow(se)
+	defer w.Close()
+
+	assert.False(t, se.clearButton.Visible())
+
+	se.SetText("abc")
+	assert.True(t, se.clearButton.Visible())
+
+	se.SetText("")
+	assert.False(t, se.clearButton.Visible())
+}
+
+func TestSearchEntry_ClearButtonTapClearsText(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var got string
+	se := NewSearchEntry("Search...", func(s string) {
+		got = s
+	})
+	w := test.NewWindow(se)
+	defer w.Close()
+
+	se.SetText("abc")
+	test.Tap(se.clearButton)
+
+	assert.Equal(t, "", se.Text)
+	assert.Equal(t, "", got)
+}

--- a/internal/xwidget/searchentry_test.go
+++ b/internal/xwidget/searchentry_test.go
@@ -1,0 +1,57 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestSearchEntry_CanCreate(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	se := xwidget.NewSearchEntry("Search...", nil)
+	w := test.NewWindow(se)
+	defer w.Close()
+
+	assert.Equal(t, "Search...", se.PlaceHolder)
+}
+
+func TestSearchEntry_SetTextCallsOnChanged(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var got string
+	se := xwidget.NewSearchEntry("Search...", func(s string) {
+		got = s
+	})
+	w := test.NewWindow(se)
+	defer w.Close()
+
+	se.SetText("abc")
+
+	assert.Equal(t, "abc", se.Text)
+	assert.Equal(t, "abc", got)
+}
+
+func TestSearchEntry_ClearSilentResetsTextWithoutCallback(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	var callCount int
+	se := xwidget.NewSearchEntry("Search...", func(s string) {
+		callCount++
+	})
+	w := test.NewWindow(se)
+	defer w.Close()
+
+	se.SetText("abc")
+	assert.Equal(t, 1, callCount)
+
+	se.ClearSilent()
+	assert.Equal(t, "", se.Text)
+	assert.Equal(t, 1, callCount)
+}

--- a/internal/xwidget/skilllevel_internal_test.go
+++ b/internal/xwidget/skilllevel_internal_test.go
@@ -1,0 +1,38 @@
+package xwidget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkillLevel_Set_ChoosesCorrectIconPerDot(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	sl := NewSkillLevel()
+
+	t.Run("all untrained by default", func(t *testing.T) {
+		sl.Set(0, 0, 0)
+		for i := range 5 {
+			assert.Equal(t, sl.disabled, sl.dots[i].Resource)
+		}
+	})
+	t.Run("active levels show trained icon, blocked levels show blocked icon, queued shows queued icon", func(t *testing.T) {
+		sl.Set(2, 4, 5)
+		assert.Equal(t, sl.trained, sl.dots[0].Resource)
+		assert.Equal(t, sl.trained, sl.dots[1].Resource)
+		assert.Equal(t, sl.blocked, sl.dots[2].Resource)
+		assert.Equal(t, sl.blocked, sl.dots[3].Resource)
+		assert.Equal(t, sl.queued, sl.dots[4].Resource)
+	})
+	t.Run("queued is ignored when zero", func(t *testing.T) {
+		sl.Set(1, 3, 0)
+		assert.Equal(t, sl.trained, sl.dots[0].Resource)
+		assert.Equal(t, sl.blocked, sl.dots[1].Resource)
+		assert.Equal(t, sl.blocked, sl.dots[2].Resource)
+		assert.Equal(t, sl.disabled, sl.dots[3].Resource)
+		assert.Equal(t, sl.disabled, sl.dots[4].Resource)
+	})
+}

--- a/internal/xwidget/skilllevel_test.go
+++ b/internal/xwidget/skilllevel_test.go
@@ -1,0 +1,23 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestSkillLevel_CanCreateAndSet(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	sl := xwidget.NewSkillLevel()
+	w := test.NewWindow(sl)
+	defer w.Close()
+
+	assert.NotPanics(t, func() {
+		sl.Set(2, 4, 5)
+	})
+}

--- a/internal/xwidget/spacer_test.go
+++ b/internal/xwidget/spacer_test.go
@@ -1,0 +1,26 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNewSpacer_HasGivenMinSize(t *testing.T) {
+	s := xwidget.NewSpacer(fyne.NewSize(10, 20))
+	assert.Equal(t, fyne.NewSize(10, 20), s.MinSize())
+}
+
+func TestNewStandardSpacer_HasPaddingSize(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	s := xwidget.NewStandardSpacer()
+	p := theme.Padding()
+	assert.Equal(t, fyne.NewSquareSize(p), s.MinSize())
+}

--- a/internal/xwidget/toolbaraction_test.go
+++ b/internal/xwidget/toolbaraction_test.go
@@ -1,0 +1,44 @@
+package xwidget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ErikKalkoken/evebuddy/internal/xwidget"
+)
+
+func TestNewToolbarActionMenu_ActivatingShowsMenu(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	a := xwidget.NewToolbarActionMenu(theme.HomeIcon(), menu)
+	tb := widget.NewToolbar(a)
+	w := test.NewWindow(tb)
+	defer w.Close()
+
+	require.NotNil(t, a.OnActivated)
+	assert.NotPanics(t, a.OnActivated)
+}
+
+func TestSetToolbarActionMenu_ReplacesActivationHandler(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	a := widget.NewToolbarAction(theme.HomeIcon(), nil)
+	tb := widget.NewToolbar(a)
+	w := test.NewWindow(tb)
+	defer w.Close()
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("Item1", nil))
+	xwidget.SetToolbarActionMenu(a, menu)
+
+	require.NotNil(t, a.OnActivated)
+	assert.NotPanics(t, a.OnActivated)
+}


### PR DESCRIPTION
- Adds unit tests for the previously-untested widgets in internal/xwidget (activity, appbar, context menu, hyperlink, icon button, image, label, navbar, navigator, navlist, progress button, search entry, skill level, spacer, toolbar action)
- Adds unit tests for internal/app/settings, covering all getter/setter/default/reset pairs, the notification earliest/enabled flags, ResetUI, Keys(), and nil-receiver safety across the whole API
- Fixes a latent bug in the settings test stub: myPreferences was missing Float/FloatWithFallback/SetFloat, causing a nil-pointer panic when testing FyneScale
- No production code behavior changes — test-only additions plus the test-stub fix